### PR TITLE
Fix illegal packet being sent

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsA.java
@@ -25,6 +25,7 @@ public class BadPacketsA extends Check implements PacketCheck {
 
             if (slot == lastSlot) {
                 flagAndAlert("slot=" + slot);
+                return;
             }
 
             lastSlot = packet.getSlot();


### PR DESCRIPTION
This prevents the last slot value to be set if the slot is an invalid slot. This prevents the client sending packets which are illegal such as the new slot and the current slot both being 1.