### PR TITLE
Cancel stupidity packets

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsU.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsU.java
@@ -1,0 +1,14 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+
+@CheckData(name = "BadPacketsU", experimental = true)
+public class BadPacketsU extends Check implements PacketCheck {
+
+    public BadPacketsU(final GrimPlayer player) {
+        super(player);
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
@@ -6,9 +6,9 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "BadPacketsU", experimental = true)
-public class BadPacketsU extends Check implements PacketCheck {
+public class BadPacketsW extends Check implements PacketCheck {
 
-    public BadPacketsU(final GrimPlayer player) {
+    public BadPacketsW(final GrimPlayer player) {
         super(player);
     }
 }

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -361,7 +361,13 @@ public class CheckManagerListener extends PacketListenerAbstract {
             // Mark that we want this packet to be cancelled from reaching the server
             // Since we delay USE_ITEM until the next valid flying packet, this is not an issue.
             // Additionally, only yaw/pitch matters: https://github.com/GrimAnticheat/Grim/issues/1275#issuecomment-1872444018
-            player.packetStateData.cancelDuplicatePacket = true;
+            // 1.9+ isn't impacted by this packet as much.
+            if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_9)) {
+                player.packetStateData.cancelDuplicatePacket = true;
+            } else {
+                // Override location to force it to use the last real position of the player. Prevents position-related bypasses like nofall.
+                flying.setLocation(new Location(player.filterMojangStupidityOnMojangStupidity.getX(), player.filterMojangStupidityOnMojangStupidity.getY(), player.filterMojangStupidityOnMojangStupidity.getZ(), location.getYaw(), location.getPitch()));
+            }
 
             player.packetStateData.lastPacketWasOnePointSeventeenDuplicate = true;
 

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPingListener.java
@@ -21,7 +21,6 @@ public class PacketPingListener extends PacketListenerAbstract {
         super(PacketListenerPriority.LOWEST);
     }
 
-
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.WINDOW_CONFIRMATION) {

--- a/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
+++ b/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.events.packets.patch;
 
 import ac.grim.grimac.GrimAPI;
-import ac.grim.grimac.checks.impl.badpackets.BadPacketsU;
+import ac.grim.grimac.checks.impl.badpackets.BadPacketsW;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerAbstract;
@@ -33,7 +33,7 @@ public class EnforceUseItemStupidity extends PacketListenerAbstract {
             player.packetStateData.lastTeleportWasPotentiallyOnePointSeventeenDuplicate = false;
             if (!player.packetStateData.detectedStupidity && !wasPotentiallyOnePointSeventeenDuplicate) {
                 // The player MUST send a stupidity packet before use item
-                player.checkManager.getPacketCheck(BadPacketsU.class).flagAndAlert("type=skipped_stupid");
+                player.checkManager.getPacketCheck(BadPacketsW.class).flagAndAlert("type=skipped_stupid");
                 return;
             }
         }

--- a/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
+++ b/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
@@ -1,0 +1,85 @@
+package ac.grim.grimac.events.packets.patch;
+
+import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.checks.impl.badpackets.BadPacketsU;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerAbstract;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.world.BlockFace;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerBlockPlacement;
+
+// This runs before anything else.
+public class EnforceUseItemStupidity extends PacketListenerAbstract {
+
+    public EnforceUseItemStupidity() {
+        super(PacketListenerPriority.LOWEST);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
+        if (player == null) return;
+
+        // Stupidity packet only exists on 1.17+
+        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_17)) return;
+
+        final boolean wasPotentiallyOnePointSeventeenDuplicate = player.packetStateData.lastTeleportWasPotentiallyOnePointSeventeenDuplicate;
+        if (isUseItem(event)) {
+            player.packetStateData.lastTeleportWasPotentiallyOnePointSeventeenDuplicate = false;
+            if (!player.packetStateData.detectedStupidity && !wasPotentiallyOnePointSeventeenDuplicate) {
+                // The player MUST send a stupidity packet before use item
+                player.checkManager.getPacketCheck(BadPacketsU.class).flagAndAlert("type=skipped_stupid");
+                return;
+            }
+        }
+
+        player.packetStateData.lastTeleportWasPotentiallyOnePointSeventeenDuplicate = false;
+
+        // If we received a believed stupidity packet, the next packet MUST be USE_ITEM.
+        // If not, we were wrong or the client is attempting to fake stupidity.
+        if (player.packetStateData.detectedStupidity || wasPotentiallyOnePointSeventeenDuplicate) {
+            if (isUseItem(event)) {
+                // Valid stupidity packet.
+                player.packetStateData.detectedStupidity = false;
+
+                // Possibly delay this USE_ITEM packet.
+                player.checkManager.getPacketCheck(UseItemDelayer.class).addDelayed(event);
+                player.packetStateData.stupidityRotChanged = false;
+
+//                player.packetStateData.lastStupidity = null;
+                return;
+            }
+
+            // Reset
+            player.packetStateData.detectedStupidity = false;
+            player.packetStateData.stupidityRotChanged = false;
+
+            // There's not really much point doing this below here
+            // I've left this in as originally it was intended to reduce falses from wrongly processing stupidity
+            // It can also be bypassed in 5 minutes by sending a valid USE_ITEM packet
+            // But there are issues with viaversion on 1.9 -> 1.8
+            // You would also need to bump all priorities on the packet listeners to ensure this runs first
+
+            // Let's ignore teleports
+//            if (player.packetStateData.lastStupidity == null || wasPotentiallyOnePointSeventeenDuplicate) return; // Probably a teleport
+
+            // We were wrong about it being stupidity, or the client is attempting to fake stupidity, reprocess this packet as non-stupidity
+//            player.packetStateData.ignoreDuplicatePacket = true;
+//
+//            PacketEvents.getAPI().getPlayerManager().receivePacket(player.bukkitPlayer, new WrapperPlayClientPlayerFlying(true, true, player.packetStateData.packetPlayerOnGround, player.packetStateData.lastStupidity));
+        }
+    }
+
+    private boolean isUseItem(PacketReceiveEvent event) {
+        // This is USE_ITEM but translated by via
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_9) && event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+            return new WrapperPlayClientPlayerBlockPlacement(event).getFace() == BlockFace.OTHER;
+        }
+        return event.getPacketType() == PacketType.Play.Client.USE_ITEM;
+    }
+}

--- a/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
+++ b/src/main/java/ac/grim/grimac/events/packets/patch/EnforceUseItemStupidity.java
@@ -48,7 +48,10 @@ public class EnforceUseItemStupidity extends PacketListenerAbstract {
                 player.packetStateData.detectedStupidity = false;
 
                 // Possibly delay this USE_ITEM packet.
-                player.checkManager.getPacketCheck(UseItemDelayer.class).addDelayed(event);
+                if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_9)) {
+                    player.checkManager.getPacketCheck(UseItemDelayer.class).addDelayed(event);
+                }
+
                 player.packetStateData.stupidityRotChanged = false;
 
 //                player.packetStateData.lastStupidity = null;

--- a/src/main/java/ac/grim/grimac/events/packets/patch/UseItemDelayer.java
+++ b/src/main/java/ac/grim/grimac/events/packets/patch/UseItemDelayer.java
@@ -1,0 +1,96 @@
+package ac.grim.grimac.events.packets.patch;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.lists.EvictingQueue;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.protocol.player.InteractionHand;
+import com.github.retrooper.packetevents.protocol.world.BlockFace;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerBlockPlacement;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUseItem;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class UseItemDelayer extends Check implements PacketCheck {
+
+    // EvictingQueue to prevent spamming this
+    private final EvictingQueue<DelayedUseItem> delayedUseItemPackets = new EvictingQueue<>(20);
+
+    public UseItemDelayer(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        // If we received a normal flying packet
+        // Use item packets are delayed until we have a valid flying packet
+        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType()) && !player.packetStateData.lastPacketWasOnePointSeventeenDuplicate) {
+            for (DelayedUseItem delayedUseItemPacket : delayedUseItemPackets) {
+                PacketWrapper<?> packet;
+                if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_9)) {
+                    packet = new WrapperPlayClientPlayerBlockPlacement(delayedUseItemPacket.interactionHand, delayedUseItemPacket.blockPosition, delayedUseItemPacket.face, delayedUseItemPacket.cursorPosition, delayedUseItemPacket.itemStack, delayedUseItemPacket.insideBlock, delayedUseItemPacket.sequence);
+                } else {
+                    final WrapperPlayClientUseItem useItem = new WrapperPlayClientUseItem(delayedUseItemPacket.interactionHand);
+                    useItem.setSequence(delayedUseItemPacket.getSequence());
+                    packet = useItem;
+                }
+
+                // Receive after flying has been received by the server
+                event.getPostTasks().add(() -> ChannelHelper.runInEventLoop(player.user.getChannel(), () -> {
+                    PacketEvents.getAPI().getPlayerManager().receivePacketSilently(player.bukkitPlayer, packet);
+                }));
+            }
+            delayedUseItemPackets.clear();
+        }
+    }
+
+    public void addDelayed(PacketReceiveEvent event) {
+        // Only delay if rotation changed.
+        if (!player.packetStateData.stupidityRotChanged) {
+            return;
+        }
+
+        InteractionHand hand;
+        DelayedUseItem delayed;
+
+        // This is USE_ITEM but translated by via
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_9)) {
+            final WrapperPlayClientPlayerBlockPlacement placement = new WrapperPlayClientPlayerBlockPlacement(event);
+            hand = placement.getHand();
+            delayed = new DelayedUseItem(placement.getHand(), placement.getBlockPosition(), placement.getFace(), placement.getCursorPosition(), placement.getItemStack().orElse(null), placement.getInsideBlock().orElse(null), placement.getSequence());
+        } else {
+            final WrapperPlayClientUseItem useItem = new WrapperPlayClientUseItem(event);
+            hand = useItem.getHand();
+            delayed = new DelayedUseItem(useItem.getHand(), null, null, null, null, null, useItem.getSequence());
+        }
+
+        // Only delay if it comes from a bucket, as this is the purpose of this packet
+        // Otherwise just pass use item
+        ItemStack stack = hand == InteractionHand.MAIN_HAND ? player.getInventory().getHeldItem() : player.getInventory().getOffHand();
+        if (stack.getType().getName().getKey().contains("BUCKET")) return;
+
+        delayedUseItemPackets.add(delayed);
+        event.setCancelled(true);
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class DelayedUseItem {
+        private InteractionHand interactionHand;
+        private Vector3i blockPosition;
+        private BlockFace face;
+        private Vector3f cursorPosition;
+        private ItemStack itemStack;
+        private Boolean insideBlock;
+        private int sequence;
+    }
+}

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -29,6 +29,7 @@ import ac.grim.grimac.events.packets.PacketChangeGameState;
 import ac.grim.grimac.events.packets.PacketEntityReplication;
 import ac.grim.grimac.events.packets.PacketPlayerAbilities;
 import ac.grim.grimac.events.packets.PacketWorldBorder;
+import ac.grim.grimac.events.packets.patch.UseItemDelayer;
 import ac.grim.grimac.manager.init.start.SuperDebug;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.predictionengine.GhostBlockDetector;
@@ -85,10 +86,12 @@ public class CheckManager {
                 .put(BadPacketsR.class, new BadPacketsR(player))
                 .put(BadPacketsS.class, new BadPacketsS(player))
                 .put(BadPacketsT.class, new BadPacketsT(player))
+                .put(BadPacketsU.class, new BadPacketsU(player))
                 .put(InvalidPlace.class, new InvalidPlace(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(TransactionOrder.class, new TransactionOrder(player))
                 .put(NoSlowB.class, new NoSlowB(player))
+                .put(UseItemDelayer.class, new UseItemDelayer(player))
                 .put(SetbackBlocker.class, new SetbackBlocker(player)) // Must be last class otherwise we can't check while blocking packets
                 .build();
         positionCheck = new ImmutableClassToInstanceMap.Builder<PositionCheck>()

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -86,7 +86,7 @@ public class CheckManager {
                 .put(BadPacketsR.class, new BadPacketsR(player))
                 .put(BadPacketsS.class, new BadPacketsS(player))
                 .put(BadPacketsT.class, new BadPacketsT(player))
-                .put(BadPacketsU.class, new BadPacketsU(player))
+                .put(BadPacketsW.class, new BadPacketsW(player))
                 .put(InvalidPlace.class, new InvalidPlace(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(TransactionOrder.class, new TransactionOrder(player))

--- a/src/main/java/ac/grim/grimac/manager/init/start/PacketManager.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/PacketManager.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.manager.init.start;
 
 import ac.grim.grimac.events.packets.*;
+import ac.grim.grimac.events.packets.patch.EnforceUseItemStupidity;
 import ac.grim.grimac.events.packets.worldreader.BasePacketWorldReader;
 import ac.grim.grimac.events.packets.worldreader.PacketWorldReaderEight;
 import ac.grim.grimac.events.packets.worldreader.PacketWorldReaderEighteen;
@@ -29,6 +30,7 @@ public class PacketManager implements Initable {
         PacketEvents.getAPI().getEventManager().registerListener(new PacketPlayerRespawn());
         PacketEvents.getAPI().getEventManager().registerListener(new CheckManagerListener());
         PacketEvents.getAPI().getEventManager().registerListener(new PacketPlayerSteer());
+        PacketEvents.getAPI().getEventManager().registerListener(new EnforceUseItemStupidity());
 
         if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_18)) {
             PacketEvents.getAPI().getEventManager().registerListener(new PacketWorldReaderEighteen());

--- a/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.data;
 
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
+import com.github.retrooper.packetevents.protocol.world.Location;
 import com.github.retrooper.packetevents.util.Vector3d;
 
 // This is to keep all the packet data out of the main player class
@@ -8,6 +9,8 @@ import com.github.retrooper.packetevents.util.Vector3d;
 public class PacketStateData {
     public boolean packetPlayerOnGround = false;
     public boolean lastPacketWasTeleport = false;
+    public boolean cancelDuplicatePacket;
+    public boolean stupidityRotChanged, detectedStupidity, lastTeleportWasPotentiallyOnePointSeventeenDuplicate;
     public boolean lastPacketWasOnePointSeventeenDuplicate = false;
     public boolean lastTransactionPacketWasValid = false;
     public int lastSlotSelected;


### PR DESCRIPTION
This cancels stupidity packets from reaching the server whilst retaining the bucket desync fix.

Changes:

- Clients are only able to send stupidity packets when they have an item in their hand
- The packet is cancelled so it is not sent to the server
- Clients must send a stupidity packet before USE_ITEM
- On 1.8 servers: If the rotation in the packet changed, the resulting USE_ITEM packet is delayed until the next valid movement packet

Fixes #1248 
Fixes #1275 
Fixes #1310 
Fixes #1315

Also fixes fast use bypasses.

Should be tested for a couple more days first.