### PR TITLE
Re-enable brigadier for 1.19.1+

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/init/start/CommandRegister.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/CommandRegister.java
@@ -4,8 +4,6 @@ import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.commands.*;
 import ac.grim.grimac.manager.init.Initable;
 import co.aikar.commands.PaperCommandManager;
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
 
 public class CommandRegister implements Initable {
     @Override
@@ -14,10 +12,7 @@ public class CommandRegister implements Initable {
         // It only enables new features such as asynchronous tab completion on paper
         PaperCommandManager commandManager = new PaperCommandManager(GrimAPI.INSTANCE.getPlugin());
 
-        // brigadier is currently broken on 1.19.1+ with acf
-        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_19_1)) {
-            commandManager.enableUnstableAPI("brigadier");
-        }
+        commandManager.enableUnstableAPI("brigadier");
 
         commandManager.registerCommand(new GrimPerf());
         commandManager.registerCommand(new GrimDebug());


### PR DESCRIPTION
ACF fixed brigadier on 1.19.1+ in a recent commit, so there's no reason to disable it anymore.