### PR TITLE
Improve BadPacketsQ

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsQ.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsQ.java
@@ -20,14 +20,10 @@ public class BadPacketsQ extends Check implements PacketCheck {
         if (event.getPacketType() == Client.ENTITY_ACTION) {
             WrapperPlayClientEntityAction wrapper = new WrapperPlayClientEntityAction(event);
 
-            if (wrapper.getAction() == Action.START_JUMPING_WITH_HORSE) {
-                if (wrapper.getJumpBoost() < 0 || wrapper.getJumpBoost() > 100) {
-                    if (flag()) {
-                        alert("b=" + wrapper.getJumpBoost()); // Ban
-                        if (shouldModifyPackets()) {
-                            event.setCancelled(true);
-                        }
-                    }
+            if (wrapper.getJumpBoost() < 0 || wrapper.getJumpBoost() > 100 || wrapper.getEntityId() != player.entityID || (wrapper.getAction() != Action.START_JUMPING_WITH_HORSE && wrapper.getJumpBoost() != 0)) {
+                if (flagAndAlert("boost=" + wrapper.getJumpBoost() + ", action=" + wrapper.getAction() + ", entity=" + wrapper.getEntityId()) && shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
                 }
             }
         }


### PR DESCRIPTION
Checks if the `entityId` is the player's, and only allows `jumpBoost` to be non-zero if `action` is `START_JUMPING_WITH_HORSE`, not tested much, but shouldn't false https://wiki.vg/Protocol#Player_Command