### PR TITLE
Fix connection state crash

### DIFF
--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -354,10 +354,9 @@ public class GrimPlayer implements GrimUser {
     }
 
     public void sendTransaction(boolean async) {
-        // don't send transactions in configuration phase
-        if (user.getDecoderState() == ConnectionState.CONFIGURATION) return;
+        // don't send transactions outside PLAY phase
         // Sending in non-play corrupts the pipeline, don't waste bandwidth when anticheat disabled
-        if (user.getConnectionState() != ConnectionState.PLAY) return;
+        if (user.getEncoderState() != ConnectionState.PLAY) return;
 
         // Send a packet once every 15 seconds to avoid any memory leaks
         if (disableGrim && (System.nanoTime() - getPlayerClockAtLeast()) > 15e9) {


### PR DESCRIPTION
Connection state was split into encoder/decoder state in PE since 1.20.2. These two can be different from eachother, if this is the case `getConnectionState` throws an error that crashes the server, since there is no "common" state.
![image](https://github.com/GrimAnticheat/Grim/assets/11319274/b885a760-9369-46f0-bae0-c19ce8dd092d)

Fixes #1255 