### PR TITLE
Utilise bundles for 1.19.4+ clients

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -42,7 +42,6 @@ import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.client.*;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
 import org.bukkit.util.Vector;
@@ -792,7 +791,6 @@ public class CheckManagerListener extends PacketListenerAbstract {
         if (event.getConnectionState() != ConnectionState.PLAY) return;
         GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
         if (player == null) return;
-
         player.checkManager.onPacketSend(event);
     }
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketSelfMetadataListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketSelfMetadataListener.java
@@ -15,6 +15,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBundle;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityAnimation;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUseBed;
@@ -163,6 +164,10 @@ public class PacketSelfMetadataListener extends PacketListenerAbstract {
                     if (riptide != null && riptide.getValue() instanceof Byte) {
                         boolean isRiptiding = (((byte) riptide.getValue()) & 0x04) == 0x04;
 
+                        if (player.supportsBundles()) {
+                            player.user.writePacket(new WrapperPlayServerBundle());
+                        }
+
                         if (!hasSendTransaction) player.sendTransaction();
                         hasSendTransaction = true;
 
@@ -195,6 +200,7 @@ public class PacketSelfMetadataListener extends PacketListenerAbstract {
                             int markedTransaction = player.lastTransactionSent.get();
 
                             // Player has gotten this packet
+                            // If on 1.19.4+, we know they will receive this packet on the same tick as we bundle it
                             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> {
                                 ItemStack item = isOffhand ? player.getInventory().getOffHand() : player.getInventory().getHeldItem();
 
@@ -214,6 +220,10 @@ public class PacketSelfMetadataListener extends PacketListenerAbstract {
 
                             // Yes, we do have to use a transaction for eating as otherwise it can desync much easier
                             event.getTasksAfterSend().add(player::sendTransaction);
+                        }
+
+                        if (player.supportsBundles()) {
+                            event.getTasksAfterSend().add(() -> player.user.writePacket(new WrapperPlayServerBundle()));
                         }
                     }
                 }

--- a/src/main/java/ac/grim/grimac/manager/init/start/TickEndEvent.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/TickEndEvent.java
@@ -3,11 +3,9 @@ package ac.grim.grimac.manager.init.start;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.manager.init.Initable;
 import ac.grim.grimac.player.GrimPlayer;
-import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.lists.HookedListWrapper;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
 import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
-import org.bukkit.Bukkit;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -53,6 +53,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // Everything in this class should be sync'd to the anticheat thread.
@@ -534,6 +535,10 @@ public class GrimPlayer implements GrimUser {
 
     public boolean canThePlayerBeCloseToZeroMovement(int ticks) {
         return (!uncertaintyHandler.lastPointThree.hasOccurredSince(ticks));
+    }
+
+    public boolean supportsBundles() {
+        return user.getClientVersion() != null && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19_4) && user.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19_4);
     }
 
     public CompensatedInventory getInventory() {


### PR DESCRIPTION
This adds bundling sent packets for 1.19.4+ clients. See https://wiki.vg/Protocol#Bundle_Delimiter for more info.

The main benefit is this removes the uncertainty of the second transaction spanning across multiple ticks in the entity movement handling. If there's other areas that can benefit from the bundling, let me know.

Bit unsure about how I handle the start tick of the bundle delimiter... but it's easy and works perfectly in my testing (validated that all packets are bundled using a packet logger).

We might want to somehow make multiple bundles if there are more than 4096 packets being sent? I'll look into this if this is a concern