### PR TITLE
Ignore dead entities for Reach

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -78,6 +78,9 @@ public class Reach extends Check implements PacketCheck {
                 }
                 return;
             }
+            
+            // Dead entities cause false flags (https://github.com/GrimAnticheat/Grim/issues/546)
+            if (entity.isDead) return;
 
             // TODO: Remove when in front of via
             if (entity.type == EntityTypes.ARMOR_STAND && player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) return;


### PR DESCRIPTION
Hitting a dead entity will false flag the Reach check. resolves #546 