### PR TITLE
Filter out formatting codes

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/ClientBrand.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/ClientBrand.java
@@ -36,6 +36,7 @@ public class ClientBrand extends Check implements PacketCheck {
                     System.arraycopy(data, 1, minusLength, 0, minusLength.length);
 
                     brand = new String(minusLength).replace(" (Velocity)", ""); //removes velocity's brand suffix
+                    brand = brand.replace("§", ""); // removes formatting codes
                     if (player.checkManager.getPrePredictionCheck(ExploitA.class).checkString(brand)) brand = "sent log4j";
                     if (!GrimAPI.INSTANCE.getConfigManager().isIgnoredClient(brand)) {
                         String message = GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("client-brand-format", "%prefix% &f%player% joined using %brand%");


### PR DESCRIPTION
Filter out formatting codes from client brands to prevent obnoxious join messages. Incredibly minor issue but probably worth fixing regardless.

Before:
![image](https://github.com/GrimAnticheat/Grim/assets/65602967/30b21685-66d5-4832-9f16-a372bd3c35f9)
After:
![image](https://github.com/GrimAnticheat/Grim/assets/65602967/a6484e95-1e9e-4042-a19b-9033c382de34)
