### PR TITLE
Cancel stupidity packets (v2)

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -322,7 +322,9 @@ public class CheckManagerListener extends PacketListenerAbstract {
     }
 
     private boolean isMojangStupid(GrimPlayer player, WrapperPlayClientPlayerFlying flying) {
-        double threshold = player.getMovementThreshold();
+        final Location location = flying.getLocation();
+        final double threshold = player.getMovementThreshold();
+
         // Don't check duplicate 1.17 packets (Why would you do this mojang?)
         // Don't check rotation since it changes between these packets, with the second being irrelevant.
         //
@@ -334,21 +336,34 @@ public class CheckManagerListener extends PacketListenerAbstract {
                         // Mojang added this stupid mechanic in 1.17
                         && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_17) &&
                         // Due to 0.03, we can't check exact position, only within 0.03
-                        player.filterMojangStupidityOnMojangStupidity.distanceSquared(flying.getLocation().getPosition()) < threshold * threshold))
+                        player.filterMojangStupidityOnMojangStupidity.distanceSquared(location.getPosition()) < threshold * threshold))
                         // If the player was in a vehicle, has position and look, and wasn't a teleport, then it was this stupid packet
                         || player.compensatedEntities.getSelf().inVehicle())) {
+
+            // Mark that we want this packet to be cancelled from reaching the server
+            // Additionally, only yaw/pitch matters: https://github.com/GrimAnticheat/Grim/issues/1275#issuecomment-1872444018
+            // 1.9+ isn't impacted by this packet as much.
+            if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_9)) {
+                if (GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("cancel-duplicate-packet", true)) {
+                    player.packetStateData.cancelDuplicatePacket = true;
+                }
+            } else {
+                // Override location to force it to use the last real position of the player. Prevents position-related bypasses like nofall.
+                flying.setLocation(new Location(player.filterMojangStupidityOnMojangStupidity.getX(), player.filterMojangStupidityOnMojangStupidity.getY(), player.filterMojangStupidityOnMojangStupidity.getZ(), location.getYaw(), location.getPitch()));
+            }
+
             player.packetStateData.lastPacketWasOnePointSeventeenDuplicate = true;
 
-            if (player.xRot != flying.getLocation().getYaw() || player.yRot != flying.getLocation().getPitch()) {
+            if (player.xRot != location.getYaw() || player.yRot != location.getPitch()) {
                 player.lastXRot = player.xRot;
                 player.lastYRot = player.yRot;
             }
 
             // Take the pitch and yaw, just in case we were wrong about this being a stupidity packet
-            player.xRot = flying.getLocation().getYaw();
-            player.yRot = flying.getLocation().getPitch();
+            player.xRot = location.getYaw();
+            player.yRot = location.getPitch();
 
-            player.packetStateData.lastClaimedPosition = flying.getLocation().getPosition();
+            player.packetStateData.lastClaimedPosition = location.getPosition();
             return true;
         }
         return false;
@@ -400,6 +415,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
 
         // The player flagged crasher or timer checks, therefore we must protect predictions against these attacks
         if (event.isCancelled() && (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType()) || event.getPacketType() == PacketType.Play.Client.VEHICLE_MOVE)) {
+            player.packetStateData.cancelDuplicatePacket = false;
             return;
         }
 
@@ -546,6 +562,11 @@ public class CheckManagerListener extends PacketListenerAbstract {
         // Call the packet checks last as they can modify the contents of the packet
         // Such as the NoFall check setting the player to not be on the ground
         player.checkManager.onPacketReceive(event);
+
+        if (player.packetStateData.cancelDuplicatePacket) {
+            event.setCancelled(true);
+            player.packetStateData.cancelDuplicatePacket = false;
+        }
 
         // Finally, remove the packet state variables on this packet
         player.packetStateData.lastPacketWasOnePointSeventeenDuplicate = false;

--- a/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
@@ -8,7 +8,7 @@ import com.github.retrooper.packetevents.util.Vector3d;
 public class PacketStateData {
     public boolean packetPlayerOnGround = false;
     public boolean lastPacketWasTeleport = false;
-    public boolean lastPacketWasOnePointSeventeenDuplicate = false;
+    public boolean cancelDuplicatePacket, lastPacketWasOnePointSeventeenDuplicate = false;
     public boolean lastTransactionPacketWasValid = false;
     public int lastSlotSelected;
     public InteractionHand eatingHand = InteractionHand.MAIN_HAND;

--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -36,6 +36,11 @@ spectators:
 # Wie lange sollen Spieler Zeit haben, bis wir sie wegen Zeitüberschreitung rauswerfen? Standard = 60 Sekunden
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # Mit wie viel soll der Gesamtvorteil multipliziert werden, wenn der Spieler legitim ist.
   # So sieht die Standardkonfiguration aus (x-Achse = Sekunden, y-Achse = 1/1000 Block): https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -36,6 +36,11 @@ spectators:
 # How long should players have until we kick them for timing out? Default = 60 seconds
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # How much should we multiply total advantage by when the player is legit
   # This is what the default config looks like (x axis = seconds, y axis = 1/1000 block): https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -37,6 +37,11 @@ spectators:
 # Por defecto, este valor se encuentra en 60 segundos.
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # Por cuanto deberíamos multiplicar la ventaja total cuando el jugador es legítimo
   # Asi es como se ve la configuración por defecto (eje x = segundos, eje y = bloque 1/1000): https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -36,6 +36,11 @@ spectators:
 # Au bout de combien de temps les joueurs doivent-ils être expulsés en cas de perte de connexion ? Défault = 60 secondes
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # De combien devons-nous multiplier l'avantage total lorsque le joueur est légitime ?
   # Voici à quoi ressemble la configuration par défaut (l'axe x = secondes, l'axe y = 1/1000 de bloc) : https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/it.yml
+++ b/src/main/resources/config/it.yml
@@ -36,6 +36,11 @@ spectators:
 
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # Riduce gradualmente l'avanzamento totale del giocatore quando è legittimo
   setback-decay-multiplier: 0.999

--- a/src/main/resources/config/pt.yml
+++ b/src/main/resources/config/pt.yml
@@ -36,6 +36,11 @@ spectators:
 # Quanto tempo os jogadores tem até expulsarmos eles por inatividade? Padrão = 60 segundos.
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # Por quanto deveríamos multiplicar a vantagem caso o jogador não tenha falhado em nem uma verificação?
   # Isso é como a configuração padrão se parece (eixo X = segundos, eixo Y = 1/1000 blocos): https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -36,6 +36,11 @@ spectators:
 # Сколько времени должно быть у игроков, пока мы не выкинем их за тайм-аут? По умолчанию = 60 секунд
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # На сколько мы должны умножить общее преимущество, когда игрок легален.
   # Вот как выглядит конфигурация по умолчанию (ось x = секунды, ось y = 1/1000 блока): https://www.desmos.com/calculator/d4ufgxrxer

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -36,6 +36,11 @@ spectators:
 # 在我们让他们超时之前，玩家应该有多长时间？ 此处的60 指60s
 max-transaction-time: 60
 
+# Should the duplicate movement packet be cancelled?
+# Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
+# This setting only applies to 1.17-1.20.5 clients on 1.8 servers.
+cancel-duplicate-packet: true
+
 Simulation:
   # 当玩家合法时，我们应该将总优势乘以多少
   # 这是默认配置的样子（x 轴 = seconds ，y 轴 = 1/1000 方块）: https://www.desmos.com/calculator/d4ufgxrxer


### PR DESCRIPTION
This is a simple implementation to at least allow people to prevent exploitation of this packet. Also fixes position-related nofall bypasses on 1.9+ servers.

Fixes https://github.com/GrimAnticheat/Grim/issues/1248
Fixes https://github.com/GrimAnticheat/Grim/issues/1275
Fixes https://github.com/GrimAnticheat/Grim/issues/1310
Fixes https://github.com/GrimAnticheat/Grim/issues/1315

And fastuse.