### PR TITLE
Avoid reading non-existent property

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -456,9 +456,6 @@ public class CompensatedWorld {
                     case DOWN:
                         isPowered = true;
                         break;
-                    case UP:
-                        isPowered = state.isUp();
-                        break;
                     case NORTH:
                         isPowered = state.getNorth() == North.TRUE;
                         if (isPowered && (badOne == BlockFace.NORTH || badTwo == BlockFace.NORTH)) {


### PR DESCRIPTION
Grim is trying to read a non-existent property which results in nullpointers. 
Define once mentioned in #998 that this can be fixed by making grim not read the UP property, which should fix that mentioned issue
