### PR TITLE
Disconnect player immediately after hitting packet threshold

### DIFF
--- a/src/main/java/ac/grim/grimac/GrimExternalAPI.java
+++ b/src/main/java/ac/grim/grimac/GrimExternalAPI.java
@@ -56,6 +56,7 @@ public class GrimExternalAPI implements GrimAbstractAPI, Initable {
         //Reload checks for all players
         for (GrimPlayer grimPlayer : GrimAPI.INSTANCE.getPlayerDataManager().getEntries()) {
             ChannelHelper.runInEventLoop(grimPlayer.user.getChannel(), () -> {
+                grimPlayer.onReload();
                 grimPlayer.updatePermissions();
                 grimPlayer.punishmentManager.reload();
                 for (Check value : grimPlayer.checkManager.allChecks.values()) {

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -62,7 +62,7 @@ public class Reach extends PacketCheck {
             // Don't let the player teleport to bypass reach
             if (player.getSetbackTeleportUtil().shouldBlockMovement()) {
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
                 return;
             }
 
@@ -73,7 +73,7 @@ public class Reach extends PacketCheck {
                 // This is because we don't track paintings.
                 if (shouldModifyPackets() && player.compensatedEntities.serverPositionsMap.containsKey(action.getEntityId())) {
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                 }
                 return;
             }
@@ -89,7 +89,7 @@ public class Reach extends PacketCheck {
 
             if (shouldModifyPackets() && cancelImpossibleHits && isKnownInvalid(entity)) {
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
             }
         }
 

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashA.java
@@ -26,7 +26,7 @@ public class CrashA extends PacketCheck {
                 flagAndAlert(); // Ban
                 player.getSetbackTeleportUtil().executeViolationSetback();
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
             }
         }
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
@@ -19,7 +19,7 @@ public class CrashB extends PacketCheck {
             if (player.gamemode != GameMode.CREATIVE) {
                 player.getSetbackTeleportUtil().executeViolationSetback();
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
                 flagAndAlert(); // Could be transaction split, no need to setback though
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashC.java
@@ -26,7 +26,7 @@ public class CrashC extends PacketCheck {
                     flagAndAlert("xyzYP: " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ() + ", " + pos.getYaw() + ", " + pos.getPitch());
                     player.getSetbackTeleportUtil().executeViolationSetback();
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
@@ -40,7 +40,7 @@ public class CrashD extends PacketCheck {
             if (type == 16 && windowId > 0 && windowId == lecternId) {
                 if (flagAndAlert("clickType=" + clickType + " button=" + button)) {
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitA.java
@@ -32,14 +32,14 @@ public class ExploitA extends PacketCheck {
             String message = wrapper.getMessage();
             if (checkString(message)) {
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
             }
         } else if (event.getPacketType() == PacketType.Play.Client.NAME_ITEM) {
             WrapperPlayClientNameItem wrapper = new WrapperPlayClientNameItem(event);
             String name = wrapper.getItemName();
             if (checkString(name)) {
                 event.setCancelled(true);
-                player.cancelledPackets.incrementAndGet();
+                player.onPacketCancel();
             }
         }
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
@@ -24,7 +24,7 @@ public class ExploitB extends PacketCheck {
             if (text.equals("/") || text.trim().length() == 0) {
                 if (flag()) {
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -73,7 +73,7 @@ public class FastBreak extends PacketCheck {
 
                 if (blockDelayBalance > 1000 && shouldModifyPackets()) { // If more than a second of advantage
                     event.setCancelled(true); // Cancelling start digging will cause server to reject block break
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                     flagAndAlert("Delay=" + breakDelay);
                 }
 
@@ -123,7 +123,7 @@ public class FastBreak extends PacketCheck {
 
                     if (flagAndAlert("Diff=" + diff + ",Balance=" + blockBreakBalance) && shouldModifyPackets()) {
                         event.setCancelled(true);
-                        player.cancelledPackets.incrementAndGet();
+                        player.onPacketCancel();
                     }
                 }
 

--- a/src/main/java/ac/grim/grimac/checks/impl/movement/TimerCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/movement/TimerCheck.java
@@ -71,7 +71,7 @@ public class TimerCheck extends PacketCheck {
                 // Cancel the packet
                 if (shouldModifyPackets()) {
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
                 }
                 player.getSetbackTeleportUtil().executeNonSimulatingSetback();
                 alert("");

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -485,7 +485,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
 
                 if (blockPlace.isCancelled()) { // The player tried placing blocks in air/water
                     event.setCancelled(true);
-                    player.cancelledPackets.incrementAndGet();
+                    player.onPacketCancel();
 
                     Vector3i facePos = new Vector3i(packet.getBlockPosition().getX() + packet.getFace().getModX(), packet.getBlockPosition().getY() + packet.getFace().getModY(), packet.getBlockPosition().getZ() + packet.getFace().getModZ());
                     int placed = player.compensatedWorld.getWrappedBlockStateAt(packet.getBlockPosition()).getGlobalId();

--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
@@ -57,7 +57,7 @@ public class PacketEntityAction extends PacketListenerAbstract {
                             player.bukkitPlayer.setSneaking(!player.bukkitPlayer.isSneaking());
                         }
                         event.setCancelled(true);
-                        player.cancelledPackets.incrementAndGet();
+                        player.onPacketCancel();
                     }
                     break;
                 case START_JUMPING_WITH_HORSE:

--- a/src/main/java/ac/grim/grimac/manager/init/start/PacketLimiter.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/PacketLimiter.java
@@ -3,23 +3,14 @@ package ac.grim.grimac.manager.init.start;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.manager.init.Initable;
 import ac.grim.grimac.player.GrimPlayer;
-import ac.grim.grimac.utils.anticheat.LogUtil;
-import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 
 public class PacketLimiter implements Initable {
     @Override
     public void start() {
         Bukkit.getScheduler().runTaskTimerAsynchronously(GrimAPI.INSTANCE.getPlugin(), () -> {
-            int spamThreshold = GrimAPI.INSTANCE.getConfigManager().getConfig().getIntElse("packet-spam-threshold", 100);
             for (GrimPlayer player : GrimAPI.INSTANCE.getPlayerDataManager().getEntries()) {
                 // Avoid concurrent reading on an integer as it's results are unknown
-                if (player.cancelledPackets.get() > spamThreshold) {
-                    LogUtil.info("Disconnecting " + player.user.getName() + " for spamming invalid packets, packets cancelled in a second " + player.cancelledPackets);
-                    //let's disconnect them safely
-                    ChannelHelper.runInEventLoop(player.user.getChannel(), () -> player.disconnect(Component.translatable("disconnect.closed")));
-                }
                 player.cancelledPackets.set(0);
             }
         }, 0, 20);

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -125,6 +125,6 @@ experimental-checks: false
 
 # Grim sometimes cancels illegal packets such as with timer, after X packets in a second cancelled, when should
 # we simply kick the player? This is required as some packet limiters don't count packets cancelled by grim.
-packet-spam-threshold: 150
+packet-spam-threshold: 100
 
 config-version: 8

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -131,6 +131,6 @@ experimental-checks: false
 # Grim a veces cancela paquetes ilegal como los de Timer. Después de X paquetes en un solo segundo cancelados,
 # cuando deberíamos simplemente expulsar al jugador? Esto es obligatorio ya que algunos limitadores de paquetes
 # no cuentan los paquetes cancelados por Grim.
-packet-spam-threshold: 150
+packet-spam-threshold: 100
 
 config-version: 8

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -123,6 +123,6 @@ experimental-checks: false
 
 # Grim有时会取消非法的数据包，比如用timer，在一秒钟内取消了数个数据包后，我们应该踢掉这个玩家？
 # 我们认为是应该的，因为有些数据包限制器并不计算被Grim取消的数据包。
-packet-spam-threshold: 150
+packet-spam-threshold: 100
 
 config-version: 8


### PR DESCRIPTION
Disconnects players who hit the packet threshold immediately instead of checking every second. Needs to be tested before pushing.