### PR TITLE
[+] added BadPacketR check

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -22,8 +22,8 @@ public class BadPacketsR extends Check implements PacketCheck {
         if (event.getPacketType() == PacketType.Play.Client.WINDOW_CONFIRMATION) {
             final WrapperPlayClientWindowConfirmation packet = new WrapperPlayClientWindowConfirmation(event);
 
-            if (packet.getWindowId() == 0) {
-                final short actionId = packet.getActionId();
+            final short actionId = packet.getActionId();
+            if (packet.getWindowId() == 0 && player.didWeSendThatTrans.contains(actionId)) {
                 if (lastConfirm != Short.MAX_VALUE && actionId != lastConfirm - 1) {
                     flagAndAlert("action=" + actionId);
                 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -1,0 +1,34 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientWindowConfirmation;
+
+@CheckData(name = "BadPacketsR")
+public class BadPacketsR extends Check implements PacketCheck {
+
+    private short lastConfirm = Short.MAX_VALUE;
+
+    public BadPacketsR(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() == PacketType.Play.Client.WINDOW_CONFIRMATION) {
+            final WrapperPlayClientWindowConfirmation packet = new WrapperPlayClientWindowConfirmation(event);
+
+            if (packet.getWindowId() == 0) {
+                final short actionId = packet.getActionId();
+                if (lastConfirm != Short.MAX_VALUE && actionId != lastConfirm - 1) {
+                    flagAndAlert("action=" + actionId);
+                }
+                lastConfirm = actionId;
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -23,7 +23,7 @@ public class BadPacketsR extends Check implements PacketCheck {
             final WrapperPlayClientWindowConfirmation packet = new WrapperPlayClientWindowConfirmation(event);
 
             final short actionId = packet.getActionId();
-            if (packet.getWindowId() == 0 && player.didWeSendThatTrans.contains(actionId)) {
+            if (packet.getWindowId() == 0 && player.didWeSendThatTrans.contains(actionId) && actionId < 0) {
                 if (lastConfirm != Short.MAX_VALUE && actionId != lastConfirm - 1) {
                     flagAndAlert("action=" + actionId);
                 }

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -79,6 +79,7 @@ public class CheckManager {
                 .put(BadPacketsN.class, new BadPacketsN(player))
                 .put(BadPacketsP.class, new BadPacketsP(player))
                 .put(BadPacketsQ.class, new BadPacketsQ(player))
+                .put(BadPacketsR.class, new BadPacketsR(player))
                 .put(PostCheck.class, new PostCheck(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(NoSlowB.class, new NoSlowB(player))


### PR DESCRIPTION
when WindowConfirmation's windowId == 0 the actionId is always equal to lastActionId-1
this will flag when some one trying to cancel some WindowConfirmation packet and skip it
eg:
Normal (-1) (-2) (-3) (-4) (-5) (-6) (-7) (-8) (-9) (-10) etc..
Hacker (-1) (-6) (-11) (-16) (-21) (-26) (-31) (-36) (-41) (-46) etc.. and this will be detected(I suggest you should ban the player when vl is up to 1)