### PR TITLE
Fix ping in debug log & FastBreak clampBalance

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -138,7 +138,7 @@ public class FastBreak extends Check implements PacketCheck {
     }
 
     private void clampBalance() {
-        double balance = Math.max(1000, (player.getTransactionPing() / 1e6));
+        double balance = Math.max(1000, (player.getTransactionPing()));
         blockBreakBalance = GrimMath.clamp(blockBreakBalance, -balance, balance); // Clamp not Math.max in case other logic changes
         blockDelayBalance = GrimMath.clamp(blockDelayBalance, -balance, balance);
     }

--- a/src/main/java/ac/grim/grimac/manager/init/start/SuperDebug.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/SuperDebug.java
@@ -70,7 +70,7 @@ public final class SuperDebug extends Check implements PostPredictionCheck {
         sb.append("\nServer Version: ");
         sb.append(PacketEvents.getAPI().getServerManager().getVersion().getReleaseName());
         sb.append("\nPing: ");
-        sb.append(player.getTransactionPing() * 0.000001);
+        sb.append(player.getTransactionPing());
         sb.append("ms\n\n");
 
         for (int i = 0; i < predicted.size(); i++) {


### PR DESCRIPTION
It seems these instances were forgotten about when this commit was made back in July: https://github.com/GrimAnticheat/Grim/commit/6cb8770d7cb388e95f8d81533d16ac591080b36a#diff-b3a1ed2321e90f1869bbb1174b3b6eb01375f973c5afde9da580793117ee5d14R494-R496

I've tested the fast break change up to 700ms of ping and it seems correct, as it would have returned the actual ping in ms before that commit, but I'm dumb so I could be completely wrong.