### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
@@ -1182,7 +1182,7 @@ public enum CollisionData {
     DEFAULT(new SimpleCollisionBox(0, 0, 0, 1, 1, 1, true), StateTypes.STONE);
 
     // This should be an array... but a hashmap will do for now...
-    private static final Map<StateType, CollisionData> rawLookupMap = new HashMap<>();
+    private static final Map<StateType, CollisionData> rawLookupMap = new IdentityHashMap<>();
 
     static {
         for (CollisionData data : values()) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -263,21 +263,24 @@ public class Collisions {
                             int x = currX | chunkXGlobalPos;
                             int z = currZ | chunkZGlobalPos;
 
-                            WrappedBlockState data = section.get(CompensatedWorld.blockVersion, x & 0xF, y & 0xF, z & 0xF);
+                            WrappedBlockState data = section.get(CompensatedWorld.blockVersion, x & 0xF, y & 0xF, z & 0xF, false);
 
                             // Works on both legacy and modern!  Faster than checking for material types, most common case
                             if (data.getGlobalId() == 0) continue;
+
                             // Thanks SpottedLeaf for this optimization, I took edgeCount from Tuinity
                             int edgeCount = ((x == minBlockX || x == maxBlockX) ? 1 : 0) +
                                     ((y == minBlockY || y == maxBlockY) ? 1 : 0) +
                                     ((z == minBlockZ || z == maxBlockZ) ? 1 : 0);
 
-                            if (edgeCount != 3 && (edgeCount != 1 || Materials.isShapeExceedsCube(data.getType()))
-                                    && (edgeCount != 2 || data.getType() == StateTypes.PISTON_HEAD)) {
+                            final StateType type = data.getType();
+                            if (edgeCount != 3 && (edgeCount != 1 || Materials.isShapeExceedsCube(type))
+                                    && (edgeCount != 2 || type == StateTypes.PISTON_HEAD)) {
+                                final CollisionBox collisionBox = CollisionData.getData(type).getMovementCollisionBox(player, player.getClientVersion(), data, x, y, z);
                                 // Don't add to a list if we only care if the player intersects with the block
                                 if (!onlyCheckCollide) {
-                                    CollisionData.getData(data.getType()).getMovementCollisionBox(player, player.getClientVersion(), data, x, y, z).downCast(listOfBlocks);
-                                } else if (CollisionData.getData(data.getType()).getMovementCollisionBox(player, player.getClientVersion(), data, x, y, z).isCollided(wantedBB)) {
+                                    collisionBox.downCast(listOfBlocks);
+                                } else if (collisionBox.isCollided(wantedBB)) {
                                     return true;
                                 }
                             }


### PR DESCRIPTION
- Using IdentityHashMap avoids calls to StateType#hashCode, which is not needed as we are only using the constant value.
- WrappedBlockState does not need to be cloned when using BaseChunk#get in Collisions#getCollisionBoxes, this should give quite a good performance improvement.

_**In Actions -> Caches you will need to delete `dependencies-<id>` to make it use the latest PacketEvents.**_