### PR TITLE
Fix depth strider check and refactor to util

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -21,6 +21,7 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityRideable;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityTrackXRot;
 import ac.grim.grimac.utils.enums.Pose;
+import ac.grim.grimac.utils.inventory.EnchantmentHelper;
 import ac.grim.grimac.utils.latency.CompensatedWorld;
 import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.math.VectorUtils;
@@ -445,9 +446,8 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             wasChecked = true;
 
             // Depth strider was added in 1.8
-            ItemStack boots = player.getInventory().getBoots();
             if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
-                player.depthStriderLevel = boots.getEnchantmentLevel(EnchantmentTypes.DEPTH_STRIDER, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
+                player.depthStriderLevel = EnchantmentHelper.getMaximumEnchantLevel(player.getInventory(), EnchantmentTypes.DEPTH_STRIDER, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
             } else {
                 player.depthStriderLevel = 0;
             }

--- a/src/main/java/ac/grim/grimac/utils/inventory/EnchantmentHelper.java
+++ b/src/main/java/ac/grim/grimac/utils/inventory/EnchantmentHelper.java
@@ -1,10 +1,40 @@
 package ac.grim.grimac.utils.inventory;
 
+import ac.grim.grimac.utils.latency.CompensatedInventory;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentType;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 
 public class EnchantmentHelper {
     public static boolean isCurse(EnchantmentType type) {
         return type == EnchantmentTypes.BINDING_CURSE || type == EnchantmentTypes.VANISHING_CURSE;
+    }
+
+    // Some enchants work on any armor piece but only the maximum level counts
+    public static int getMaximumEnchantLevel(CompensatedInventory inventory, EnchantmentType enchantmentType, ClientVersion clientVersion) {
+        int maxEnchantLevel = 0;
+
+        ItemStack helmet = inventory.getHelmet();
+        if (helmet != ItemStack.EMPTY) {
+            maxEnchantLevel = Math.max(maxEnchantLevel, helmet.getEnchantmentLevel(enchantmentType, clientVersion));
+        }
+
+        ItemStack chestplate = inventory.getChestplate();
+        if (chestplate != ItemStack.EMPTY) {
+            maxEnchantLevel = Math.max(maxEnchantLevel, chestplate.getEnchantmentLevel(enchantmentType, clientVersion));
+        }
+
+        ItemStack leggings = inventory.getLeggings();
+        if (leggings != ItemStack.EMPTY) {
+            maxEnchantLevel = Math.max(maxEnchantLevel, leggings.getEnchantmentLevel(enchantmentType, clientVersion));
+        }
+
+        ItemStack boots = inventory.getBoots();
+        if (boots != ItemStack.EMPTY) {
+            maxEnchantLevel = Math.max(maxEnchantLevel, boots.getEnchantmentLevel(enchantmentType, clientVersion));
+        }
+
+        return maxEnchantLevel;
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -2,6 +2,7 @@ package ac.grim.grimac.utils.nmsutil;
 
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.enums.FluidTag;
+import ac.grim.grimac.utils.inventory.EnchantmentHelper;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
@@ -149,15 +150,7 @@ public class BlockBreakSpeed {
         }
 
         if (player.fluidOnEyes == FluidTag.WATER) {
-            ItemStack helmet = player.getInventory().getHelmet();
-            ItemStack chestplate = player.getInventory().getChestplate();
-            ItemStack leggings = player.getInventory().getLeggings();
-            ItemStack boots = player.getInventory().getBoots();
-
-            if ((helmet == null || helmet.getEnchantmentLevel(EnchantmentTypes.AQUA_AFFINITY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) == 0) &&
-                    (chestplate == null || chestplate.getEnchantmentLevel(EnchantmentTypes.AQUA_AFFINITY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) == 0) &&
-                    (leggings == null || leggings.getEnchantmentLevel(EnchantmentTypes.AQUA_AFFINITY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) == 0) &&
-                    (boots == null || boots.getEnchantmentLevel(EnchantmentTypes.AQUA_AFFINITY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) == 0)) {
+            if (EnchantmentHelper.getMaximumEnchantLevel(player.getInventory(), EnchantmentTypes.AQUA_AFFINITY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) == 0) {
                 speedMultiplier /= 5;
             }
         }


### PR DESCRIPTION
Similar to Aqua Affinity, Depth Strider applies in the same manner. Any piece of the player's armor can contain the enchantment, but only the maximum level is applied as an effect. This commit introduces a helper for retrieving the maximum value of an enchantment applied to a player's armor and utilizes it in the checks for both Depth Strider and Aqua Affinity.