### PR TITLE
Fix unloaded chunk falses by running simulation and accounting for respawn flags

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -54,6 +54,11 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
     private static final byte KEEP_ALL = 3;
 
     private boolean hasFlag(WrapperPlayServerRespawn respawn, byte flag) {
+        // This packet was added in 1.16
+        // On versions older than 1.16, via keeps all data.
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_16)) {
+            return true;
+        }
         return (respawn.getKeptData() & flag) != 0;
     }
 
@@ -177,8 +182,8 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                     player.compensatedWorld.setDimension(respawn.getDimension(), event.getUser());
                 }
 
-                // TODO this needs to be done for other client versions as well. And there should probably be some attribute holder that we can just call reset() on.
-                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5) && !this.hasFlag(respawn, KEEP_ATTRIBUTES)) {
+                // TODO And there should probably be some attribute holder that we can just call reset() on.
+                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16) && !this.hasFlag(respawn, KEEP_ATTRIBUTES)) {
                     // Reset attributes if not kept
                     final PacketEntitySelf self = player.compensatedEntities.getSelf();
                     self.gravityAttribute = 0.08d;

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -55,19 +55,14 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         // This teleport wasn't valid as the player STILL hasn't loaded this damn chunk.
         // Keep re-teleporting until they load the chunk!
         if (player.getSetbackTeleportUtil().insideUnloadedChunk()) {
-            player.lastOnGround = player.clientClaimsLastOnGround; // Stop a false on join
-
             // The player doesn't control this vehicle, we don't care
-            if (player.compensatedEntities.getSelf().inVehicle() &&
+            final boolean invalidVehicle = player.compensatedEntities.getSelf().inVehicle() &&
                     (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_9) ||
-                    player.getClientVersion().isOlderThan(ClientVersion.V_1_9))) {
-                return;
-            }
+                            player.getClientVersion().isOlderThan(ClientVersion.V_1_9));
 
-            if (!data.isTeleport()) {
+            if (!invalidVehicle && !data.isTeleport()) {
                 // Teleport the player back to avoid players being able to simply ignore transactions
                 player.getSetbackTeleportUtil().executeForceResync();
-                return;
             }
         }
 


### PR DESCRIPTION
Tested on server versions 1.20.4 and 1.8.

Tested on client versions 1.20.6, 1.20.4, 1.16, 1.13.2, 1.12.2.

Clumsy 200ms delay.

Fixes #1211 