### PR TITLE
Create BadPacketsM

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -21,7 +21,7 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_9)) return;
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             placedBlock = false;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "BadPacketsM", experimental = true)
@@ -18,6 +19,7 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
+        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             i = 0;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -21,7 +21,7 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8)) return;
+        if (!player.isTickingReliablyFor(4)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             i = 0;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.DiggingAction;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
@@ -20,6 +21,7 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             i = 0;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -17,17 +17,18 @@ public class BadPacketsM extends Check implements PacketCheck {
         super(player);
     }
 
-    private int i = 0;
+    private boolean placedBlock;
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (!player.isTickingReliablyFor(4)) return;
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
-            i = 0;
-        } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
-            i++;
+        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType()) || !player.isTickingReliablyFor(4)) {
+            placedBlock = false;
+            return;
+        }
+        if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+            placedBlock = true;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
-            if (i > 0) {
+            if (placedBlock) {
                 DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
                 if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK))
                     flagAndAlert();

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -6,7 +6,6 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.DiggingAction;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
@@ -21,7 +20,6 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             i = 0;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -21,7 +21,7 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) return;
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_9)) return;
         if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             placedBlock = false;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -7,6 +7,8 @@ import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.DiggingAction;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "BadPacketsM", experimental = true)
@@ -26,7 +28,9 @@ public class BadPacketsM extends Check implements PacketCheck {
             i++;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
             if (i > 0) {
-                flagAndAlert();
+                DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
+                if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK))
+                    flagAndAlert();
             }
         }
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -1,0 +1,31 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
+
+@CheckData(name = "BadPacketsM", experimental = true)
+public class BadPacketsM extends Check implements PacketCheck {
+    public BadPacketsM(GrimPlayer player) {
+        super(player);
+    }
+
+    private int i = 0;
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+            i = 0;
+        } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+            i++;
+        } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
+            if (i > 0) {
+                flagAndAlert();
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -21,17 +21,17 @@ public class BadPacketsM extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType()) || !player.isTickingReliablyFor(4)) {
+        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) return;
+        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             placedBlock = false;
-            return;
-        }
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+        } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
             placedBlock = true;
         } else if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
             if (placedBlock) {
                 DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
-                if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK))
+                if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK)) {
                     flagAndAlert();
+                }
             }
         }
     }

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -77,6 +77,7 @@ public class CheckManager {
                 .put(BadPacketsJ.class, new BadPacketsJ(player))
                 .put(BadPacketsK.class, new BadPacketsK(player))
                 .put(BadPacketsL.class, new BadPacketsL(player))
+                .put(BadPacketsM.class, new BadPacketsM(player))
                 .put(BadPacketsN.class, new BadPacketsN(player))
                 .put(BadPacketsP.class, new BadPacketsP(player))
                 .put(PostCheck.class, new PostCheck(player))


### PR DESCRIPTION
The old `BadPacketsM` checked for `HELD_ITEM_CHANGE` being called twice in a single tick. 
This check reimplements a similar one. It checks if the client has send a `PLAYER_BLOCK_PLACEMENT` and a `PLAYER_DIGGING` in the same tick. (order is important) 
We have debugged this check for the past days (on 1.8 Client on 1.8 Servers) . It seems like sending a digging and then a placement packet while one tick is legit doable.
I have marked this check as experimental since it has not been tested on any other versions.
Flags some shitty AutoSoups/AutoBlocks. 
Edit:
Tested on 1.19 Client on 1.19 Server. Falses when standing still and pressing right click on block while pressing q to drop (Returning if player stands still for 1.8+ 21e44a2aebcc8790e82c99854326cef91c762bf7)