### PR TITLE
Fix food desynchronization

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -49,11 +49,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
 
             player.sendTransaction();
 
-            if (health.getFood() == 20) { // Split so transaction before packet
-                player.latencyUtils.addRealTimeTask(player.lastTransactionReceived.get(), () -> player.food = 20);
-            } else { // Split so transaction after packet
-                player.latencyUtils.addRealTimeTask(player.lastTransactionReceived.get() + 1, () -> player.food = health.getFood());
-            }
+            player.latencyUtils.addRealTimeTask(player.lastTransactionReceived.get(), () -> player.food = health.getFood());
 
             if (health.getHealth() <= 0) {
                 player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.compensatedEntities.getSelf().isDead = true);


### PR DESCRIPTION
Server version: Paper 1.12.2

This fixes the issue where the `food` field may become desynchronized if the Bukkit API `setHealth()` and `setFoodLevel()` are applied to the player at the same time.  Due to this, the player falsely gets flagged for "NoSlow (Prediction)."

Steps to reproduce:
1. player has incomplete hunger.
2. player's "health" and "food level" are restored by 20 in that exact order.
3. player right-clicks while holding food in hand.

**I haven't thoroughly tested these changes. So, it is possible that it may create other false flags.**