### PR TITLE
(WIP) CrashF: Check for negative slot values

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
@@ -22,9 +22,10 @@ public class CrashF extends Check implements PacketCheck {
             int clickType = click.getWindowClickType().ordinal();
             int button = click.getButton();
             int windowId = click.getWindowId();
+            int slot = click.getSlot();
 
-            if ((clickType == 1 || clickType == 2) && windowId >= 0 && button < 0) {
-                if (flagAndAlert("clickType=" + clickType + " button=" + button)) {
+            if ((clickType == 1 || clickType == 2) && windowId >= 0 && (slot < 0 || button < 0)) {
+                if (flagAndAlert("clickType=" + clickType + " slot=" + slot + " button=" + button)) {
                     event.setCancelled(true);
                     player.onPacketCancel();
                 }


### PR DESCRIPTION
Paper added the negative slot check in 1.20.1 so this still affects <=1.19.4 servers.

Thanks to ProGamingDk for reporting this in DM (https://imgur.com/a/iWLDFts).