### PR TITLE
Fix incorrect connecting block handling (legacy versions)

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
@@ -1,7 +1,11 @@
 package ac.grim.grimac.utils.collisions.blocks.connecting;
 
 import ac.grim.grimac.player.GrimPlayer;
-import ac.grim.grimac.utils.collisions.datatypes.*;
+import ac.grim.grimac.utils.collisions.datatypes.CollisionBox;
+import ac.grim.grimac.utils.collisions.datatypes.ComplexCollisionBox;
+import ac.grim.grimac.utils.collisions.datatypes.HexCollisionBox;
+import ac.grim.grimac.utils.collisions.datatypes.NoCollisionBox;
+import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.nmsutil.Materials;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
@@ -76,7 +80,7 @@ public class DynamicConnecting {
         } else {
             if (fence == target) return true;
 
-            return checkCanConnect(player, targetBlock, target, fence);
+            return checkCanConnect(player, targetBlock, target, fence, direction);
         }
     }
 
@@ -85,7 +89,7 @@ public class DynamicConnecting {
         if (BlockTags.SHULKER_BOXES.contains(m)) return true;
         if (BlockTags.TRAPDOORS.contains(m)) return true;
 
-        return m == StateTypes.CARVED_PUMPKIN || m == StateTypes.JACK_O_LANTERN || m == StateTypes.PUMPKIN || m == StateTypes.MELON ||
+        return m == StateTypes.ENCHANTING_TABLE || m == StateTypes.CARVED_PUMPKIN || m == StateTypes.JACK_O_LANTERN || m == StateTypes.PUMPKIN || m == StateTypes.MELON ||
                 m == StateTypes.BEACON || BlockTags.CAULDRONS.contains(m) || m == StateTypes.GLOWSTONE || m == StateTypes.SEA_LANTERN || m == StateTypes.ICE
                 || m == StateTypes.PISTON || m == StateTypes.STICKY_PISTON || m == StateTypes.PISTON_HEAD || (!canConnectToGlassBlock()
                 && BlockTags.GLASS_BLOCKS.contains(m));
@@ -113,7 +117,7 @@ public class DynamicConnecting {
         return i;
     }
 
-    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two) {
+    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two, BlockFace direction) {
         return false;
     }
 

--- a/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicFence.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicFence.java
@@ -23,7 +23,6 @@ public class DynamicFence extends DynamicConnecting implements CollisionFactory 
 
     public static SimpleCollisionBox[] LEGACY_BOUNDING_BOXES = new SimpleCollisionBox[] {new SimpleCollisionBox(0.375D, 0.0D, 0.375D, 0.625D, 1.0D, 0.625D), new SimpleCollisionBox(0.375D, 0.0D, 0.375D, 0.625D, 1.0D, 1.0D), new SimpleCollisionBox(0.0D, 0.0D, 0.375D, 0.625D, 1.0D, 0.625D), new SimpleCollisionBox(0.0D, 0.0D, 0.375D, 0.625D, 1.0D, 1.0D), new SimpleCollisionBox(0.375D, 0.0D, 0.0D, 0.625D, 1.0D, 0.625D), new SimpleCollisionBox(0.375D, 0.0D, 0.0D, 0.625D, 1.0D, 1.0D), new SimpleCollisionBox(0.0D, 0.0D, 0.0D, 0.625D, 1.0D, 0.625D), new SimpleCollisionBox(0.0D, 0.0D, 0.0D, 0.625D, 1.0D, 1.0D), new SimpleCollisionBox(0.375D, 0.0D, 0.375D, 1.0D, 1.0D, 0.625D), new SimpleCollisionBox(0.375D, 0.0D, 0.375D, 1.0D, 1.0D, 1.0D), new SimpleCollisionBox(0.0D, 0.0D, 0.375D, 1.0D, 1.0D, 0.625D), new SimpleCollisionBox(0.0D, 0.0D, 0.375D, 1.0D, 1.0D, 1.0D), new SimpleCollisionBox(0.375D, 0.0D, 0.0D, 1.0D, 1.0D, 0.625D), new SimpleCollisionBox(0.375D, 0.0D, 0.0D, 1.0D, 1.0D, 1.0D), new SimpleCollisionBox(0.0D, 0.0D, 0.0D, 1.0D, 1.0D, 0.625D), new SimpleCollisionBox(0.0D, 0.0D, 0.0D, 1.0D, 1.0D, 1.0D)};
 
-
     @Override
     public CollisionBox fetch(GrimPlayer player, ClientVersion version, WrappedBlockState block, int x, int y, int z) {
         boolean east;
@@ -49,10 +48,10 @@ public class DynamicFence extends DynamicConnecting implements CollisionFactory 
     }
 
     @Override
-    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two) {
+    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two, BlockFace direction) {
         if (BlockTags.FENCES.contains(one))
             return !(one == StateTypes.NETHER_BRICK_FENCE) && !(two == StateTypes.NETHER_BRICK_FENCE);
         else
-            return BlockTags.FENCES.contains(one) || CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isFullBlock();
+            return BlockTags.FENCES.contains(one) || CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isSideFullBlock(direction);
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicPane.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicPane.java
@@ -82,12 +82,11 @@ public class DynamicPane extends DynamicConnecting implements CollisionFactory {
         return true;
     }
 
-
     @Override
-    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two) {
+    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two, BlockFace direction) {
         if (BlockTags.GLASS_PANES.contains(one) || one == StateTypes.IRON_BARS)
             return true;
         else
-            return CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isFullBlock();
+            return CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isSideFullBlock(direction);
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicWall.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicWall.java
@@ -14,6 +14,7 @@ import com.github.retrooper.packetevents.protocol.world.states.enums.North;
 import com.github.retrooper.packetevents.protocol.world.states.enums.South;
 import com.github.retrooper.packetevents.protocol.world.states.enums.West;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
+import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 
 public class DynamicWall extends DynamicConnecting implements CollisionFactory {
     public static final CollisionBox[] BOXES = makeShapes(4.0F, 3.0F, 16.0F, 0.0F, 16.0F, false);
@@ -181,7 +182,7 @@ public class DynamicWall extends DynamicConnecting implements CollisionFactory {
     }
 
     @Override
-    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two) {
-        return BlockTags.WALLS.contains(one) || CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isFullBlock();
+    public boolean checkCanConnect(GrimPlayer player, WrappedBlockState state, StateType one, StateType two, BlockFace direction) {
+        return BlockTags.WALLS.contains(one) || CollisionData.getData(one).getMovementCollisionBox(player, player.getClientVersion(), state, 0, 0, 0).isSideFullBlock(direction);
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/collisions/datatypes/CollisionBox.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/datatypes/CollisionBox.java
@@ -1,5 +1,7 @@
 package ac.grim.grimac.utils.collisions.datatypes;
 
+import com.github.retrooper.packetevents.protocol.world.BlockFace;
+
 import java.util.List;
 
 public interface CollisionBox {
@@ -16,4 +18,8 @@ public interface CollisionBox {
     boolean isNull();
 
     boolean isFullBlock();
+
+    default boolean isSideFullBlock(BlockFace axis) {
+        return isFullBlock();
+    }
 }

--- a/src/main/java/ac/grim/grimac/utils/collisions/datatypes/SimpleCollisionBox.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/datatypes/SimpleCollisionBox.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.collisions.datatypes;
 
 import ac.grim.grimac.utils.nmsutil.Ray;
+import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3i;
 import org.bukkit.Location;
@@ -238,6 +239,29 @@ public class SimpleCollisionBox implements CollisionBox {
     @Override
     public boolean isFullBlock() {
         return isFullBlock;
+    }
+
+    @Override
+    public boolean isSideFullBlock(BlockFace axis) {
+        if (isFullBlock) {
+            return true;
+        }
+
+        // Get the direction of block we are trying to connect to -> towards the block that is trying to connect
+        final BlockFace faceToSourceConnector = axis.getOppositeFace();
+        switch (faceToSourceConnector) {
+            case EAST:
+            case WEST:
+                return this.minX == 0 && this.maxX == 1;
+            case UP:
+            case DOWN:
+                return this.minY == 0 && this.maxY == 1;
+            case NORTH:
+            case SOUTH:
+                return this.minZ == 0 && this.maxZ == 1;
+        }
+
+        return false;
     }
 
     public boolean isFullBlockNoCache() {


### PR DESCRIPTION
The client checks whether the side the connecting block is connecting to is full, not the entire block itself. The sides on soulsand are considered full, which is why there were falses as Grim believed fences could not connect to soul sand on these clients.
![image](https://github.com/GrimAnticheat/Grim/assets/11319274/fb1f0645-32bd-4791-b234-761e48f87b57)

Also fixed Grim trying to connect fences to enchantment tables, in my testing this does not happen all the way from 1.8-1.12.

Tested on 1.8 on a 1.20.2 server with via.

Fixes #1140.