### PR TITLE
Fix Fastbreak falses on piston heads for pre 1.15.2

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -25,7 +25,7 @@ public class BlockBreakSpeed {
         float blockHardness = block.getType().getHardness();
 
         // 1.15.2 and below need this hack
-        if ((block.getType() == StateTypes.PISTON || block.getType() == StateTypes.STICKY_PISTON) && player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_15_2)) {
+        if ((block.getType() == StateTypes.PISTON || block.getType() == StateTypes.PISTON_HEAD || block.getType() == StateTypes.STICKY_PISTON) && player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_15_2)) {
             blockHardness = 0.5f;
         }
 


### PR DESCRIPTION
Full credit for this pr goes to @BerryThDev #887 which fixes Fastbreak falses uppon breaking piston heads.
Berry seems either inactive or has forgotten about his open pr soooo i did one (his pr is not getting merged since it also contains a new feature)