### PR TITLE
Don't mark CrashF as experimental

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
@@ -8,7 +8,7 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientClickWindow;
 
-@CheckData(name = "CrashF", experimental = true)
+@CheckData(name = "CrashF")
 public class CrashF extends Check implements PacketCheck {
 
     public CrashF(GrimPlayer playerData) {


### PR DESCRIPTION
Impossible to false flag based on the protocol (-1 button only valid for -1 window id)