### PR TITLE
Fix world resync Y position (again)

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/patch/ResyncWorldUtil.java
+++ b/src/main/java/ac/grim/grimac/events/packets/patch/ResyncWorldUtil.java
@@ -97,7 +97,7 @@ public class ResyncWorldUtil {
                                         blockId = (block.getType().getId() << 4) | block.getData();
                                     }
 
-                                    encodedBlocks[blockIndex++] = new WrapperPlayServerMultiBlockChange.EncodedBlock(blockId, currX, (minChunkY << 4) + currY, currZ);
+                                    encodedBlocks[blockIndex++] = new WrapperPlayServerMultiBlockChange.EncodedBlock(blockId, currX, (currChunkY << 4) + currY, currZ);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixed using a wrong variable in https://github.com/GrimAnticheat/Grim/pull/950 which caused empty blocks to appear in some areas.
![javaw](https://user-images.githubusercontent.com/78062896/218172870-95633802-ebf3-4e8a-8ad2-91006ea59664.png)
