### PR TITLE
Fix jump in fluid

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineLava.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineLava.java
@@ -13,6 +13,10 @@ public class PredictionEngineLava extends PredictionEngine {
         for (VectorData vector : new HashSet<>(existingVelocities)) {
             existingVelocities.add(new VectorData(vector.vector.clone().add(new Vector(0, 0.04f, 0)), vector, VectorData.VectorType.Jump));
 
+            if (player.skippedTickInActualMovement) {
+                existingVelocities.add(new VectorData(vector.vector.clone().add(new Vector(0, 0.02f, 0)), vector, VectorData.VectorType.Jump));
+            }
+
             if (player.slightlyTouchingLava && player.lastOnGround && !player.onGround) {
                 Vector withJump = vector.vector.clone();
                 super.doJump(player, withJump);

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
@@ -77,6 +77,10 @@ public class PredictionEngineWater extends PredictionEngine {
         for (VectorData vector : new HashSet<>(existingVelocities)) {
             existingVelocities.add(vector.returnNewModified(vector.vector.clone().add(new Vector(0, 0.04f, 0)), VectorData.VectorType.Jump));
 
+            if (player.skippedTickInActualMovement) {
+                existingVelocities.add(new VectorData(vector.vector.clone().add(new Vector(0, 0.02f, 0)), vector, VectorData.VectorType.Jump));
+            }
+
             if (player.slightlyTouchingWater && player.lastOnGround && !player.onGround) {
                 Vector withJump = vector.vector.clone();
                 super.doJump(player, withJump);

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWaterLegacy.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWaterLegacy.java
@@ -50,6 +50,10 @@ public class PredictionEngineWaterLegacy extends PredictionEngine {
     public void addJumpsToPossibilities(GrimPlayer player, Set<VectorData> existingVelocities) {
         for (VectorData vector : new HashSet<>(existingVelocities)) {
             existingVelocities.add(new VectorData(vector.vector.clone().add(new Vector(0, 0.04f, 0)), vector, VectorData.VectorType.Jump));
+
+            if (player.skippedTickInActualMovement) {
+                existingVelocities.add(new VectorData(vector.vector.clone().add(new Vector(0, 0.02f, 0)), vector, VectorData.VectorType.Jump));
+            }
         }
     }
 


### PR DESCRIPTION
It did not seem necessary to add it for every fluid. If it happens for lava, maybe it happens for other fluids in edge cases too. 

Fixes #1094 & #1167 by adding an additional offset of 0.02 when players velocity is 0 0 0 (see [this comment](https://github.com/GrimAnticheat/Grim/issues/1167#issuecomment-1745518467))