### PR TITLE
Support for 1.20.5 and some attributes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
     implementation("org.jetbrains:annotations:24.1.0")
     compileOnly("org.geysermc.floodgate:api:2.0-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.20.5-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT")
     compileOnly("com.viaversion:viaversion-api:4.9.4-SNAPSHOT")
     //
     compileOnly("io.netty:netty-all:4.1.85.Final")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.retrooper.packetevents:spigot:2.2.1")
+    implementation("com.github.retrooper.packetevents:spigot:2.3.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("club.minnced:discord-webhooks:0.8.0") // Newer versions include kotlin-stdlib, which leads to incompatibility with plugins that use Kotlin
     implementation("it.unimi.dsi:fastutil:8.5.13")
@@ -41,7 +41,7 @@ dependencies {
 
     implementation("org.jetbrains:annotations:24.1.0")
     compileOnly("org.geysermc.floodgate:api:2.0-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.5-R0.1-SNAPSHOT")
     compileOnly("com.viaversion:viaversion-api:4.9.4-SNAPSHOT")
     //
     compileOnly("io.netty:netty-all:4.1.85.Final")

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -134,7 +134,7 @@ public class Reach extends Check implements PacketCheck {
             if (reachEntity.type == EntityTypes.END_CRYSTAL) {
                 targetBox = new SimpleCollisionBox(reachEntity.desyncClientPos.subtract(1, 0, 1), reachEntity.desyncClientPos.add(1, 2, 1));
             }
-            return ReachUtils.getMinReachToBox(player, targetBox) > 3;
+            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getEntityInteractRangeAttribute();
         }
     }
 
@@ -198,10 +198,12 @@ public class Reach extends Check implements PacketCheck {
             }
         }
 
+        // +3 would be 3 + 3 = 6, which is the pre-1.20.5 behaviour, preventing "Missed Hitbox"
+        final double distance = player.compensatedEntities.getSelf().getEntityInteractRangeAttribute() + 3;
         for (Vector lookVec : possibleLookDirs) {
             for (double eye : player.getPossibleEyeHeights()) {
                 Vector eyePos = new Vector(from.getX(), from.getY() + eye, from.getZ());
-                Vector endReachPos = eyePos.clone().add(new Vector(lookVec.getX() * 6, lookVec.getY() * 6, lookVec.getZ() * 6));
+                Vector endReachPos = eyePos.clone().add(new Vector(lookVec.getX() * distance, lookVec.getY() * distance, lookVec.getZ() * distance));
 
                 Vector intercept = ReachUtils.calculateIntercept(targetBox, eyePos, endReachPos).getFirst();
 
@@ -221,7 +223,7 @@ public class Reach extends Check implements PacketCheck {
             if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return "Missed hitbox";
-            } else if (minDistance > 3) {
+            } else if (minDistance > player.compensatedEntities.getSelf().getEntityInteractRangeAttribute()) {
                 cancelBuffer = 1;
                 return String.format("%.5f", minDistance) + " blocks";
             } else {

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -21,7 +21,6 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
-import ac.grim.grimac.utils.math.VectorUtils;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
@@ -134,7 +133,7 @@ public class Reach extends Check implements PacketCheck {
             if (reachEntity.type == EntityTypes.END_CRYSTAL) {
                 targetBox = new SimpleCollisionBox(reachEntity.desyncClientPos.subtract(1, 0, 1), reachEntity.desyncClientPos.add(1, 2, 1));
             }
-            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getEntityInteractRangeAttribute();
+            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getEntityInteractRange();
         }
     }
 
@@ -199,7 +198,7 @@ public class Reach extends Check implements PacketCheck {
         }
 
         // +3 would be 3 + 3 = 6, which is the pre-1.20.5 behaviour, preventing "Missed Hitbox"
-        final double distance = player.compensatedEntities.getSelf().getEntityInteractRangeAttribute() + 3;
+        final double distance = player.compensatedEntities.getSelf().getEntityInteractRange() + 3;
         for (Vector lookVec : possibleLookDirs) {
             for (double eye : player.getPossibleEyeHeights()) {
                 Vector eyePos = new Vector(from.getX(), from.getY() + eye, from.getZ());
@@ -223,7 +222,7 @@ public class Reach extends Check implements PacketCheck {
             if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return "Missed hitbox";
-            } else if (minDistance > player.compensatedEntities.getSelf().getEntityInteractRangeAttribute()) {
+            } else if (minDistance > player.compensatedEntities.getSelf().getEntityInteractRange()) {
                 cancelBuffer = 1;
                 return String.format("%.5f", minDistance) + " blocks";
             } else {

--- a/src/main/java/ac/grim/grimac/checks/impl/groundspoof/NoFallA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/groundspoof/NoFallA.java
@@ -69,7 +69,7 @@ public class NoFallA extends Check implements PacketCheck {
 
     public boolean isNearGround(boolean onGround) {
         if (onGround) {
-            SimpleCollisionBox feetBB = GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y, player.z, 0.6f, 0.001f);
+            SimpleCollisionBox feetBB = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y, player.z, 0.6f, 0.001f);
             feetBB.expand(player.getMovementThreshold()); // Movement threshold can be in any direction
 
             return checkForBoxes(feetBB);

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
@@ -33,7 +33,7 @@ public class FarPlace extends BlockPlaceCheck {
 
         // getPickRange() determines this?
         // TODO how does the new attribute work with creative mode?
-        double maxReach = player.gamemode == GameMode.CREATIVE ? 6.0 : player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
+        double maxReach = player.gamemode == GameMode.CREATIVE ? 6.0 : player.compensatedEntities.getSelf().getBlockInteractRange();
         double threshold = player.getMovementThreshold();
         maxReach += Math.hypot(threshold, threshold);
 

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
@@ -32,7 +32,8 @@ public class FarPlace extends BlockPlaceCheck {
         }
 
         // getPickRange() determines this?
-        double maxReach = player.gamemode == GameMode.CREATIVE ? 6.0 : 4.5D;
+        // TODO how does the new attribute work with creative mode?
+        double maxReach = player.gamemode == GameMode.CREATIVE ? 6.0 : player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
         double threshold = player.getMovementThreshold();
         maxReach += Math.hypot(threshold, threshold);
 

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.math.VectorUtils;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 import com.github.retrooper.packetevents.util.Vector3i;
@@ -32,11 +33,12 @@ public class FarPlace extends BlockPlaceCheck {
         }
 
         // getPickRange() determines this?
-        // TODO how does the new attribute work with creative mode?
-        double maxReach = player.gamemode == GameMode.CREATIVE ? 6.0 : player.compensatedEntities.getSelf().getBlockInteractRange();
+        // With 1.20.5+ the new attribute determines creative mode reach using a modifier
+        double maxReach = player.gamemode == GameMode.CREATIVE && !player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5)
+                ? 6.0
+                : player.compensatedEntities.getSelf().getBlockInteractRange();
         double threshold = player.getMovementThreshold();
         maxReach += Math.hypot(threshold, threshold);
-
 
         if (min > maxReach * maxReach) { // fail
             if (flagAndAlert() && shouldModifyPackets() && shouldCancel()) {

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -94,13 +94,14 @@ public class RotationPlace extends BlockPlaceCheck {
             possibleLookDirs = Collections.singletonList(new Vector3f(player.xRot, player.yRot, 0));
         }
 
+        final double distance = player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
         for (double d : player.getPossibleEyeHeights()) {
             for (Vector3f lookDir : possibleLookDirs) {
                 // x, y, z are correct for the block placement even after post tick because of code elsewhere
                 Vector3d starting = new Vector3d(player.x, player.y + d, player.z);
                 // xRot and yRot are a tick behind
                 Ray trace = new Ray(player, starting.getX(), starting.getY(), starting.getZ(), lookDir.getX(), lookDir.getY());
-                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(6));
+                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(distance));
 
                 if (intercept.getFirst() != null) return true;
             }

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -94,7 +94,7 @@ public class RotationPlace extends BlockPlaceCheck {
             possibleLookDirs = Collections.singletonList(new Vector3f(player.xRot, player.yRot, 0));
         }
 
-        final double distance = player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
+        final double distance = player.compensatedEntities.getSelf().getBlockInteractRange();
         for (double d : player.getPossibleEyeHeights()) {
             for (Vector3f lookDir : possibleLookDirs) {
                 // x, y, z are correct for the block placement even after post tick because of code elsewhere

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -753,7 +753,8 @@ public class CheckManagerListener extends PacketListenerAbstract {
         Vector3d startingPos = new Vector3d(player.x, player.y + player.getEyeHeight(), player.z);
         Vector startingVec = new Vector(startingPos.getX(), startingPos.getY(), startingPos.getZ());
         Ray trace = new Ray(player, startingPos.getX(), startingPos.getY(), startingPos.getZ(), player.xRot, player.yRot);
-        Vector endVec = trace.getPointAtDistance(5);
+        final double distance = player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
+        Vector endVec = trace.getPointAtDistance(distance);
         Vector3d endPos = new Vector3d(endVec.getX(), endVec.getY(), endVec.getZ());
 
         return traverseBlocks(player, startingPos, endPos, (block, vector3i) -> {
@@ -766,7 +767,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
             BlockFace bestFace = null;
 
             for (SimpleCollisionBox box : boxes) {
-                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(6));
+                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(distance));
                 if (intercept.getFirst() == null) continue; // No intercept
 
                 Vector hitLoc = intercept.getFirst();
@@ -787,7 +788,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
                 double waterHeight = player.compensatedWorld.getFluidLevelAt(vector3i.getX(), vector3i.getY(), vector3i.getZ());
                 SimpleCollisionBox box = new SimpleCollisionBox(vector3i.getX(), vector3i.getY(), vector3i.getZ(), vector3i.getX() + 1, vector3i.getY() + waterHeight, vector3i.getZ() + 1);
 
-                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(6));
+                Pair<Vector, BlockFace> intercept = ReachUtils.calculateIntercept(box, trace.getOrigin(), trace.getPointAtDistance(distance));
 
                 if (intercept.getFirst() != null) {
                     return new HitData(vector3i, intercept.getFirst(), intercept.getSecond(), block);

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -43,7 +43,6 @@ import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.client.*;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
 import org.bukkit.util.Vector;
@@ -753,7 +752,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
         Vector3d startingPos = new Vector3d(player.x, player.y + player.getEyeHeight(), player.z);
         Vector startingVec = new Vector(startingPos.getX(), startingPos.getY(), startingPos.getZ());
         Ray trace = new Ray(player, startingPos.getX(), startingPos.getY(), startingPos.getZ(), player.xRot, player.yRot);
-        final double distance = player.compensatedEntities.getSelf().getBlockInteractRangeAttribute();
+        final double distance = player.compensatedEntities.getSelf().getBlockInteractRange();
         Vector endVec = trace.getPointAtDistance(distance);
         Vector3d endPos = new Vector3d(endVec.getX(), endVec.getY(), endVec.getZ());
 

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -74,7 +74,6 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
             player.dimension = joinGame.getDimension();
 
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_17)) return;
-            System.out.println("dim name: " + joinGame.getDimension().getDimensionName());
             player.compensatedWorld.setDimension(joinGame.getDimension(), event.getUser());
         }
 

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -74,7 +74,8 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
             player.dimension = joinGame.getDimension();
 
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_17)) return;
-            player.compensatedWorld.setDimension(joinGame.getDimension().getDimensionName(), event.getUser());
+            System.out.println("dim name: " + joinGame.getDimension().getDimensionName());
+            player.compensatedWorld.setDimension(joinGame.getDimension(), event.getUser());
         }
 
         if (event.getPacketType() == PacketType.Play.Server.RESPAWN) {
@@ -139,7 +140,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 player.clientVelocity = new Vector();
                 player.gamemode = respawn.getGameMode();
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_17)) {
-                    player.compensatedWorld.setDimension(respawn.getDimension().getDimensionName(), event.getUser());
+                    player.compensatedWorld.setDimension(respawn.getDimension(), event.getUser());
                 }
             });
         }

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -212,7 +212,7 @@ public class GrimPlayer implements GrimUser {
         this.playerUUID = user.getUUID();
         onReload();
 
-        boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSize(x, y, z, 0.6f, 1.8f);
+        boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSizeRaw(x, y, z, 0.6f, 1.8f);
 
         compensatedFireworks = new CompensatedFireworks(this); // Must be before checkmanager
 
@@ -544,7 +544,8 @@ public class GrimPlayer implements GrimUser {
 
     public List<Double> getPossibleEyeHeights() { // We don't return sleeping eye height
         if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_14)) { // Elytra, sneaking (1.14), standing
-            return Arrays.asList(0.4, 1.27, 1.62);
+            final float scale = compensatedEntities.getSelf().scale;
+            return Arrays.asList(0.4 * scale, 1.27 * scale, 1.62 * scale);
         } else if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) { // Elytra, sneaking, standing
             return Arrays.asList(0.4, 1.54, 1.62);
         } else { // Only sneaking or standing

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -14,6 +14,8 @@ import ac.grim.grimac.predictionengine.UncertaintyHandler;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.*;
+import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.data.packetentity.PacketEntitySelf;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.enums.Pose;
 import ac.grim.grimac.utils.latency.*;
@@ -343,14 +345,16 @@ public class GrimPlayer implements GrimUser {
     }
 
     public float getMaxUpStep() {
-        if (compensatedEntities.getSelf().getRiding() == null) return 0.6f;
+        final PacketEntitySelf self = compensatedEntities.getSelf();
+        final PacketEntity riding = self.getRiding();
+        if (riding == null) return self.stepHeight;
 
-        if (EntityTypes.isTypeInstanceOf(compensatedEntities.getSelf().getRiding().type, EntityTypes.BOAT)) {
+        if (EntityTypes.isTypeInstanceOf(riding.type, EntityTypes.BOAT)) {
             return 0f;
         }
 
-        // Pigs, horses, striders, and other vehicles all have 1 stepping height
-        return 1.0f;
+        // Pigs, horses, striders, and other vehicles all have 1 stepping height by default
+        return riding.stepHeight;
     }
 
     public void sendTransaction() {

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -382,7 +382,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         player.uncertaintyHandler.thisTickSlimeBlockUncertainty = player.uncertaintyHandler.nextTickSlimeBlockUncertainty;
         player.uncertaintyHandler.nextTickSlimeBlockUncertainty = 0;
 
-        SimpleCollisionBox expandedBB = GetBoundingBox.getBoundingBoxFromPosAndSize(player.lastX, player.lastY, player.lastZ, 0.001f, 0.001f);
+        SimpleCollisionBox expandedBB = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.lastX, player.lastY, player.lastZ, 0.001f, 0.001f);
 
         // Don't expand if the player moved more than 50 blocks this tick (stop netty crash exploit)
         if (player.actualMovement.lengthSquared() < 2500)

--- a/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -24,12 +24,14 @@ public class PlayerBaseTick {
     }
 
     public static boolean canEnterPose(GrimPlayer player, Pose pose, double x, double y, double z) {
-        return Collisions.isEmpty(player, getBoundingBoxForPose(pose, x, y, z).expand(-1.0E-7D));
+        return Collisions.isEmpty(player, getBoundingBoxForPose(player, pose, x, y, z).expand(-1.0E-7D));
     }
 
-    protected static SimpleCollisionBox getBoundingBoxForPose(Pose pose, double x, double y, double z) {
-        float radius = pose.width / 2.0F;
-        return new SimpleCollisionBox(x - radius, y, z - radius, x + radius, y + pose.height, z + radius, false);
+    protected static SimpleCollisionBox getBoundingBoxForPose(GrimPlayer player, Pose pose, double x, double y, double z) {
+        final float width = pose.width * player.compensatedEntities.getSelf().scale;
+        final float height = pose.height * player.compensatedEntities.getSelf().scale;
+        float radius = width / 2.0F;
+        return new SimpleCollisionBox(x - radius, y, z - radius, x + radius, y + height, z + radius, false);
     }
 
     public void doBaseTick() {
@@ -188,7 +190,7 @@ public class PlayerBaseTick {
             }
 
             player.pose = pose;
-            player.boundingBox = getBoundingBoxForPose(player.pose, player.x, player.y, player.z);
+            player.boundingBox = getBoundingBoxForPose(player, player.pose, player.x, player.y, player.z);
         }
     }
 

--- a/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
@@ -405,6 +405,11 @@ public class PointThreeEstimator {
             // If less than minimum movement, then set to 0
             if (Math.abs(yVel) < minMovement) yVel = 0;
 
+            // Don't add the first vector to the movement.  We already counted it.
+            if (!first) {
+                maxYTraveled += yVel;
+            }
+
             // Support for custom gravity, this means we aren't making progress
             // 0.003 gravity
             // iterate -> 0 - 0.003 = -0.003 * 0.98 = -0.00294
@@ -413,10 +418,6 @@ public class PointThreeEstimator {
                 break;
             }
 
-            // Don't add the first vector to the movement.  We already counted it.
-            if (!first) {
-                maxYTraveled += yVel;
-            }
             first = false;
 
             // Simulate end of tick vector

--- a/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
@@ -405,6 +405,14 @@ public class PointThreeEstimator {
             // If less than minimum movement, then set to 0
             if (Math.abs(yVel) < minMovement) yVel = 0;
 
+            // Support for custom gravity, this means we aren't making progress
+            // 0.003 gravity
+            // iterate -> 0 - 0.003 = -0.003 * 0.98 = -0.00294
+            // 0.00294 < 0.003 -> 0
+            if (!first && yVel == 0) {
+                break;
+            }
+
             // Don't add the first vector to the movement.  We already counted it.
             if (!first) {
                 maxYTraveled += yVel;

--- a/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PointThreeEstimator.java
@@ -119,7 +119,7 @@ public class PointThreeEstimator {
     // Handle game events that occur between skipped ticks - thanks a lot mojang for removing the idle packet!
     public void handleChangeBlock(int x, int y, int z, WrappedBlockState state) {
         CollisionBox data = CollisionData.getData(state.getType()).getMovementCollisionBox(player, player.getClientVersion(), state, x, y, z);
-        SimpleCollisionBox normalBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y, player.z, 0.6f, 1.8f);
+        SimpleCollisionBox normalBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y, player.z, 0.6f, 1.8f);
 
         // Calculate head hitters.  Take a shortcut by checking if the player doesn't intersect with this block, but does
         // when the player vertically moves upwards by 0.03!  This is equivalent to the move method, but MUCH faster.
@@ -128,7 +128,7 @@ public class PointThreeEstimator {
             headHitter = true;
         }
 
-        SimpleCollisionBox pointThreeBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y - 0.03, player.z, 0.66f, 1.86f);
+        SimpleCollisionBox pointThreeBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y - 0.03, player.z, 0.66f, 1.86f);
         if ((Materials.isWater(player.getClientVersion(), state) || state.getType() == StateTypes.LAVA) &&
                 pointThreeBox.isIntersected(new SimpleCollisionBox(x, y, z))) {
 
@@ -208,7 +208,7 @@ public class PointThreeEstimator {
     }
 
     public void endOfTickTick() {
-        SimpleCollisionBox pointThreeBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y - 0.03, player.z, 0.66f, 1.86f);
+        SimpleCollisionBox pointThreeBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y - 0.03, player.z, 0.66f, 1.86f);
 
         // Determine the head hitter using the current Y position
         SimpleCollisionBox oldBB = player.boundingBox;
@@ -217,7 +217,7 @@ public class PointThreeEstimator {
         // Can we trust the pose height?
         for (float sizes : (player.skippedTickInActualMovement ? new float[]{0.6f, 1.5f, 1.8f} : new float[]{player.pose.height})) {
             // Try to limit collisions to be as small as possible, for maximum performance
-            player.boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y + (sizes - 0.01f), player.z, 0.6f, 0.01f);
+            player.boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y + (sizes - 0.01f), player.z, 0.6f, 0.01f);
             headHitter = headHitter || Collisions.collide(player, 0, 0.03, 0).getY() != 0.03;
         }
 

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -27,38 +27,38 @@ public class MovementTicker {
 
     public static void handleEntityCollisions(GrimPlayer player) {
         // 1.7 and 1.8 do not have player collision
-        if (player.getClientVersion().isNewerThan(ClientVersion.V_1_8)) {
-            int possibleCollidingEntities = 0;
+        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) return;
 
-            // Players in vehicles do not have collisions
-            if (!player.compensatedEntities.getSelf().inVehicle()) {
-                // Calculate the offset of the player to colliding other stuff
-                SimpleCollisionBox playerBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player.lastX, player.lastY, player.lastZ, 0.6f, 1.8f);
-                SimpleCollisionBox expandedPlayerBox = playerBox.copy().expandToAbsoluteCoordinates(player.x, player.y, player.z).expand(1);
+        int possibleCollidingEntities = 0;
 
-                for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-                    // Players can only push living entities
-                    // Players can also push boats or minecarts
-                    // The one exemption to a living entity is an armor stand
-                    if (!entity.isLivingEntity() && !EntityTypes.isTypeInstanceOf(entity.type, EntityTypes.BOAT) && !entity.isMinecart() || entity.type == EntityTypes.ARMOR_STAND)
-                        continue;
+        // Players in vehicles do not have collisions
+        if (!player.compensatedEntities.getSelf().inVehicle()) {
+            // Calculate the offset of the player to colliding other stuff
+            SimpleCollisionBox playerBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.lastX, player.lastY, player.lastZ, 0.6f, 1.8f);
+            SimpleCollisionBox expandedPlayerBox = playerBox.copy().expandToAbsoluteCoordinates(player.x, player.y, player.z).expand(1);
 
-                    SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
+            for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
+                // Players can only push living entities
+                // Players can also push boats or minecarts
+                // The one exemption to a living entity is an armor stand
+                if (!entity.isLivingEntity() && !EntityTypes.isTypeInstanceOf(entity.type, EntityTypes.BOAT) && !entity.isMinecart() || entity.type == EntityTypes.ARMOR_STAND)
+                    continue;
 
-                    if (expandedPlayerBox.isCollided(entityBox))
-                        possibleCollidingEntities++;
-                }
+                SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
+
+                if (expandedPlayerBox.isCollided(entityBox))
+                    possibleCollidingEntities++;
             }
-
-            if (player.isGliding && possibleCollidingEntities > 0) {
-                // Horizontal starting movement affects vertical movement with elytra, hack around this.
-                // This can likely be reduced but whatever, I don't see this as too much of a problem
-                player.uncertaintyHandler.yNegativeUncertainty -= 0.05;
-                player.uncertaintyHandler.yPositiveUncertainty += 0.05;
-            }
-
-            player.uncertaintyHandler.collidingEntities.add(possibleCollidingEntities);
         }
+
+        if (player.isGliding && possibleCollidingEntities > 0) {
+            // Horizontal starting movement affects vertical movement with elytra, hack around this.
+            // This can likely be reduced but whatever, I don't see this as too much of a problem
+            player.uncertaintyHandler.yNegativeUncertainty -= 0.05;
+            player.uncertaintyHandler.yPositiveUncertainty += 0.05;
+        }
+
+        player.uncertaintyHandler.collidingEntities.add(possibleCollidingEntities);
     }
 
     public void move(Vector inputVel, Vector collide) {
@@ -308,7 +308,7 @@ public class MovementTicker {
     }
 
     public void livingEntityTravel() {
-        double playerGravity = 0.08;
+        double playerGravity = player.compensatedEntities.getSelf().getGravityAttribute();
 
         boolean isFalling = player.actualMovement.getY() <= 0.0;
         if (isFalling && player.compensatedEntities.getSlowFallingAmplifier() != null) {

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -314,7 +314,7 @@ public class MovementTicker {
 
         boolean isFalling = player.actualMovement.getY() <= 0.0;
         if (isFalling && player.compensatedEntities.getSlowFallingAmplifier() != null) {
-            playerGravity = 0.01;
+            playerGravity = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5) ? 0.01 : Math.min(playerGravity, 0.01);
             // Set fall distance to 0 if the player has slow falling
             player.fallDistance = 0;
         }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -308,7 +308,9 @@ public class MovementTicker {
     }
 
     public void livingEntityTravel() {
-        double playerGravity = player.compensatedEntities.getSelf().getGravityAttribute();
+        double playerGravity = player.compensatedEntities.getSelf().getRiding() == null
+                ? player.compensatedEntities.getSelf().gravityAttribute
+                : player.compensatedEntities.getSelf().getRiding().gravityAttribute;
 
         boolean isFalling = player.actualMovement.getY() <= 0.0;
         if (isFalling && player.compensatedEntities.getSlowFallingAmplifier() != null) {

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -548,9 +548,8 @@ public class PredictionEngine {
         // We can't simulate the player's Y velocity, unknown number of ticks with a gravity change
         // Feel free to simulate all 104857600000000000000000000 possibilities!
         if (!player.pointThreeEstimator.canPredictNextVerticalMovement()) {
-            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().getGravityAttribute());
+            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().gravityAttribute);
         }
-
 
         // Hidden slime block bounces by missing idle tick and 0.03
         if (player.actualMovement.getY() >= 0 && player.uncertaintyHandler.influencedByBouncyBlock()) {

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -112,7 +112,7 @@ public class PredictionEngine {
         SimpleCollisionBox originalBB = player.boundingBox;
         // 0.03 doesn't exist with vehicles, thank god
         // 1.13+ clients have stupid poses that desync because mojang brilliantly removed the idle packet in 1.9
-        SimpleCollisionBox pointThreeThanksMojang = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) ? GetBoundingBox.getBoundingBoxFromPosAndSize(player.lastX, player.lastY, player.lastZ, 0.6f, 0.6f) : originalBB;
+        SimpleCollisionBox pointThreeThanksMojang = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) ? GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.lastX, player.lastY, player.lastZ, 0.6f, 0.6f) : originalBB;
 
         player.skippedTickInActualMovement = false;
 
@@ -548,7 +548,7 @@ public class PredictionEngine {
         // We can't simulate the player's Y velocity, unknown number of ticks with a gravity change
         // Feel free to simulate all 104857600000000000000000000 possibilities!
         if (!player.pointThreeEstimator.canPredictNextVerticalMovement()) {
-            minVector.setY(minVector.getY() - 0.08);
+            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().getGravityAttribute());
         }
 
 
@@ -647,7 +647,7 @@ public class PredictionEngine {
         //
         // Or the player is switching in and out of controlling a vehicle, in which friction messes it up
         //
-        if (player.uncertaintyHandler.lastVehicleSwitch.hasOccurredSince(0) || player.uncertaintyHandler.lastHardCollidingLerpingEntity.hasOccurredSince(3) || (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) && vector.vector.getY() > 0 && vector.isZeroPointZeroThree() && !Collisions.isEmpty(player, GetBoundingBox.getBoundingBoxFromPosAndSize(player.lastX, vector.vector.getY() + player.lastY + 0.6, player.lastZ, 0.6f, 1.26f)))) {
+        if (player.uncertaintyHandler.lastVehicleSwitch.hasOccurredSince(0) || player.uncertaintyHandler.lastHardCollidingLerpingEntity.hasOccurredSince(3) || (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) && vector.vector.getY() > 0 && vector.isZeroPointZeroThree() && !Collisions.isEmpty(player, GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.lastX, vector.vector.getY() + player.lastY + 0.6, player.lastZ, 0.6f, 1.26f)))) {
             box.expandToAbsoluteCoordinates(0, 0, 0);
         }
 
@@ -763,7 +763,7 @@ public class PredictionEngine {
         // Except on vehicles which don't have poses, thankfully.
         //
         SimpleCollisionBox oldBox = player.compensatedEntities.getSelf().inVehicle() ? GetBoundingBox.getCollisionBoxForPlayer(player, player.lastX, player.lastY, player.lastZ) :
-                GetBoundingBox.getBoundingBoxFromPosAndSize(player.lastX, player.lastY, player.lastZ, 0.6f, 1.8f);
+                GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.lastX, player.lastY, player.lastZ, 0.6f, 1.8f);
 
         if (!player.compensatedWorld.containsLiquid(oldBox.expand(0.1, 0.1, 0.1))) return false;
 
@@ -775,7 +775,7 @@ public class PredictionEngine {
         player.boundingBox = oldBB;
 
         SimpleCollisionBox newBox = player.compensatedEntities.getSelf().inVehicle() ? GetBoundingBox.getCollisionBoxForPlayer(player, player.x, player.y, player.z) :
-                GetBoundingBox.getBoundingBoxFromPosAndSize(player.x, player.y, player.z, 0.6f, 1.8f);
+                GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y, player.z, 0.6f, 1.8f);
 
         return player.uncertaintyHandler.lastHardCollidingLerpingEntity.hasOccurredSince(3) || !Collisions.isEmpty(player, newBox.expand(player.clientVelocity.getX(), -1 * pointThreeToGround, player.clientVelocity.getZ()).expand(0.5, 0.03, 0.5));
     }

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
@@ -42,9 +42,9 @@ public class PredictionEngineElytra extends PredictionEngine {
         // So we actually use the player's actual movement to get the gravity/slow falling status
         // However, this is wrong with elytra movement because players can control vertical movement after gravity is calculated
         // Yeah, slow falling needs a refactor in grim.
-        double recalculatedGravity = player.compensatedEntities.getSelf().getGravityAttribute();
+        double recalculatedGravity = player.compensatedEntities.getSelf().gravityAttribute;
         if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null)
-            recalculatedGravity = 0.01;
+            recalculatedGravity = 0.01; // TODO fix for 1.20.5+
 
         vector.add(new Vector(0.0D, recalculatedGravity * (-1.0D + vertCosRotation * 0.75D), 0.0D));
         double d5;

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
@@ -36,15 +36,18 @@ public class PredictionEngineElytra extends PredictionEngine {
         double horizontalSqrt = Math.sqrt(lookVector.getX() * lookVector.getX() + lookVector.getZ() * lookVector.getZ());
         double horizontalLength = vector.clone().setY(0).length();
         double length = lookVector.length();
+
         // Mojang changed from using their math to using regular java math in 1.18.2 elytra movement
         double vertCosRotation = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_18_2) ? Math.cos(yRotRadians) : player.trigHandler.cos(yRotRadians);
         vertCosRotation = (float) (vertCosRotation * vertCosRotation * Math.min(1.0D, length / 0.4D));
+
         // So we actually use the player's actual movement to get the gravity/slow falling status
         // However, this is wrong with elytra movement because players can control vertical movement after gravity is calculated
         // Yeah, slow falling needs a refactor in grim.
         double recalculatedGravity = player.compensatedEntities.getSelf().gravityAttribute;
-        if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null)
-            recalculatedGravity = 0.01; // TODO fix for 1.20.5+
+        if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null) {
+            recalculatedGravity = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5) ? 0.01 : Math.min(recalculatedGravity, 0.01);
+        }
 
         vector.add(new Vector(0.0D, recalculatedGravity * (-1.0D + vertCosRotation * 0.75D), 0.0D));
         double d5;

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
@@ -42,7 +42,7 @@ public class PredictionEngineElytra extends PredictionEngine {
         // So we actually use the player's actual movement to get the gravity/slow falling status
         // However, this is wrong with elytra movement because players can control vertical movement after gravity is calculated
         // Yeah, slow falling needs a refactor in grim.
-        double recalculatedGravity = 0.08;
+        double recalculatedGravity = player.compensatedEntities.getSelf().getGravityAttribute();
         if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null)
             recalculatedGravity = 0.01;
 

--- a/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
+++ b/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
@@ -655,7 +655,7 @@ public class BlockPlace {
         SimpleCollisionBox box = new SimpleCollisionBox(getPlacedAgainstBlockLocation());
         Vector look = ReachUtils.getLook(player, player.xRot, player.yRot);
 
-        final double distance = player.compensatedEntities.getSelf().getEntityInteractRangeAttribute() + 3;
+        final double distance = player.compensatedEntities.getSelf().getEntityInteractRange() + 3;
         Vector eyePos = new Vector(player.x, player.y + player.getEyeHeight(), player.z);
         Vector endReachPos = eyePos.clone().add(new Vector(look.getX() * distance, look.getY() * distance, look.getZ() * distance));
         Vector intercept = ReachUtils.calculateIntercept(box, eyePos, endReachPos).getFirst();

--- a/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
+++ b/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
@@ -655,8 +655,9 @@ public class BlockPlace {
         SimpleCollisionBox box = new SimpleCollisionBox(getPlacedAgainstBlockLocation());
         Vector look = ReachUtils.getLook(player, player.xRot, player.yRot);
 
+        final double distance = player.compensatedEntities.getSelf().getEntityInteractRangeAttribute() + 3;
         Vector eyePos = new Vector(player.x, player.y + player.getEyeHeight(), player.z);
-        Vector endReachPos = eyePos.clone().add(new Vector(look.getX() * 6, look.getY() * 6, look.getZ() * 6));
+        Vector endReachPos = eyePos.clone().add(new Vector(look.getX() * distance, look.getY() * distance, look.getZ() * distance));
         Vector intercept = ReachUtils.calculateIntercept(box, eyePos, endReachPos).getFirst();
 
         // Bring this back to relative to the block

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -34,7 +34,7 @@ public class ReachInterpolationData {
 
     public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox startingLocation, double x, double y, double z, boolean isPointNine, PacketEntity entity) {
         this.startingLocation = startingLocation;
-        this.targetLocation = GetBoundingBox.getBoundingBoxFromPosAndSize(x, y, z, BoundingBoxSize.getWidth(player, entity), BoundingBoxSize.getHeight(player, entity));
+        this.targetLocation = GetBoundingBox.getBoundingBoxFromPosAndSize(entity, x, y, z, BoundingBoxSize.getWidth(player, entity), BoundingBoxSize.getHeight(player, entity));
 
         // 1.9 -> 1.8 precision loss in packets
         // (ViaVersion is doing some stuff that makes this code difficult)

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -43,6 +43,7 @@ public class PacketEntity {
     private ReachInterpolationData newPacketLocation;
 
     public HashMap<PotionType, Integer> potionsMap = null;
+    public float scale = 1f; // 1.20.5+
 
     public PacketEntity(EntityType type) {
         this.type = type;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -44,6 +44,7 @@ public class PacketEntity {
 
     public HashMap<PotionType, Integer> potionsMap = null;
     public float scale = 1f; // 1.20.5+
+    public float stepHeight = 0.6f; // 1.20.5+
 
     public PacketEntity(EntityType type) {
         this.type = type;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -45,6 +45,7 @@ public class PacketEntity {
     public HashMap<PotionType, Integer> potionsMap = null;
     public float scale = 1f; // 1.20.5+
     public float stepHeight = 0.6f; // 1.20.5+
+    public double gravityAttribute = 0.08; // 1.20.5+
 
     public PacketEntity(EntityType type) {
         this.type = type;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
@@ -12,6 +12,7 @@ public class PacketEntityCamel extends PacketEntityHorse {
 
         jumpStrength = 0.42F;
         movementSpeedAttribute = 0.09f;
+        stepHeight = 1.5f;
     }
 
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
@@ -13,6 +13,7 @@ public class PacketEntityHorse extends PacketEntityTrackXRot {
 
     public PacketEntityHorse(GrimPlayer player, EntityType type, double x, double y, double z, float xRot) {
         super(player, type, x, y, z, xRot);
+        this.stepHeight = 1.0f;
 
         if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CHESTED_HORSE)) {
             jumpStrength = 0.5;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
@@ -13,5 +13,6 @@ public class PacketEntityRideable extends PacketEntity {
 
     public PacketEntityRideable(GrimPlayer player, EntityType type, double x, double y, double z) {
         super(player, type, x, y, z);
+        this.stepHeight = 1.0f;
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -17,6 +17,12 @@ public class PacketEntitySelf extends PacketEntity {
     @Getter
     @Setter
     int opLevel;
+    @Getter
+    @Setter
+    double gravityAttribute = 0.08;
+    @Getter
+    @Setter
+    double entityInteractRangeAttribute = 3, blockInteractRangeAttribute = 4.5;
 
     public PacketEntitySelf(GrimPlayer player) {
         super(EntityTypes.PLAYER);

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -22,9 +22,6 @@ public class PacketEntitySelf extends PacketEntity {
     float jumpStrength = 0.42f;
     @Getter
     @Setter
-    double gravityAttribute = 0.08;
-    @Getter
-    @Setter
     double entityInteractRangeAttribute = 3, blockInteractRangeAttribute = 4.5;
 
     public PacketEntitySelf(GrimPlayer player) {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -22,7 +22,7 @@ public class PacketEntitySelf extends PacketEntity {
     float jumpStrength = 0.42f;
     @Getter
     @Setter
-    double entityInteractRangeAttribute = 3, blockInteractRangeAttribute = 4.5;
+    double breakSpeedMultiplier = 1.0, entityInteractRange = 3, blockInteractRange = 4.5;
 
     public PacketEntitySelf(GrimPlayer player) {
         super(EntityTypes.PLAYER);
@@ -35,8 +35,8 @@ public class PacketEntitySelf extends PacketEntity {
         this.opLevel = old.opLevel;
         this.jumpStrength = old.jumpStrength;
         this.gravityAttribute = old.gravityAttribute;
-        this.entityInteractRangeAttribute = old.entityInteractRangeAttribute;
-        this.blockInteractRangeAttribute = old.blockInteractRangeAttribute;
+        this.entityInteractRange = old.entityInteractRange;
+        this.blockInteractRange = old.blockInteractRange;
         this.scale = old.scale;
         this.stepHeight = old.stepHeight;
     }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -19,6 +19,9 @@ public class PacketEntitySelf extends PacketEntity {
     int opLevel;
     @Getter
     @Setter
+    float jumpStrength = 0.42f;
+    @Getter
+    @Setter
     double gravityAttribute = 0.08;
     @Getter
     @Setter
@@ -33,6 +36,12 @@ public class PacketEntitySelf extends PacketEntity {
         super(EntityTypes.PLAYER);
         this.player = player;
         this.opLevel = old.opLevel;
+        this.jumpStrength = old.jumpStrength;
+        this.gravityAttribute = old.gravityAttribute;
+        this.entityInteractRangeAttribute = old.entityInteractRangeAttribute;
+        this.blockInteractRangeAttribute = old.blockInteractRangeAttribute;
+        this.scale = old.scale;
+        this.stepHeight = old.stepHeight;
     }
 
     public boolean inVehicle() {

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -120,12 +120,19 @@ public class CompensatedEntities {
 
                 // Attribute limits defined by https://minecraft.wiki/w/Attribute
                 // These seem to be clamped on the client, but not the server
-                if (key.equals("minecraft:generic.gravity")) {
-                    player.compensatedEntities.getSelf().setGravityAttribute(GrimMath.clamp(snapshotWrapper.getValue(), -1, 1));
-                } else if (key.equals("minecraft:player.block_interaction_range")) {
-                    player.compensatedEntities.getSelf().setBlockInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
-                } else if (key.equals("minecraft:player.entity_interaction_range")) {
-                    player.compensatedEntities.getSelf().setEntityInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
+                switch (key) {
+                    case "minecraft:generic.gravity":
+                        player.compensatedEntities.getSelf().setGravityAttribute(GrimMath.clamp(snapshotWrapper.getValue(), -1, 1));
+                        break;
+                    case "minecraft:player.block_interaction_range":
+                        player.compensatedEntities.getSelf().setBlockInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
+                        break;
+                    case "minecraft:player.entity_interaction_range":
+                        player.compensatedEntities.getSelf().setEntityInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
+                        break;
+                    case "minecraft:generic.jump_strength":
+                        player.compensatedEntities.getSelf().setJumpStrength(GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0, 32));
+                        break;
                 }
             }
         }
@@ -136,8 +143,13 @@ public class CompensatedEntities {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
                 final String key = snapshotWrapper.getKey();
                 if (key.equals("minecraft:generic.scale")) {
-                    // TODO is casting to float safe?
+                    // The game itself casts to float, this is fine.
                     entity.scale = GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0.0625f, 16f);
+                } else if (key.equals("minecraft:generic.step_height")) {
+                    entity.stepHeight = GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0f, 10f);
+                } else if (entity instanceof PacketEntityHorse && key.equals("minecraft:generic.jump_strength")) {
+                    // TODO check if this is how horses determine jump strength now
+                    ((PacketEntityHorse) entity).jumpStrength = GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0, 32);
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -6,7 +6,6 @@ import ac.grim.grimac.utils.data.TrackerData;
 import ac.grim.grimac.utils.data.packetentity.*;
 import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.nmsutil.BoundingBoxSize;
-import ac.grim.grimac.utils.nmsutil.GetBoundingBox;
 import ac.grim.grimac.utils.nmsutil.WatchableIndexUtil;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
@@ -121,9 +120,6 @@ public class CompensatedEntities {
                 // Attribute limits defined by https://minecraft.wiki/w/Attribute
                 // These seem to be clamped on the client, but not the server
                 switch (key) {
-                    case "minecraft:generic.gravity":
-                        player.compensatedEntities.getSelf().setGravityAttribute(GrimMath.clamp(snapshotWrapper.getValue(), -1, 1));
-                        break;
                     case "minecraft:player.block_interaction_range":
                         player.compensatedEntities.getSelf().setBlockInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
                         break;
@@ -142,7 +138,9 @@ public class CompensatedEntities {
         if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5)) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
                 final String key = snapshotWrapper.getKey();
-                if (key.equals("minecraft:generic.scale")) {
+                if (key.equals("minecraft:generic.gravity")) {
+                    entity.gravityAttribute = GrimMath.clamp(snapshotWrapper.getValue(), -1, 1);
+                } else if (key.equals("minecraft:generic.scale")) {
                     // The game itself casts to float, this is fine.
                     entity.scale = GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0.0625f, 16f);
                 } else if (key.equals("minecraft:generic.step_height")) {

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -120,11 +120,13 @@ public class CompensatedEntities {
                 // Attribute limits defined by https://minecraft.wiki/w/Attribute
                 // These seem to be clamped on the client, but not the server
                 switch (key) {
+                    case "minecraft:player.block_break_speed":
+                        player.compensatedEntities.getSelf().setBreakSpeedMultiplier(GrimMath.clamp(snapshotWrapper.getValue(), 0, 1024));
                     case "minecraft:player.block_interaction_range":
-                        player.compensatedEntities.getSelf().setBlockInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
+                        player.compensatedEntities.getSelf().setBlockInteractRange(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
                         break;
                     case "minecraft:player.entity_interaction_range":
-                        player.compensatedEntities.getSelf().setEntityInteractRangeAttribute(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
+                        player.compensatedEntities.getSelf().setEntityInteractRange(GrimMath.clamp(snapshotWrapper.getValue(), 0, 64));
                         break;
                     case "minecraft:generic.jump_strength":
                         player.compensatedEntities.getSelf().setJumpStrength(GrimMath.clampFloat((float) snapshotWrapper.getValue(), 0, 32));

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -679,24 +679,17 @@ public class CompensatedWorld {
         final NBTCompound worldNBT = user.getWorldNBT(dimension);
 
         final NBTCompound dimensionNBT = worldNBT.getCompoundTagOrNull("element");
-        // TODO see https://discord.com/channels/721686193061888071/721686193515003966/1232730054971363398
         // Mojang has decided to save another 1MB an hour by not sending data the client has "preinstalled"
+        // This code runs in 1.20.5+ with default world datapacks
         if (dimensionNBT == null && user.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5)) {
-            final String dimName = worldNBT.getStringTagValueOrThrow("name");
-            if (dimName.equals("minecraft:overworld")) {
-                minHeight = -64;
-                maxHeight = 320;
-            } else if (dimName.equals("minecraft:the_nether") || dimName.equals("minecraft:the_end")) {
-                minHeight = 0;
-                maxHeight = 256;
-            }
+            minHeight = user.getMinWorldHeight();
+            maxHeight = user.getMinWorldHeight() + user.getTotalWorldHeight();
             return;
         }
 
-        // TODO check if this works with custom heights on 1.20.5+
+        // Else get the heights directly from the NBT
         minHeight = dimensionNBT.getNumberTagOrThrow("min_y").getAsInt();
         maxHeight = minHeight + dimensionNBT.getNumberTagOrThrow("height").getAsInt();
-        System.out.println("min: " + minHeight + ", max: " + maxHeight);
     }
 
     public int getMaxHeight() {

--- a/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
+++ b/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
@@ -53,18 +53,18 @@ public class GrimMath {
         return (int) Math.ceil(d);
     }
 
-    public static double clamp(double d, double d2, double d3) {
-        if (d < d2) {
-            return d2;
+    public static double clamp(double num, double min, double max) {
+        if (num < min) {
+            return min;
         }
-        return Math.min(d, d3);
+        return Math.min(num, max);
     }
 
-    public static float clampFloat(float d, float d2, float d3) {
-        if (d < d2) {
-            return d2;
+    public static float clampFloat(float num, float min, float max) {
+        if (num < min) {
+            return min;
         }
-        return Math.min(d, d3);
+        return Math.min(num, max);
     }
 
     public static double lerp(double lerpAmount, double start, double end) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -115,6 +115,8 @@ public class BlockBreakSpeed {
             isCorrectToolForDrop = block.getType() == StateTypes.COBWEB;
         }
 
+        speedMultiplier *= (float) player.compensatedEntities.getSelf().getBreakSpeedMultiplier();
+
         if (speedMultiplier > 1.0f) {
             int digSpeed = tool.getEnchantmentLevel(EnchantmentTypes.BLOCK_EFFICIENCY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
             if (digSpeed > 0) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -54,7 +54,7 @@ public class Collisions {
 
     public static boolean slowCouldPointThreeHitGround(GrimPlayer player, double x, double y, double z) {
         SimpleCollisionBox oldBB = player.boundingBox;
-        player.boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSize(x, y, z, 0.6f, 0.06f);
+        player.boundingBox = GetBoundingBox.getBoundingBoxFromPosAndSize(player, x, y, z, 0.6f, 0.06f);
 
         double posXZ = Collisions.collide(player, 0.03, -0.03, 0.03).getY();
         double negXNegZ = Collisions.collide(player, -0.03, -0.03, -0.03).getY();

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -17,7 +17,7 @@ public class GetBoundingBox {
         float width = BoundingBoxSize.getWidth(player, entity);
         float height = BoundingBoxSize.getHeight(player, entity);
 
-        return getBoundingBoxFromPosAndSize(centerX, minY, centerZ, width, height);
+        return getBoundingBoxFromPosAndSize(player, centerX, minY, centerZ, width, height);
     }
 
     // Size regular: 0.6 width 1.8 height
@@ -27,11 +27,18 @@ public class GetBoundingBox {
     public static SimpleCollisionBox getPlayerBoundingBox(GrimPlayer player, double centerX, double minY, double centerZ) {
         float width = player.pose.width;
         float height = player.pose.height;
-
-        return getBoundingBoxFromPosAndSize(centerX, minY, centerZ, width, height);
+        return getBoundingBoxFromPosAndSize(player, centerX, minY, centerZ, width, height);
     }
 
-    public static SimpleCollisionBox getBoundingBoxFromPosAndSize(double centerX, double minY, double centerZ, float width, float height) {
+    public static SimpleCollisionBox getBoundingBoxFromPosAndSize(GrimPlayer player, double centerX, double minY, double centerZ, float width, float height) {
+        return getBoundingBoxFromPosAndSize(player.compensatedEntities.getSelf(), centerX, minY, centerZ, width, height);
+    }
+
+    public static SimpleCollisionBox getBoundingBoxFromPosAndSize(PacketEntity entity, double centerX, double minY, double centerZ, float width, float height) {
+        return getBoundingBoxFromPosAndSizeRaw(centerX, minY, centerZ, width * entity.scale, height * entity.scale);
+    }
+
+    public static SimpleCollisionBox getBoundingBoxFromPosAndSizeRaw(double centerX, double minY, double centerZ, float width, float height) {
         double minX = centerX - (width / 2f);
         double maxX = centerX + (width / 2f);
         double maxY = minY + height;

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.nmsutil;
 
 import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.util.Vector3d;
 import org.bukkit.util.Vector;
 
@@ -12,6 +13,8 @@ public class JumpPower {
             f += 0.1f * (player.compensatedEntities.getJumpAmplifier() + 1);
         }
 
+        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5) && f <= 1.0E-5F) return;
+
         vector.setY(f);
 
         if (player.isSprinting) {
@@ -21,7 +24,7 @@ public class JumpPower {
     }
 
     public static float getJumpPower(GrimPlayer player) {
-        return 0.42f * getPlayerJumpFactor(player);
+        return player.compensatedEntities.getSelf().getJumpStrength() * getPlayerJumpFactor(player);
     }
 
     public static float getPlayerJumpFactor(GrimPlayer player) {


### PR DESCRIPTION
Working on 1.20.5 update. ~~I'll also update block collisions in a different pr once packetevents merges the 1.20.5 PR (generally waiting on packetevents to test stuff)~~.

Need to get shulkr working as well so I can view .4 -> .5 diff