### PR TITLE
Implement BadPacketsW when player eating food or potions during combat

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
@@ -1,0 +1,33 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
+import org.bukkit.inventory.ItemStack;
+
+@CheckData(name = "BadPacketsW", experimental = true)
+public class BadPacketsW extends Check implements PacketCheck {
+    public BadPacketsW(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) {
+            WrapperPlayClientInteractEntity interactEntity = new WrapperPlayClientInteractEntity(event);
+            if (interactEntity.getAction() != WrapperPlayClientInteractEntity.InteractAction.ATTACK) return;
+            ItemStack itemInUse = player.bukkitPlayer.getItemInUse();
+            if (itemInUse == null) return;
+            // When eating food or potions during combat
+            // main hand or off hand
+            if (itemInUse.getType().isEdible()) {
+                flagAndAlert("Eating="+itemInUse.getType().name());
+            }
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -88,6 +88,7 @@ public class CheckManager {
                 .put(BadPacketsS.class, new BadPacketsS(player))
                 .put(BadPacketsT.class, new BadPacketsT(player))
                 .put(BadPacketsU.class, new BadPacketsU(player))
+                .put(BadPacketsW.class, new BadPacketsW(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(TransactionOrder.class, new TransactionOrder(player))
                 .put(NoSlowB.class, new NoSlowB(player))


### PR DESCRIPTION
It has been tested in version 1.20.2 that players should not eat food (golden apple ) or potions while attacking other players.
#1360 