### PR TITLE
BadPacketsM: fix armor stand false flag

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -4,7 +4,9 @@ import ac.grim.grimac.checks.Check;
 import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
@@ -23,7 +25,18 @@ public class BadPacketsM extends Check implements PacketCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
             if (exempt) return;
-            switch (new WrapperPlayClientInteractEntity(event).getAction()) {
+
+            WrapperPlayClientInteractEntity wrapper = new WrapperPlayClientInteractEntity(event);
+
+            PacketEntity entity = player.compensatedEntities.entityMap.get(wrapper.getEntityId());
+
+            // For armor stands, vanilla clients send:
+            //  - when renaming the armor stand or in spectator mode: INTERACT_AT + INTERACT
+            //  - in all other cases: only INTERACT
+            // Just exempt armor stands to be safe
+            if(entity != null && entity.type == EntityTypes.ARMOR_STAND) return;
+
+            switch (wrapper.getAction()) {
                 // INTERACT_AT then INTERACT
                 case INTERACT:
                     if (!sentInteractAt) {


### PR DESCRIPTION
Noticed that BadPacketsM falses when interacting with armor stands.

For armor stands, vanilla clients send:

- when renaming the armor stand or in spectator mode: INTERACT_AT + INTERACT
- in all other cases: only INTERACT

Just exempt armor stands to be safe.