### PR TITLE
Do not force a kb for flying players

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/SetbackTeleportUtil.java
+++ b/src/main/java/ac/grim/grimac/manager/SetbackTeleportUtil.java
@@ -184,7 +184,7 @@ public class SetbackTeleportUtil extends Check implements PostPredictionCheck {
 
         player.boundingBox = oldBB; // reset back to the new bounding box
 
-        if (!hasAcceptedSpawnTeleport) clientVel = null; // if the player hasn't spawned... don't force kb
+        if (!hasAcceptedSpawnTeleport || player.isFlying) clientVel = null; // if the player is flying or hasn't spawned... don't force kb
 
         // Something weird has occurred in the player's movement, block offsets until we resync
         if (isResync) {


### PR DESCRIPTION
If a player teleports to an unloaded chunk while flying, the anticheat will not let him move until he turns off the flight or teleport again, but into the loaded chunk. It seems that this bug is not present on 1.19.2 server version, but at least on 1.12.2 it is present.

Fixed this bug simply by not forcing velocity on the flying players.