### PR TITLE
fix noslow false with shields on pre-1.9 clients

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
@@ -72,7 +72,7 @@ public class PacketPlayerDigging extends PacketListenerAbstract {
                 player.packetStateData.slowedByUsingItem = false;
             }
 
-            if (material == ItemTypes.SHIELD) {
+            if (material == ItemTypes.SHIELD && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) {
                 player.packetStateData.slowedByUsingItem = true;
                 player.packetStateData.eatingHand = hand;
 


### PR DESCRIPTION
shields don't exist on 1.8/1.7