### PR TITLE
Fix setting slots in player inventory

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
@@ -456,10 +456,13 @@ public class CompensatedInventory extends Check implements PacketCheck {
                     if (inventory.getInventoryStorage().getSize() > slot.getSlot() && slot.getSlot() >= 0) {
                         inventory.getInventoryStorage().setItem(slot.getSlot(), slot.getItem());
                     }
-                } else if (slot.getWindowId() == 0) { // Player hotbar (ONLY!)
-                    if (slot.getSlot() >= 36 && slot.getSlot() <= 45) {
+                } else if (slot.getWindowId() == 0) { // Player inventory
+                    // This packet can only be used to edit the hotbar and offhand of the player's inventory if
+                    // window ID is set to 0 (slots 36 through 45) if the player is in creative, with their inventory open,
+                    // and not in their survival inventory tab. Otherwise, when window ID is 0, it can edit any slot in the player's inventory.
+//                    if (slot.getSlot() >= 36 && slot.getSlot() <= 45) {
                         inventory.getSlot(slot.getSlot()).set(slot.getItem());
-                    }
+//                    }
                 } else if (slot.getWindowId() == openWindowID) { // Opened inventory (if not valid, client crashes)
                     menu.getSlot(slot.getSlot()).set(slot.getItem());
                 }


### PR DESCRIPTION
Grim states this can only set the player's hotbar, but it seems the info on wiki.vg was read incorrectly. This causes an inventory desync when something other than the player sets slots, easiest way to see it is putting swift sneak leggings in a dispenser and letting it apply to your armour slot. 

The wiki states:

> This packet can only be used to edit the hotbar and offhand of the player's inventory if window ID is set to 0 (slots 36 through 45) **if the player is in creative, with their inventory open, and not in their survival inventory tab**. Otherwise, when window ID is 0, it can edit any slot in the player's inventory.

By changing this, the desync will change to be creative-mode only if you don't have the survival inventory tab selected. It doesn't seem possible to detect what inventory tab a player has selected, but IMO creative mode is generally "unsupported" anyway due to its weirdness and this is more on Mojang to fix.