### PR TITLE
Fix an exception while updating a block

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -267,7 +267,7 @@ public class CompensatedWorld {
         int offsetY = y - minHeight;
 
         if (column != null) {
-            if (column.getChunks().length <= (offsetY >> 4)) return;
+            if (column.getChunks().length <= (offsetY >> 4) || (offsetY >> 4) < 0) return;
 
             BaseChunk chunk = column.getChunks()[offsetY >> 4];
 


### PR DESCRIPTION
This PR fixes `java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 16` on block update.

Stacktrace: https://pastebin.com/30sdcrm5