### PR TITLE
Fix 0 interval on webhook and proxy commands

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -140,27 +140,24 @@ public class PunishmentManager {
                             if (command.command.equals("[webhook]")) {
                                 String vl = group.violations.values().stream().filter((e) -> e == check).count() + "";
                                 GrimAPI.INSTANCE.getDiscordManager().sendAlert(player, verbose, check.getCheckName(), vl);
-                                continue;
-                            }
-
-                            if (command.command.equals("[proxy]")) {
+                            } else if (command.command.equals("[proxy]")) {
                                 String proxyAlertString = GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("alerts-format-proxy", "%prefix% &f[&cproxy&f] &f%player% &bfailed &f%check_name% &f(x&c%vl%&f) &7%verbose%");
                                 proxyAlertString = replaceAlertPlaceholders(command.getCommand(), group, check, proxyAlertString, verbose);
                                 ProxyAlertMessenger.sendPluginMessage(proxyAlertString);
-                                continue;
-                            }
-
-                            if (command.command.equals("[alert]")) {
-                                sentDebug = true;
-                                if (testMode) { // secret test mode
-                                    player.user.sendMessage(cmd);
-                                    continue;
+                            } else {
+                                if (command.command.equals("[alert]")) {
+                                    sentDebug = true;
+                                    if (testMode) { // secret test mode
+                                        player.user.sendMessage(cmd);
+                                        continue;
+                                    }
+                                    cmd = "grim sendalert " + cmd; // Not test mode, we can add the command prefix
                                 }
-                                cmd = "grim sendalert " + cmd; // Not test mode, we can add the command prefix
-                            }
 
-                            String finalCmd = cmd;
-                            FoliaCompatUtil.runTask(GrimAPI.INSTANCE.getPlugin(), (dummy) -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), finalCmd));}
+                                String finalCmd = cmd;
+                                FoliaCompatUtil.runTask(GrimAPI.INSTANCE.getPlugin(), (dummy) -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), finalCmd));
+                            }
+                        }
 
                         command.setExecuteCount(command.getExecuteCount() + 1);
                     }


### PR DESCRIPTION
Currently, the PunishmentManager does a `continue;` after executing webhook and proxy commands, which means their execution counter is not increased, therefore setting the interval to 0 (which is documented as permitting a single execution) does not work.

This PR removes the `continue` calls and moves the alert and regular command code in an `else` to keep the previous behavior for other commands.