### PR TITLE
Update config key for NoSlowA threshold and default

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/movement/NoSlowA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/movement/NoSlowA.java
@@ -53,6 +53,6 @@ public class NoSlowA extends Check implements PostPredictionCheck {
     @Override
     public void reload() {
         super.reload();
-        offsetToFlag = getConfig().getDoubleElse("NoSlow.threshold", 0.00001);
+        offsetToFlag = getConfig().getDoubleElse("NoSlowA.threshold", 0.001);
     }
 }


### PR DESCRIPTION
The `NoSlowA` check was renamed from `NoSlow`. The commit https://github.com/GrimAnticheat/Grim/commit/6609016e5d83fdf756b3fe2ad0e1d50dac261443 updated the config values to be `NoSlowA` but this config key check still references the old location `NoSlow.threshold` which no longer exists. 

The default config also had this set to `0.001` but is referenced here as `0.00001` which seems like a mismatch.