### PR TITLE
Fix some pre-attribute remnants and bug with getting packet entity scaled box

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -17,6 +17,7 @@ import ac.grim.grimac.utils.anticheat.update.PositionUpdate;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.VectorData;
+import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityRideable;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityTrackXRot;
@@ -175,19 +176,20 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             player.clientVelocity.multiply(0.98); // This is vanilla, do not touch
         }
 
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
         if (player.vehicleData.wasVehicleSwitch || player.vehicleData.lastDummy) {
             update.setTeleport(true);
 
             player.vehicleData.lastDummy = false;
             player.vehicleData.wasVehicleSwitch = false;
 
-            if (player.compensatedEntities.getSelf().getRiding() != null) {
+            if (riding != null) {
                 Vector pos = new Vector(player.x, player.y, player.z);
-                SimpleCollisionBox interTruePositions = player.compensatedEntities.getSelf().getRiding().getPossibleCollisionBoxes();
+                SimpleCollisionBox interTruePositions = riding.getPossibleCollisionBoxes();
 
                 // We shrink the expanded bounding box to what the packet positions can be, for a smaller box
-                float width = BoundingBoxSize.getWidth(player, player.compensatedEntities.getSelf().getRiding());
-                float height = BoundingBoxSize.getHeight(player, player.compensatedEntities.getSelf().getRiding());
+                float width = BoundingBoxSize.getWidth(player, riding) * riding.scale;
+                float height = BoundingBoxSize.getHeight(player, riding) * riding.scale;
                 interTruePositions.expand(-width, 0, -width);
                 interTruePositions.expandMax(0, -height, 0);
 
@@ -253,25 +255,25 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             player.checkManager.getExplosionHandler().forceExempt();
 
             // When in control of the entity, the player sets the entity position to their current position
-            player.compensatedEntities.getSelf().getRiding().setPositionRaw(GetBoundingBox.getPacketEntityBoundingBox(player, player.x, player.y, player.z, player.compensatedEntities.getSelf().getRiding()));
+            riding.setPositionRaw(GetBoundingBox.getPacketEntityBoundingBox(player, player.x, player.y, player.z, riding));
 
-            if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityTrackXRot) {
-                PacketEntityTrackXRot boat = (PacketEntityTrackXRot) player.compensatedEntities.getSelf().getRiding();
+            if (riding instanceof PacketEntityTrackXRot) {
+                PacketEntityTrackXRot boat = (PacketEntityTrackXRot) riding;
                 boat.packetYaw = player.xRot;
                 boat.interpYaw = player.xRot;
                 boat.steps = 0;
             }
 
-            if (player.hasGravity != player.compensatedEntities.getSelf().getRiding().hasGravity) {
+            if (player.hasGravity != riding.hasGravity) {
                 player.pointThreeEstimator.updatePlayerGravity();
             }
-            player.hasGravity = player.compensatedEntities.getSelf().getRiding().hasGravity;
+            player.hasGravity = riding.hasGravity;
 
             // For whatever reason the vehicle move packet occurs AFTER the player changes slots...
-            if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityRideable) {
+            if (riding instanceof PacketEntityRideable) {
                 EntityControl control = player.checkManager.getPostPredictionCheck(EntityControl.class);
 
-                ItemType requiredItem = player.compensatedEntities.getSelf().getRiding().getType() == EntityTypes.PIG ? ItemTypes.CARROT_ON_A_STICK : ItemTypes.WARPED_FUNGUS_ON_A_STICK;
+                ItemType requiredItem = riding.getType() == EntityTypes.PIG ? ItemTypes.CARROT_ON_A_STICK : ItemTypes.WARPED_FUNGUS_ON_A_STICK;
                 ItemStack mainHand = player.getInventory().getHeldItem();
                 ItemStack offHand = player.getInventory().getOffHand();
 
@@ -318,7 +320,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             player.isSprinting = false;
             player.isSneaking = false;
 
-            if (player.compensatedEntities.getSelf().getRiding().getType() != EntityTypes.PIG && player.compensatedEntities.getSelf().getRiding().getType() != EntityTypes.STRIDER) {
+            if (riding.getType() != EntityTypes.PIG && riding.getType() != EntityTypes.STRIDER) {
                 player.isClimbing = false;
             }
         }
@@ -422,7 +424,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         boolean wasChecked = false;
 
         // Exempt if the player is dead or is riding a dead entity
-        if (player.compensatedEntities.getSelf().isDead || (player.compensatedEntities.getSelf().getRiding() != null && player.compensatedEntities.getSelf().getRiding().isDead)) {
+        if (player.compensatedEntities.getSelf().isDead || (riding != null && riding.isDead)) {
             // Dead players can't cheat, if you find a way how they could, open an issue
             player.predictedVelocity = new VectorData(new Vector(), VectorData.VectorType.Dead);
             player.clientVelocity = new Vector();
@@ -436,7 +438,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             player.gravity = 0;
             player.friction = 0.91f;
             PredictionEngineNormal.staticVectorEndOfTick(player, player.clientVelocity);
-        } else if (player.compensatedEntities.getSelf().getRiding() == null) {
+        } else if (riding == null) {
             wasChecked = true;
 
             // Depth strider was added in 1.8
@@ -490,17 +492,17 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             // The player and server are both on a version with client controlled entities
             // If either or both of the client server version has server controlled entities
             // The player can't use entities (or the server just checks the entities)
-            if (EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT)) {
+            if (EntityTypes.isTypeInstanceOf(riding.getType(), EntityTypes.BOAT)) {
                 new PlayerBaseTick(player).doBaseTick();
                 // Speed doesn't affect anything with boat movement
                 new BoatPredictionEngine(player).guessBestMovement(0.1f, player);
-            } else if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityHorse) {
+            } else if (riding instanceof PacketEntityHorse) {
                 new PlayerBaseTick(player).doBaseTick();
                 new MovementTickerHorse(player).livingEntityAIStep();
-            } else if (player.compensatedEntities.getSelf().getRiding().getType() == EntityTypes.PIG) {
+            } else if (riding.getType() == EntityTypes.PIG) {
                 new PlayerBaseTick(player).doBaseTick();
                 new MovementTickerPig(player).livingEntityAIStep();
-            } else if (player.compensatedEntities.getSelf().getRiding().getType() == EntityTypes.STRIDER) {
+            } else if (riding.getType() == EntityTypes.STRIDER) {
                 new PlayerBaseTick(player).doBaseTick();
                 new MovementTickerStrider(player).livingEntityAIStep();
                 MovementTickerStrider.floatStrider(player);

--- a/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -138,8 +138,8 @@ public class UncertaintyHandler {
             if (entity == null) continue;
 
             SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
-            float width = BoundingBoxSize.getWidth(player, entity);
-            float height = BoundingBoxSize.getHeight(player, entity);
+            float width = BoundingBoxSize.getWidth(player, entity) * entity.scale;
+            float height = BoundingBoxSize.getHeight(player, entity) * entity.scale;
 
             // Convert back to coordinates instead of hitbox
             entityBox.maxY -= height;

--- a/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
+++ b/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
@@ -574,8 +574,8 @@ public class BlockPlace {
                 for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
                     SimpleCollisionBox interpBox = entity.getPossibleCollisionBoxes();
 
-                    double width = BoundingBoxSize.getWidth(player, entity);
-                    double height = BoundingBoxSize.getHeight(player, entity);
+                    double width = BoundingBoxSize.getWidth(player, entity) * entity.scale;
+                    double height = BoundingBoxSize.getHeight(player, entity) * entity.scale;
                     double interpWidth = Math.max(interpBox.maxX - interpBox.minX, interpBox.maxZ - interpBox.minZ);
                     double interpHeight = interpBox.maxY - interpBox.minY;
 

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -34,7 +34,7 @@ public class ReachInterpolationData {
 
     public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox startingLocation, double x, double y, double z, boolean isPointNine, PacketEntity entity) {
         this.startingLocation = startingLocation;
-        this.targetLocation = GetBoundingBox.getBoundingBoxFromPosAndSize(entity, x, y, z, BoundingBoxSize.getWidth(player, entity), BoundingBoxSize.getHeight(player, entity));
+        this.targetLocation = GetBoundingBox.getPacketEntityBoundingBox(player, x, y, z, entity);
 
         // 1.9 -> 1.8 precision loss in packets
         // (ViaVersion is doing some stuff that makes this code difficult)

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -73,8 +73,8 @@ public class Collisions {
     public static Vector collide(GrimPlayer player, double desiredX, double desiredY, double desiredZ, double clientVelY, VectorData data) {
         if (desiredX == 0 && desiredY == 0 && desiredZ == 0) return new Vector();
 
-        SimpleCollisionBox grabBoxesBB = player.boundingBox.copy();
-        double stepUpHeight = player.getMaxUpStep();
+        final SimpleCollisionBox grabBoxesBB = player.boundingBox.copy();
+        final double stepUpHeight = player.getMaxUpStep();
 
         if (desiredX == 0.0 && desiredZ == 0.0) {
             if (desiredY > 0.0) {
@@ -102,7 +102,7 @@ public class Collisions {
         double bestInput = Double.MAX_VALUE;
         Vector bestOrderResult = null;
 
-        Vector bestTheoreticalCollisionResult = VectorUtils.cutBoxToVector(player.actualMovement, new SimpleCollisionBox(0, Math.min(0, desiredY), 0, desiredX, Math.max(0.6, desiredY), desiredZ).sort());
+        Vector bestTheoreticalCollisionResult = VectorUtils.cutBoxToVector(player.actualMovement, new SimpleCollisionBox(0, Math.min(0, desiredY), 0, desiredX, Math.max(stepUpHeight, desiredY), desiredZ).sort());
         int zeroCount = (desiredX == 0 ? 1 : 0) + (desiredY == 0 ? 1 : 0) + (desiredZ == 0 ? 1 : 0);
 
         for (List<Axis> order : (data != null && data.isZeroPointZeroThree() ? allAxisCombinations : nonStupidityCombinations)) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -16,8 +16,7 @@ public class GetBoundingBox {
     public static SimpleCollisionBox getPacketEntityBoundingBox(GrimPlayer player, double centerX, double minY, double centerZ, PacketEntity entity) {
         float width = BoundingBoxSize.getWidth(player, entity);
         float height = BoundingBoxSize.getHeight(player, entity);
-
-        return getBoundingBoxFromPosAndSize(player, centerX, minY, centerZ, width, height);
+        return getBoundingBoxFromPosAndSize(entity, centerX, minY, centerZ, width, height);
     }
 
     // Size regular: 0.6 width 1.8 height


### PR DESCRIPTION
Fixed the few places where getting bounding box width/height directly doesn't account for scale. Fixed a bug where `getPacketEntityBoundingBox` would return the player's box, not the one of the entity.

You can now safely ride your giant horse.
![image](https://github.com/GrimAnticheat/Grim/assets/11319274/f209f1b8-d477-4cdb-b892-ff36bb2a3417)
