### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -29,7 +29,7 @@ import org.bukkit.entity.Player;
 
 // Based loosely off of Hawk BlockBreakSpeedSurvival
 // Also based loosely off of NoCheatPlus FastBreak
-// Also based off minecraft wiki: https://minecraft.fandom.com/wiki/Breaking#Instant_breaking
+// Also based off minecraft wiki: https://minecraft.wiki/w/Breaking#Instant_breaking
 @CheckData(name = "FastBreak")
 public class FastBreak extends Check implements PacketCheck {
     public FastBreak(GrimPlayer playerData) {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.