### PR TITLE
Improve isTickingReliablyFor

### DIFF
--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -503,6 +503,7 @@ public class GrimPlayer implements GrimUser {
     public boolean isTickingReliablyFor(int ticks) {
         return (getClientVersion().isOlderThan(ClientVersion.V_1_9) 
                 || !uncertaintyHandler.lastPointThree.hasOccurredSince(ticks))
+                && this.actualMovement.lengthSquared() >= 0.000064
                 || compensatedEntities.getSelf().inVehicle();
     }
 

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -502,8 +502,8 @@ public class GrimPlayer implements GrimUser {
     // 2. The player is in a vehicle
     public boolean isTickingReliablyFor(int ticks) {
         return (getClientVersion().isOlderThan(ClientVersion.V_1_9) 
-                || !uncertaintyHandler.lastPointThree.hasOccurredSince(ticks))
-                && this.actualMovement.lengthSquared() >= 0.000064
+                || (!uncertaintyHandler.lastPointThree.hasOccurredSince(ticks)
+                && this.actualMovement.lengthSquared() >= 0.000064)
                 || compensatedEntities.getSelf().inVehicle();
     }
 


### PR DESCRIPTION
By adding this.actualMovement.length() > 0.008 as additional condition we can ensure that the player actually moved 