### PR TITLE
Update zh.yml

### DIFF
--- a/src/main/resources/punishments/zh.yml
+++ b/src/main/resources/punishments/zh.yml
@@ -7,7 +7,7 @@
 # [proxy] - special command to alert to other servers connected to your proxy (BungeeCord/Velocity)
 Punishments:
   Simulation:
-    # 当达到多少VL时移除玩家
+    # 多少秒后重置VL
     remove-violations-after: 300
     # This section will match all checks with the name,
     # To exclude a check that would otherwise be matched, put an exclamation mark in front of the name


### PR DESCRIPTION
应该翻译为“重置VL”，而不是“移除玩家”
Should be translated as "reset VL", not "remove player"
Должен переводиться как "сбросить ВЛ", а не "удалить игрока"