### PR TITLE
Fix FastBreak false positives

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -64,6 +64,8 @@ public class FastBreak extends Check implements PacketCheck {
                 targetBlock = digging.getBlockPosition();
                 maximumBlockDamage = BlockBreakSpeed.getBlockDamage(player, targetBlock);
 
+                if (maximumBlockDamage == 0) return;
+
                 double breakDelay = System.currentTimeMillis() - lastFinishBreak;
 
                 if (breakDelay >= 275) { // Reduce buffer if "close enough"
@@ -82,6 +84,8 @@ public class FastBreak extends Check implements PacketCheck {
             }
 
             if (digging.getAction() == DiggingAction.FINISHED_DIGGING && targetBlock != null) {
+                if (maximumBlockDamage == 0) return;
+
                 double predictedTime = Math.ceil(1 / maximumBlockDamage) * 50;
                 double realTime = System.currentTimeMillis() - startBreak;
                 double diff = predictedTime - realTime;

--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -60,11 +60,17 @@ public class FastBreak extends Check implements PacketCheck {
             WrapperPlayClientPlayerDigging digging = new WrapperPlayClientPlayerDigging(event);
 
             if (digging.getAction() == DiggingAction.START_DIGGING) {
+                WrappedBlockState block = player.compensatedWorld.getWrappedBlockStateAt(digging.getBlockPosition());
+                
+                // Exempt all blocks that do not exist in the player version
+                if (WrappedBlockState.getDefaultState(player.getClientVersion(), block.getType()).getType() == StateTypes.AIR) {
+                    return;
+                }
+            
                 startBreak = System.currentTimeMillis() - (targetBlock == null ? 50 : 0); // ???
                 targetBlock = digging.getBlockPosition();
+                
                 maximumBlockDamage = BlockBreakSpeed.getBlockDamage(player, targetBlock);
-
-                if (maximumBlockDamage == 0) return;
 
                 double breakDelay = System.currentTimeMillis() - lastFinishBreak;
 
@@ -84,8 +90,6 @@ public class FastBreak extends Check implements PacketCheck {
             }
 
             if (digging.getAction() == DiggingAction.FINISHED_DIGGING && targetBlock != null) {
-                if (maximumBlockDamage == 0) return;
-
                 double predictedTime = Math.ceil(1 / maximumBlockDamage) * 50;
                 double realTime = System.currentTimeMillis() - startBreak;
                 double diff = predictedTime - realTime;

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -37,6 +37,11 @@ public class BlockBreakSpeed {
             // Instabreak
             return 1;
         }
+        
+        // Barrier blocks do not exist in 1.7 version
+        if (block.getType() == StateTypes.BARRIER && player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) {
+            return 0;
+        }
 
         if (blockHardness == -1) return 0; // Unbreakable block
 

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -42,6 +42,13 @@ public class BlockBreakSpeed {
         if (block.getType() == StateTypes.BARRIER && player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) {
             return 0;
         }
+        
+        // ViaVersion translates the Lantern and Soul Lantern blocks to a Redstone Lamp for older versions
+        if (block.getType() == StateTypes.LANTERN &&
+            player.getClientVersion().isOlderThan(ClientVersion.V_1_14) ||
+            block.getType() == StateTypes.SOUL_LANTERN && player.getClientVersion().isOlderThan(ClientVersion.V_1_16)) {
+            blockHardness = 0.3f;
+        }
 
         if (blockHardness == -1) return 0; // Unbreakable block
 

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -38,16 +38,9 @@ public class BlockBreakSpeed {
             return 1;
         }
         
-        // Barrier blocks do not exist in 1.7 version
-        if (block.getType() == StateTypes.BARRIER && player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) {
-            return 0;
-        }
-        
-        // ViaVersion translates the Lantern and Soul Lantern blocks to a Redstone Lamp for older versions
-        if (block.getType() == StateTypes.LANTERN &&
-            player.getClientVersion().isOlderThan(ClientVersion.V_1_14) ||
-            block.getType() == StateTypes.SOUL_LANTERN && player.getClientVersion().isOlderThan(ClientVersion.V_1_16)) {
-            blockHardness = 0.3f;
+        // Exempt all blocks that do not exist in the player version
+        if (WrappedBlockState.getDefaultState(player.getClientVersion(), block.getType()).getType() == StateTypes.AIR) {
+            blockHardness = -1;
         }
 
         if (blockHardness == -1) return 0; // Unbreakable block

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -37,11 +37,6 @@ public class BlockBreakSpeed {
             // Instabreak
             return 1;
         }
-        
-        // Exempt all blocks that do not exist in the player version
-        if (WrappedBlockState.getDefaultState(player.getClientVersion(), block.getType()).getType() == StateTypes.AIR) {
-            blockHardness = -1;
-        }
 
         if (blockHardness == -1) return 0; // Unbreakable block
 


### PR DESCRIPTION
Barrier blocks do not exist on 1.7 clients, this get's bugged due to ViaVersion WorldRemapper.
Lantern blocks do not exist on versions older than 1.14, ViaVersion transforms the block to a Redstone Lamp.
Soul Lantern blocks do not exist on versions older than 1.16, ViaVersion transforms the block to a Redstone Lamp.

Resolves #652, resolves #791 