### PR TITLE
Add BadPacketsW

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
@@ -1,0 +1,13 @@
+package ac.grim.grimac.checks.impl.badpackets;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+
+@CheckData(name = "BadPacketsW", experimental = true)
+public class BadPacketsW extends Check implements PacketCheck {
+    public BadPacketsW(GrimPlayer player) {
+        super(player);
+    }
+}

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
@@ -33,7 +33,7 @@ public class PacketPlayerAttack extends PacketListenerAbstract {
             if (player == null) return;
 
             // The entity does not exist
-            if (!player.compensatedEntities.entityMap.containsKey(interact.getEntityId())) {
+            if (!player.compensatedEntities.entityMap.containsKey(interact.getEntityId()) && !player.compensatedEntities.serverPositionsMap.containsKey(interact.getEntityId())) {
                 if (player.checkManager.getPacketCheck(BadPacketsW.class).flagAndAlert("entityId=" + interact.getEntityId()) && player.checkManager.getPacketCheck(BadPacketsW.class).shouldModifyPackets()) {
                     event.setCancelled(true);
                     player.onPacketCancel();

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.checks.impl.badpackets.BadPacketsW;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.PacketEvents;
@@ -30,6 +31,15 @@ public class PacketPlayerAttack extends PacketListenerAbstract {
             GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
 
             if (player == null) return;
+
+            // The entity does not exist
+            if (!player.compensatedEntities.entityMap.containsKey(interact.getEntityId())) {
+                if (player.checkManager.getPacketCheck(BadPacketsW.class).flagAndAlert("entityId=" + interact.getEntityId()) && player.checkManager.getPacketCheck(BadPacketsW.class).shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                }
+                return;
+            }
 
             if (interact.getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
                 ItemStack heldItem = player.getInventory().getHeldItem();

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -89,6 +89,7 @@ public class CheckManager {
                 .put(BadPacketsT.class, new BadPacketsT(player))
                 .put(BadPacketsU.class, new BadPacketsU(player))
                 .put(BadPacketsV.class, new BadPacketsV(player))
+                .put(BadPacketsW.class, new BadPacketsW(player))
                 .put(FastBreak.class, new FastBreak(player))
                 .put(TransactionOrder.class, new TransactionOrder(player))
                 .put(NoSlowB.class, new NoSlowB(player))


### PR DESCRIPTION
Prevents this noslow (flags BadPacketsV) for 1.8 swords, and other potential exploits
```kt
var send = false

override fun onPacket(event: PacketEvent) {
    if (event.packet is C08PacketPlayerBlockPlacement && event.packet.placedBlockDirection == 255) send = true
    if (event.packet is C03PacketPlayer && send) {
        if (grimSwing) sendPacket(C0APacketAnimation())
        sendPacket(C02PacketUseEntity().also {
            it.entityId = -1
            it.action = ATTACK
        })
        send = false
    }
}
```