### PR TITLE
Fix disconnect log message

### DIFF
--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -41,7 +41,9 @@ import com.viaversion.viaversion.api.protocol.packet.PacketTracker;
 import io.github.retrooper.packetevents.util.FoliaCompatUtil;
 import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
@@ -402,7 +404,8 @@ public class GrimPlayer implements GrimUser {
     }
 
     public void disconnect(Component reason) {
-        LogUtil.info("Disconnecting " + user.getProfile().getName() + " for " + reason.toString());
+        final String textReason = LegacyComponentSerializer.legacySection().serialize(reason);
+        LogUtil.info("Disconnecting " + user.getProfile().getName() + " for " + ChatColor.stripColor(textReason));
         try {
             user.sendPacket(new WrapperPlayServerDisconnect(reason));
         } catch (Exception ignored) { // There may (?) be an exception if the player is in the wrong state...
@@ -410,7 +413,7 @@ public class GrimPlayer implements GrimUser {
         }
         user.closeConnection();
         if (bukkitPlayer != null) {
-            FoliaCompatUtil.runTaskForEntity(bukkitPlayer, GrimAPI.INSTANCE.getPlugin(), () -> bukkitPlayer.kickPlayer(reason.toString()), null, 1);
+            FoliaCompatUtil.runTaskForEntity(bukkitPlayer, GrimAPI.INSTANCE.getPlugin(), () -> bukkitPlayer.kickPlayer(textReason), null, 1);
         }
     }
 


### PR DESCRIPTION
Before:
```
[15:54:38 INFO]: [GrimAC] Disconnecting Cotander for spamming invalid packets, packets cancelled within a second 101
[15:54:38 INFO]: [GrimAC] Disconnecting Cotander for TranslatableComponentImpl{key="disconnect.closed", args=[], fallback=null, style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, clickEvent=null, hoverEvent=null, insertion=null, font=null}, children=[]}
[15:54:38 INFO]: Cotander lost connection: TranslatableComponentImpl{key="disconnect.closed", args=[], fallback=null, style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, clickEvent=null, hoverEvent=null, insertion=null, font=null}, children=[]}
```

After:
```
[15:56:09 INFO]: [GrimAC] Disconnecting Cotander for spamming invalid packets, packets cancelled within a second 101
[15:56:09 INFO]: [GrimAC] Disconnecting Cotander for disconnect.closed
[15:56:09 INFO]: Cotander lost connection: Disconnected
```