### PR TITLE
Only reset horse jump when on ground

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -607,8 +607,10 @@ public class MovementCheckRunner extends Check implements PositionCheck {
 
         player.vehicleData.vehicleForward = (float) Math.min(0.98, Math.max(-0.98, player.vehicleData.nextVehicleForward));
         player.vehicleData.vehicleHorizontal = (float) Math.min(0.98, Math.max(-0.98, player.vehicleData.nextVehicleHorizontal));
-        player.vehicleData.horseJump = player.vehicleData.nextHorseJump;
-        player.vehicleData.nextHorseJump = 0;
+        if (player.onGround) { // if vehicle is on ground, this gets set
+            player.vehicleData.horseJump = player.vehicleData.nextHorseJump;
+            player.vehicleData.nextHorseJump = 0;
+        }
         player.minPlayerAttackSlow = 0;
         player.maxPlayerAttackSlow = 0;
 


### PR DESCRIPTION
In my testing this is only set when the vehicle is on the ground. Doing this fixes falses when spamming jump on a horse.