### PR TITLE
Improve BadPacketsL

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
@@ -26,8 +26,8 @@ public class BadPacketsL extends Check implements PacketCheck {
             if (packet.getAction() == DiggingAction.RELEASE_USE_ITEM) {
                 // 1.8 and above clients only send this packet in one place, with BlockPos.ZERO and Direction.DOWN
                 // 1.7 and below clients send this packet in the same place, except use Direction.SOUTH
-                if ((packet.getBlockFace() != BlockFace.DOWN && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8))
-                        || (packet.getBlockFace() != BlockFace.SOUTH && player.getClientVersion().isOlderThan(ClientVersion.V_1_8))
+                final BlockFace expectedFace = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8) ? BlockFace.DOWN : BlockFace.SOUTH;
+                if (packet.getBlockFace() != expectedFace
                         || packet.getBlockPosition().getX() != 0
                         || packet.getBlockPosition().getY() != 0
                         || packet.getBlockPosition().getZ() != 0) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
@@ -11,6 +11,8 @@ import com.github.retrooper.packetevents.protocol.player.DiggingAction;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 
+import java.util.Locale;
+
 //checks for impossible dig packets
 @CheckData(name = "BadPacketsL")
 public class BadPacketsL extends Check implements PacketCheck {
@@ -22,17 +24,27 @@ public class BadPacketsL extends Check implements PacketCheck {
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
-            WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
-            if (packet.getAction() == DiggingAction.RELEASE_USE_ITEM) {
-                // 1.8 and above clients only send this packet in one place, with BlockPos.ZERO and Direction.DOWN
-                // 1.7 and below clients send this packet in the same place, except use Direction.SOUTH
-                final BlockFace expectedFace = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8) ? BlockFace.DOWN : BlockFace.SOUTH;
-                if (packet.getBlockFace() != expectedFace
-                        || packet.getBlockPosition().getX() != 0
-                        || packet.getBlockPosition().getY() != 0
-                        || packet.getBlockPosition().getZ() != 0) {
-                    flagAndAlert();
-                }
+            final WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
+
+            final boolean isUsedForDigging = packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING || packet.getAction() == DiggingAction.CANCELLED_DIGGING;
+            if (isUsedForDigging) {
+                return;
+            }
+
+            // on 1.8 and above clients always send digging packets that aren't used for digging at 0, 0, 0, facing DOWN
+            // on 1.7 and below clients do the same, except use SOUTH for RELEASE_USE_ITEM
+            final BlockFace expectedFace = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10) && packet.getAction() == DiggingAction.RELEASE_USE_ITEM
+                    ? BlockFace.SOUTH : BlockFace.DOWN;
+
+            if (packet.getBlockFace() != expectedFace
+                    || packet.getBlockPosition().getX() != 0
+                    || packet.getBlockPosition().getY() != 0
+                    || packet.getBlockPosition().getZ() != 0
+            ) {
+                flagAndAlert("xyzF="
+                        + packet.getBlockPosition().getX() + ", " + packet.getBlockPosition().getY() + ", " + packet.getBlockPosition().getZ() + ", " + packet.getBlockFace()
+                        + ", action=" + packet.getAction().toString().toLowerCase(Locale.ROOT).replace("_", " ") + " v" + player.getVersionName()
+                );
             }
         }
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
@@ -31,8 +31,8 @@ public class BadPacketsL extends Check implements PacketCheck {
                 return;
             }
 
-            // on 1.8 and above clients always send digging packets that aren't used for digging at 0, 0, 0, facing DOWN
-            // on 1.7 and below clients do the same, except use SOUTH for RELEASE_USE_ITEM
+            // 1.8 and above clients always send digging packets that aren't used for digging at 0, 0, 0, facing DOWN
+            // 1.7 and below clients do the same, except use SOUTH for RELEASE_USE_ITEM
             final BlockFace expectedFace = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10) && packet.getAction() == DiggingAction.RELEASE_USE_ITEM
                     ? BlockFace.SOUTH : BlockFace.DOWN;
 

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
@@ -23,10 +23,11 @@ public class BadPacketsL extends Check implements PacketCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
             WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
-            // 1.7 clients flag this for some reason
-            if (packet.getAction() == DiggingAction.RELEASE_USE_ITEM && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
-                // The client only sends this packet in one place, with BlockPos.ZERO and Direction.DOWN
-                if (packet.getBlockFace() != BlockFace.DOWN
+            if (packet.getAction() == DiggingAction.RELEASE_USE_ITEM) {
+                // 1.8 and above clients only send this packet in one place, with BlockPos.ZERO and Direction.DOWN
+                // 1.7 and below clients send this packet in the same place, except use Direction.SOUTH
+                if ((packet.getBlockFace() != BlockFace.DOWN && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8))
+                        || (packet.getBlockFace() != BlockFace.SOUTH && player.getClientVersion().isOlderThan(ClientVersion.V_1_8))
                         || packet.getBlockPosition().getX() != 0
                         || packet.getBlockPosition().getY() != 0
                         || packet.getBlockPosition().getZ() != 0) {


### PR DESCRIPTION
Makes BadPacketsL work on 1.7 players, show verbose, and flag invalid `DROP_ITEM_STACK`, `DROP_ITEM`, and `SWAP_ITEM_WITH_OFFHAND`
| tested on       | Paper 1.8.8               | Paper 1.12.2           | Paper 1.16.5           |
|---------------|----------------------|---------------------|---------------------|
| Vanilla 1.7.10  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| Forge 1.7.10   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| Forge 1.12.2   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| Forge 1.8.9     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| Vanilla 1.16.5  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| Vanilla 1.17.1  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |