### PR TITLE
Use ONLINE plugin message target instead of ALL

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
+++ b/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
@@ -70,7 +70,7 @@ public class ProxyAlertMessenger extends PacketListenerAbstract {
         ByteArrayOutputStream messageBytes = new ByteArrayOutputStream();
         ByteArrayDataOutput out = ByteStreams.newDataOutput();
         out.writeUTF("Forward");
-        out.writeUTF("ALL");
+        out.writeUTF("ONLINE");
         out.writeUTF("GRIMAC");
 
         try {


### PR DESCRIPTION
This PR aims to fix bunch of issues with the proxy alerts by switching the plugin message target from `ALL` to `ONLINE`.

The `ALL` target have bunch of drawbacks and should be avoided whenever possible. One of the biggest issues with the `ALL` mode in this case is that players can get kicked by packet spam in certain situtations. For a plugin message to be sent to a subserver there needs to be at least one player connected to that specific subserver. In case of a empty server this can cause a buildup of messages that all get sent when a player finally connects to that subserver.

`ONLINE` target on the other hand **only sends the messages to the servers that has players** and thus prevents the message buildup. This fixes first and foremost the packet spam kicking players but also prevents old alerts showing up hours even days after they were sent when a player connects to a empty subserver that has been empty for a while.