### PR TITLE
Rewrite logic of TransactionOrder

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/TransactionOrder.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/TransactionOrder.java
@@ -14,4 +14,5 @@ public class TransactionOrder extends Check implements PacketCheck {
         super(player);
     }
 
+    public int lastReceived;
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
@@ -98,12 +98,10 @@ public class PacketPingListener extends PacketListenerAbstract {
     }
 
     private void onTransactionReceive(GrimPlayer player, short id) {
-        if (System.currentTimeMillis() - player.joinTime < 5000) {
-            return;
-        }
-
         Short expected;
         while ((expected = player.transactionOrder.pollFirst()) != null && expected != id) {
+            if (System.currentTimeMillis() - player.joinTime < 5000) return;
+
             TransactionOrder check = player.checkManager.getPacketCheck(TransactionOrder.class);
             if (check.lastReceived != id) {
                 check.flagAndAlert(String.format("Expected: %d | Received: %d", expected, id));
@@ -112,6 +110,4 @@ public class PacketPingListener extends PacketListenerAbstract {
         }
 
     }
-
-
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
@@ -98,7 +98,7 @@ public class PacketPingListener extends PacketListenerAbstract {
     }
 
     private void onTransactionReceive(GrimPlayer player, short id) {
-        if (player.joinTime < 5000) {
+        if (System.currentTimeMillis() - player.joinTime < 5000) {
             return;
         }
 

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
@@ -1,7 +1,6 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.GrimAPI;
-import ac.grim.grimac.checks.Check;
 import ac.grim.grimac.checks.impl.misc.TransactionOrder;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.Pair;
@@ -107,9 +106,9 @@ public class PacketPingListener extends PacketListenerAbstract {
         while ((expected = player.transactionOrder.pollFirst()) != null && expected != id) {
             TransactionOrder check = player.checkManager.getPacketCheck(TransactionOrder.class);
             if (check.lastReceived != id) {
-                check.lastReceived = id;
                 check.flagAndAlert(String.format("Expected: %d | Received: %d", expected, id));
             }
+            check.lastReceived = id;
         }
 
     }

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -67,6 +67,7 @@ public class GrimPlayer implements GrimUser {
     public final Queue<Pair<Short, Long>> transactionsSent = new ConcurrentLinkedQueue<>();
     public final List<Short> didWeSendThatTrans = Collections.synchronizedList(new ArrayList<>());
     private final AtomicInteger transactionIDCounter = new AtomicInteger(0);
+    public final Deque<Short> transactionOrder = new LinkedList<>();
     public AtomicInteger lastTransactionSent = new AtomicInteger(0);
     public AtomicInteger lastTransactionReceived = new AtomicInteger(0);
     // End transaction handling stuff
@@ -289,20 +290,16 @@ public class GrimPlayer implements GrimUser {
     public boolean addTransactionResponse(short id) {
         Pair<Short, Long> data = null;
         boolean hasID = false;
-        int skipped = 0;
         for (Pair<Short, Long> iterator : transactionsSent) {
             if (iterator.getFirst() == id) {
                 hasID = true;
                 break;
             }
-            skipped++;
         }
 
         if (hasID) {
             // Transactions that we send don't count towards total limit
             if (packetTracker != null) packetTracker.setIntervalPackets(packetTracker.getIntervalPackets() - 1);
-
-            if (skipped > 0 && System.currentTimeMillis() - joinTime > 5000) checkManager.getPacketCheck(TransactionOrder.class).flagAndAlert("skipped: " + skipped);
 
             do {
                 data = transactionsSent.poll();


### PR DESCRIPTION
~~Fixes false positives when more than one transaction based anticheat is running.~~ 
~~Grim currently doesnt account if the skipped transactions are also one we have sent.~~

This check is mostly a kind of combination of my old design and [artemis's](https://github.com/artemisac/artemis-minecraft-anticheat/blob/master/ac.artemis.checks.regular/src/main/java/ac/artemis/checks/regular/v2/checks/impl/disabler/DisablerTransaction.java#L76) way of checking for the order. 
We improved it a bit and avoided spam flagging by caching the last received transaction which was out of order

EDIT: do not merge, working on a fix since this doesnt seem to have fixed the issue with running two anticheats