### PR TITLE
Don't create a new thread for packet limiting

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/init/start/PacketLimiter.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/PacketLimiter.java
@@ -4,24 +4,21 @@ import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.manager.init.Initable;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.LogUtil;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import org.bukkit.Bukkit;
 
 public class PacketLimiter implements Initable {
     @Override
     public void start() {
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
-        executorService.scheduleAtFixedRate(() -> {
+        Bukkit.getScheduler().runTaskTimerAsynchronously(GrimAPI.INSTANCE.getPlugin(), () -> {
+            int spamThreshold = GrimAPI.INSTANCE.getConfigManager().getConfig().getIntElse("packet-spam-threshold", 100);
             for (GrimPlayer player : GrimAPI.INSTANCE.getPlayerDataManager().getEntries()) {
                 // Avoid concurrent reading on an integer as it's results are unknown
-                if (player.cancelledPackets.get() > GrimAPI.INSTANCE.getConfigManager().getConfig().getIntElse("packet-spam-threshold", 100)) {
+                if (player.cancelledPackets.get() > spamThreshold) {
                     LogUtil.info("Disconnecting " + player.user.getName() + " for spamming invalid packets, packets cancelled in a second " + player.cancelledPackets);
                     player.user.closeConnection();
                 }
                 player.cancelledPackets.set(0);
             }
-        }, 1, 1, TimeUnit.SECONDS);
+        }, 0, 20);
     }
 }


### PR DESCRIPTION
This also fixes a memory leak when the plugin is disabled and enabled