### PR TITLE
Fix Dripstone placing error

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Dripstone.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Dripstone.java
@@ -5,7 +5,6 @@ import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState
 import com.github.retrooper.packetevents.protocol.world.states.enums.Thickness;
 import com.github.retrooper.packetevents.protocol.world.states.enums.VerticalDirection;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
-import org.bukkit.block.data.type.PointedDripstone;
 
 public class Dripstone {
     public static WrappedBlockState update(GrimPlayer player, WrappedBlockState toPlace, int x, int y, int z, boolean secondaryUse) {
@@ -17,8 +16,7 @@ public class Dripstone {
         if (isPointedDripstoneWithDirection(typePlacingOn, opposite)) {
             // Use tip if the player is sneaking, or if it already is merged (somehow)
             // secondary use is flipped, for some reason, remember!
-            Thickness thick = secondaryUse && ((PointedDripstone) typePlacingOn).getThickness() != PointedDripstone.Thickness.TIP_MERGE ?
-                    Thickness.TIP : Thickness.TIP_MERGE;
+            Thickness thick = secondaryUse && typePlacingOn.getThickness() != Thickness.TIP_MERGE ? Thickness.TIP : Thickness.TIP_MERGE;
 
             toPlace.setThickness(thick);
         } else {


### PR DESCRIPTION
```
java.lang.ClassCastException: class ac.grim.grimac.shaded.com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState cannot be cast to class org.bukkit.block.data.type.PointedDripstone (ac.grim.grimac.shaded.com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState is in unnamed module of loader 'Grim.jar' @7fed3e70; org.bukkit.block.data.type.PointedDripstone is in unnamed module of loader java.net.URLClassLoader @2e817b38)
    at ac.grim.grimac.utils.nmsutil.Dripstone.update(Dripstone.java:20)
    at ac.grim.grimac.utils.blockplace.BlockPlaceResult.lambda$static$18(BlockPlaceResult.java:350)
    at ac.grim.grimac.events.packets.CheckManagerListener.handleBlockPlaceOrUseItem(CheckManagerListener.java:303)
    at ac.grim.grimac.events.packets.CheckManagerListener.handleQueuedPlaces(CheckManagerListener.java:194)
    at ac.grim.grimac.events.packets.CheckManagerListener.handleFlying(CheckManagerListener.java:614)
    at ac.grim.grimac.events.packets.CheckManagerListener.onPacketReceive(CheckManagerListener.java:393)
```