### PR TITLE
fix rotationplace false in 0.03 and bad wifi?

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -76,7 +76,7 @@ public class RotationPlace extends BlockPlaceCheck {
         double maxEyeHeight = Collections.max(player.getPossibleEyeHeights());
 
         SimpleCollisionBox eyePositions = new SimpleCollisionBox(player.x, player.y + minEyeHeight, player.z, player.x, player.y + maxEyeHeight, player.z);
-        eyePositions.expand(player.getMovementThreshold());
+        box.expand(player.getMovementThreshold());
 
         // If the player is inside a block, then they can ray trace through the block and hit the other side of the block
         if (eyePositions.isIntersected(box)) {

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -189,7 +189,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
             // Less than 15 milliseconds ago means this is likely (fix all look vectors being a tick behind server sided)
             // Or mojang had the idle packet... for the 1.7/1.8 clients
             // No idle packet on 1.9+
-            if ((now - player.lastBlockPlaceUseItem < 15 || player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) && hasLook) {
+            if (hasLook) {
                 player.xRot = yaw;
                 player.yRot = pitch;
             }


### PR DESCRIPTION
When the player sneaks between two blocks and moves left and right while right-clicking on both blocks using the auto-clicker, Grim falses RotationPlace post-flying, this may fix that, please let me know if I make any mistake