### PR TITLE
Reimplement BadPacketsG

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
@@ -10,7 +10,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEn
 
 @CheckData(name = "BadPacketsG")
 public class BadPacketsG extends Check implements PacketCheck {
-    boolean lastSneaking;
+    private boolean lastSneaking, respawn;
 
     public BadPacketsG(GrimPlayer player) {
         super(player);
@@ -19,11 +19,11 @@ public class BadPacketsG extends Check implements PacketCheck {
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
-            final boolean wasTeleport = player.packetStateData.lastPacketWasTeleport;
             WrapperPlayClientEntityAction packet = new WrapperPlayClientEntityAction(event);
 
             if (packet.getAction() == WrapperPlayClientEntityAction.Action.START_SNEAKING) {
-                if (lastSneaking && !wasTeleport) {
+                // The player may send two START_SNEAKING packets if they respawned
+                if (lastSneaking && !respawn) {
                     if (flagAndAlert("state=true") && shouldModifyPackets()) {
                         event.setCancelled(true);
                         player.onPacketCancel();
@@ -31,8 +31,9 @@ public class BadPacketsG extends Check implements PacketCheck {
                 } else {
                     lastSneaking = true;
                 }
+                respawn = false;
             } else if (packet.getAction() == WrapperPlayClientEntityAction.Action.STOP_SNEAKING) {
-                if (!lastSneaking && !wasTeleport) {
+                if (!lastSneaking && !respawn) {
                     if (flagAndAlert("state=false") && shouldModifyPackets()) {
                         event.setCancelled(true);
                         player.onPacketCancel();
@@ -40,7 +41,13 @@ public class BadPacketsG extends Check implements PacketCheck {
                 } else {
                     lastSneaking = false;
                 }
+                respawn = false;
             }
         }
+    }
+
+    public void handleRespawn() {
+        // Clients could potentially not send a STOP_SNEAKING packet when they die, so we need to track it
+        respawn = true;
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
@@ -10,7 +10,6 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEn
 
 @CheckData(name = "BadPacketsG")
 public class BadPacketsG extends Check implements PacketCheck {
-    boolean wasTeleport;
     boolean lastSneaking;
 
     public BadPacketsG(GrimPlayer player) {
@@ -19,9 +18,8 @@ public class BadPacketsG extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        wasTeleport = player.packetStateData.lastPacketWasTeleport || wasTeleport;
-
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+            final boolean wasTeleport = player.packetStateData.lastPacketWasTeleport;
             WrapperPlayClientEntityAction packet = new WrapperPlayClientEntityAction(event);
 
             if (packet.getAction() == WrapperPlayClientEntityAction.Action.START_SNEAKING) {

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.events.packets;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.checks.impl.badpackets.BadPacketsE;
 import ac.grim.grimac.checks.impl.badpackets.BadPacketsF;
+import ac.grim.grimac.checks.impl.badpackets.BadPacketsG;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.TrackerData;
 import ac.grim.grimac.utils.data.packetentity.PacketEntitySelf;
@@ -131,7 +132,11 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
             }
 
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> {
-                player.isSneaking = false;
+                // From 1.16 to 1.19, this doesn't get set to false for whatever reason
+                if (player.getClientVersion().isOlderThan(ClientVersion.V_1_16) || player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20)) {
+                    player.isSneaking = false;
+                }
+
                 player.lastOnGround = false;
                 player.onGround = false;
                 player.isInBed = false;
@@ -157,6 +162,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 }
 
                 player.checkManager.getPacketCheck(BadPacketsE.class).handleRespawn(); // Reminder ticks reset
+                player.checkManager.getPacketCheck(BadPacketsG.class).handleRespawn();
 
                 // compensate for immediate respawn gamerule
                 if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)) {


### PR DESCRIPTION
If a player is teleported once then this flag would permanently become true, which doesn't make sense.

Tested with a client to send sneaking status twice and it does flag now unlike before.

Not sure why the teleport check is needed in the first place - BadPacketsF (the sprint check) doesn't have a teleport check. Seems odd for only sneaking to require this. I've left it in anyway - shouldn't do much harm.

Edit: this might be wrong... what if a player toggles sprint during teleport? should the teleport check be removed?