### PR TITLE
Let glass panes connect to leaves on legacy versions

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
@@ -44,7 +44,7 @@ public class DynamicConnecting {
         StateType target = targetBlock.getType();
         StateType fence = currBlock.getType();
 
-        if (!BlockTags.FENCES.contains(target) && isBlacklisted(target))
+        if (!BlockTags.FENCES.contains(target) && isBlacklisted(target, v))
             return false;
 
         // 1.12+ clients can connect to TnT while previous versions can't
@@ -79,8 +79,8 @@ public class DynamicConnecting {
         }
     }
 
-    boolean isBlacklisted(StateType m) {
-        if (BlockTags.LEAVES.contains(m)) return true;
+    boolean isBlacklisted(StateType m, ClientVersion clientVersion) {
+        if (BlockTags.LEAVES.contains(m)) return clientVersion.isNewerThan(ClientVersion.V_1_8);
         if (BlockTags.SHULKER_BOXES.contains(m)) return true;
         if (BlockTags.TRAPDOORS.contains(m)) return true;
 


### PR DESCRIPTION
Glass panes seem to be able to connect to leaf blocks on legacy versions.
![image](https://user-images.githubusercontent.com/35672743/195250122-1b481efd-831e-4f7e-bd01-a29fcecf16d2.png)
Tested using 1.8, 1.12 & 1.19 on a 1.8 server.