### PR TITLE
Implement BadPacketsM & BadPacketsR & BadPacketsS

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -1,0 +1,53 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PostPredictionCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Client;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.DiggingAction;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
+
+@CheckData(name = "BadPacketsM", experimental = true)
+public class BadPacketsM extends Check implements PostPredictionCheck {
+    public BadPacketsM(GrimPlayer player) {
+        super(player);
+    }
+
+    private boolean hasPlacedBlock;
+
+    @Override
+    public void onPredictionComplete(PredictionComplete predictionComplete) {
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.isTickingReliablyFor(3) || !player.skippedTickInActualMovement)) {
+            hasPlacedBlock = false;
+        }
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        PacketTypeCommon packetType = event.getPacketType();
+
+        if (WrapperPlayClientPlayerFlying.isFlying(packetType)) {
+            hasPlacedBlock = false;
+            return;
+        }
+
+        if (packetType != Client.PLAYER_BLOCK_PLACEMENT && packetType != Client.PLAYER_DIGGING)  {
+            return;
+        }
+
+        if (packetType == Client.PLAYER_BLOCK_PLACEMENT) {
+            hasPlacedBlock = true;
+        } else if (hasPlacedBlock) {
+            DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
+            if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK)) {
+                flagAndAlert();
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -23,7 +23,7 @@ public class BadPacketsM extends Check implements PostPredictionCheck {
 
     @Override
     public void onPredictionComplete(PredictionComplete predictionComplete) {
-        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.isTickingReliablyFor(3) || !player.skippedTickInActualMovement)) {
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.skippedTickInActualMovement || !player.isTickingReliablyFor(3))) {
             hasPlacedBlock = false;
         }
     }
@@ -45,7 +45,7 @@ public class BadPacketsM extends Check implements PostPredictionCheck {
             hasPlacedBlock = true;
         } else if (hasPlacedBlock) {
             DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
-            if (action.equals(DiggingAction.RELEASE_USE_ITEM) || action.equals(DiggingAction.DROP_ITEM) || action.equals(DiggingAction.DROP_ITEM_STACK)) {
+            if (action == DiggingAction.RELEASE_USE_ITEM || action == DiggingAction.DROP_ITEM || action == DiggingAction.DROP_ITEM_STACK) {
                 flagAndAlert();
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -45,7 +45,7 @@ public class BadPacketsM extends Check implements PostPredictionCheck {
             hasPlacedBlock = true;
         } else if (hasPlacedBlock) {
             DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
-            if (action == DiggingAction.RELEASE_USE_ITEM || action == DiggingAction.DROP_ITEM || action == DiggingAction.DROP_ITEM_STACK) {
+            if (action == DiggingAction.DROP_ITEM || action == DiggingAction.DROP_ITEM_STACK) {
                 flagAndAlert();
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -23,7 +23,7 @@ public class BadPacketsR extends Check implements PostPredictionCheck {
     @Override
     public void onPredictionComplete(PredictionComplete predictionComplete) {
         // call onPredictionComplete to get updated value of isTickingReliablyFor
-        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.isTickingReliablyFor(3) || !player.skippedTickInActualMovement)) {
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.skippedTickInActualMovement || !player.isTickingReliablyFor(3))) {
             hasSentPlace = false;
         }
     }
@@ -40,9 +40,9 @@ public class BadPacketsR extends Check implements PostPredictionCheck {
         if (packetType == Client.PLAYER_BLOCK_PLACEMENT) {
             hasSentPlace = true;
         } else if (packetType == Client.INTERACT_ENTITY) {
-            WrapperPlayClientInteractEntity interact = new WrapperPlayClientInteractEntity(event);
-            if (interact.getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
-                if (hasSentPlace) {
+            if (hasSentPlace) {
+                WrapperPlayClientInteractEntity interact = new WrapperPlayClientInteractEntity(event);
+                if (interact.getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
                     if (flagAndAlert() && shouldModifyPackets()) {
                         player.onPacketCancel();
                         event.setCancelled(true);

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -1,0 +1,54 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PostPredictionCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Client;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
+
+@CheckData(name = "BadPacketsR", experimental = true)
+public class BadPacketsR extends Check implements PostPredictionCheck {
+    public BadPacketsR(GrimPlayer player) {
+        super(player);
+    }
+
+    private boolean hasSentPlace;
+
+    @Override
+    public void onPredictionComplete(PredictionComplete predictionComplete) {
+        // call onPredictionComplete to get updated value of isTickingReliablyFor
+        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8) && (!player.isTickingReliablyFor(3) || !player.skippedTickInActualMovement)) {
+            hasSentPlace = false;
+        }
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        PacketTypeCommon packetType = event.getPacketType();
+
+        if (WrapperPlayClientPlayerFlying.isFlying(packetType)) {
+            hasSentPlace = false;
+            return;
+        }
+
+        if (packetType == Client.PLAYER_BLOCK_PLACEMENT) {
+            hasSentPlace = true;
+        } else if (packetType == Client.INTERACT_ENTITY) {
+            WrapperPlayClientInteractEntity interact = new WrapperPlayClientInteractEntity(event);
+            if (interact.getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
+                if (hasSentPlace) {
+                    if (flagAndAlert() && shouldModifyPackets()) {
+                        player.onPacketCancel();
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
@@ -1,0 +1,30 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
+
+@CheckData(name = "BadPacketsS", experimental = true)
+public class BadPacketsS extends Check implements PacketCheck {
+
+    public BadPacketsS(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+            WrapperPlayClientInteractEntity.InteractAction i = new WrapperPlayClientInteractEntity(event).getAction();
+            if (i == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
+                if (player.packetStateData.slowedByUsingItem) {
+                    flagAndAlert();
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
@@ -18,11 +18,14 @@ public class BadPacketsS extends Check implements PacketCheck {
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
-            WrapperPlayClientInteractEntity.InteractAction i = new WrapperPlayClientInteractEntity(event).getAction();
-            if (i == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
-                if (player.packetStateData.slowedByUsingItem) {
-                    flagAndAlert();
-                    event.setCancelled(true);
+            if (player.packetStateData.slowedByUsingItem) {
+                WrapperPlayClientInteractEntity.InteractAction action = new WrapperPlayClientInteractEntity(event).getAction();
+                if (action == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
+                    if (flagAndAlert() && shouldModifyPackets()) {
+                        event.setCancelled(true);
+                        player.onPacketCancel();
+                    }
+
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -80,6 +80,7 @@ public class CheckManager {
                 .put(BadPacketsN.class, new BadPacketsN(player))
                 .put(BadPacketsP.class, new BadPacketsP(player))
                 .put(BadPacketsQ.class, new BadPacketsQ(player))
+                .put(BadPacketsS.class, new BadPacketsS(player))
                 .put(PostCheck.class, new PostCheck(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(TransactionOrder.class, new TransactionOrder(player))

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -105,6 +105,8 @@ public class CheckManager {
                 .put(ExplosionHandler.class, new ExplosionHandler(player))
                 .put(KnockbackHandler.class, new KnockbackHandler(player))
                 .put(GhostBlockDetector.class, new GhostBlockDetector(player))
+                .put(BadPacketsM.class, new BadPacketsM(player))
+                .put(BadPacketsR.class, new BadPacketsR(player))
                 .put(Phase.class, new Phase(player))
                 .put(NoFallB.class, new NoFallB(player))
                 .put(OffsetHandler.class, new OffsetHandler(player))


### PR DESCRIPTION
These checks check for invalid packetorders. 

All BadPackets do work falseless on 1.8 (ran in production since nearly a year)

BadPacketsM and BadPacketsS has been tested since about 6 months for 1.8+ (1.19 and 1.20) 
BadPacketsR has not been tested at all for 1.8+ (i just applied  the same logic as for BadPacketsM, i might need to test if that order is different for higher versions which i doubt)
