### PR TITLE
Always execute commands when reaching the threshold

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -131,7 +131,7 @@ public class PunishmentManager {
                     if (violationCount >= command.getThreshold()) {
                         // 0 means execute once
                         // Any other number means execute every X interval
-                        boolean inInterval = command.getInterval() == 0 ? (command.executeCount == 0) : (violationCount % command.getInterval() == 0);
+                        boolean inInterval = command.getInterval() == 0 ? (command.executeCount == 0) : ((violationCount - command.getThreshold()) % command.getInterval() == 0);
                         if (inInterval) {
                             CommandExecuteEvent executeEvent = new CommandExecuteEvent(player, check, cmd);
                             Bukkit.getPluginManager().callEvent(executeEvent);


### PR DESCRIPTION
The comments in the default punishment command config say that `100:50` means the command will execute `when the user hits flag 100, and after that, every 50th flag after 100`, which is indeed how it works: it executes at 100, 150, 200...

However, I thought setting `50:100` for example would execute at 50, then every 100th (50, 150, 250...) but it does not.

This PR makes this last example work, by subtracting the threshold to the violation count before checking if the interval is met.

This could break some configs though, so I don't know if you will want to merge it. It will not break any config where the threshold is a multiple of the interval though, which I guess is what most people use as it's precisely how all examples in the default config are written.