### PR TITLE
Fix fishing rod boat fly bypass

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -426,7 +426,7 @@ public class PacketEntityReplication extends Check implements PacketCheck {
             if (entity instanceof PacketEntityTrackXRot && yaw != null) {
                 PacketEntityTrackXRot xRotEntity = (PacketEntityTrackXRot) entity;
                 xRotEntity.packetYaw = yaw;
-                xRotEntity.steps = EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT) ? 10 : 3;
+                xRotEntity.steps = entity.isBoat() ? 10 : 3;
             }
             entity.onFirstTransaction(isRelative, hasPos, deltaX, deltaY, deltaZ, player);
         });

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerSteer.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerSteer.java
@@ -44,7 +44,7 @@ public class PacketPlayerSteer extends PacketListenerAbstract {
             if (player.packetStateData.receivedSteerVehicle && riding != null) {
                 // Horse and boat have first passenger in control
                 // If the player is the first passenger, disregard this attempt to have the server control the entity
-                if ((EntityTypes.isTypeInstanceOf(riding.getType(), EntityTypes.BOAT) || riding instanceof PacketEntityHorse) && riding.passengers.get(0) == player.compensatedEntities.getSelf() &&
+                if ((riding.isBoat() || riding instanceof PacketEntityHorse) && riding.passengers.get(0) == player.compensatedEntities.getSelf() &&
                         // Although if the player has server controlled entities
                         player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) &&
                         // or the server controls the entities, then this is vanilla logic so allow it

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -349,7 +349,7 @@ public class GrimPlayer implements GrimUser {
         final PacketEntity riding = self.getRiding();
         if (riding == null) return self.stepHeight;
 
-        if (EntityTypes.isTypeInstanceOf(riding.getType(), EntityTypes.BOAT)) {
+        if (riding.isBoat()) {
             return 0f;
         }
 

--- a/src/main/java/ac/grim/grimac/predictionengine/GhostBlockDetector.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/GhostBlockDetector.java
@@ -53,7 +53,7 @@ public class GhostBlockDetector extends Check implements PostPredictionCheck {
             SimpleCollisionBox largeExpandedBB = player.boundingBox.copy().expand(12, 0.5, 12);
 
             for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-                if (EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT)) {
+                if (entity.isBoat()) {
                     if (entity.getPossibleCollisionBoxes().isIntersected(largeExpandedBB)) {
                         return true;
                     }

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -492,7 +492,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             // The player and server are both on a version with client controlled entities
             // If either or both of the client server version has server controlled entities
             // The player can't use entities (or the server just checks the entities)
-            if (EntityTypes.isTypeInstanceOf(riding.getType(), EntityTypes.BOAT)) {
+            if (riding.isBoat()) {
                 new PlayerBaseTick(player).doBaseTick();
                 // Speed doesn't affect anything with boat movement
                 new BoatPredictionEngine(player).guessBestMovement(0.1f, player);

--- a/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -2,12 +2,12 @@ package ac.grim.grimac.predictionengine;
 
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
+import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.enums.Pose;
 import ac.grim.grimac.utils.latency.CompensatedEntities;
 import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.nmsutil.*;
-import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
@@ -102,7 +102,8 @@ public class PlayerBaseTick {
 
         double d0 = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
 
-        if (player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT) && !player.vehicleData.boatUnderwater && player.boundingBox.maxY >= d0 && player.boundingBox.minY <= d0) {
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
+        if (riding != null && riding.isBoat() && !player.vehicleData.boatUnderwater && player.boundingBox.maxY >= d0 && player.boundingBox.minY <= d0) {
             return;
         }
 
@@ -379,7 +380,8 @@ public class PlayerBaseTick {
     }
 
     public void updateInWaterStateAndDoWaterCurrentPushing() {
-        player.wasTouchingWater = this.updateFluidHeightAndDoFluidPushing(FluidTag.WATER, 0.014) && !(player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT));
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
+        player.wasTouchingWater = this.updateFluidHeightAndDoFluidPushing(FluidTag.WATER, 0.014) && !(riding != null && riding.isBoat());
         if (player.wasTouchingWater)
             player.fallDistance = 0;
     }

--- a/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -323,9 +323,10 @@ public class UncertaintyHandler {
     }
 
     private boolean regularHardCollision(SimpleCollisionBox expandedBB) {
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
         for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-            if ((EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT) || entity.getType() == EntityTypes.SHULKER) && entity != player.compensatedEntities.getSelf().getRiding() &&
-                    entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
+            if ((entity.isBoat() || entity.getType() == EntityTypes.SHULKER) && entity != riding
+                    && entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
                 return true;
             }
         }
@@ -350,16 +351,15 @@ public class UncertaintyHandler {
 
     private boolean boatCollision(SimpleCollisionBox expandedBB) {
         // Boats can collide with quite literally anything
-        if (player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT)) {
-            for (Map.Entry<Integer, PacketEntity> entityPair : player.compensatedEntities.entityMap.int2ObjectEntrySet()) {
-                PacketEntity entity = entityPair.getValue();
-                if (entity != player.compensatedEntities.getSelf().getRiding() && (player.compensatedEntities.getSelf().getRiding() == null || !player.compensatedEntities.getSelf().getRiding().hasPassenger(entityPair.getValue())) &&
-                        entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
-                    return true;
-                }
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
+        if (riding == null || !riding.isBoat()) return false;
+
+        for (Map.Entry<Integer, PacketEntity> entityPair : player.compensatedEntities.entityMap.int2ObjectEntrySet()) {
+            PacketEntity entity = entityPair.getValue();
+            if (entity != riding && entity.isPushable() && !riding.hasPassenger(entityPair.getValue()) && entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
+                return true;
             }
         }
-
         return false;
     }
 }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -38,10 +38,7 @@ public class MovementTicker {
             SimpleCollisionBox expandedPlayerBox = playerBox.copy().expandToAbsoluteCoordinates(player.x, player.y, player.z).expand(1);
 
             for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-                // Players can only push living entities
-                // Players can also push boats or minecarts
-                // The one exemption to a living entity is an armor stand
-                if (!entity.isLivingEntity() && !EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT) && !entity.isMinecart() || entity.getType() == EntityTypes.ARMOR_STAND)
+                if (!entity.isPushable())
                     continue;
 
                 SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
@@ -107,7 +104,8 @@ public class MovementTicker {
         player.boundingBox = GetBoundingBox.getCollisionBoxForPlayer(player, player.x, player.y, player.z);
         // This is how the player checks for fall damage
         // By running fluid pushing for the player
-        if (!player.wasTouchingWater && (player.compensatedEntities.getSelf().getRiding() == null || !EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT))) {
+        final PacketEntity riding = player.compensatedEntities.getSelf().getRiding();
+        if (!player.wasTouchingWater && (riding == null || !riding.isBoat())) {
             new PlayerBaseTick(player).updateInWaterStateAndDoWaterCurrentPushing();
         }
 
@@ -119,7 +117,7 @@ public class MovementTicker {
         }
 
         // Striders call the method for inside blocks AGAIN!
-        if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityStrider) {
+        if (riding instanceof PacketEntityStrider) {
             Collisions.handleInsideBlocks(player);
         }
 
@@ -138,13 +136,13 @@ public class MovementTicker {
                 } else {
                     if (player.clientVelocity.getY() < 0.0) {
                         player.clientVelocity.setY(-player.clientVelocity.getY() *
-                                (player.compensatedEntities.getSelf().getRiding() != null && !player.compensatedEntities.getSelf().getRiding().isLivingEntity() ? 0.8 : 1.0));
+                                (riding != null && !riding.isLivingEntity() ? 0.8 : 1.0));
                     }
                 }
             } else if (BlockTags.BEDS.contains(onBlock) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_12)) {
                 if (player.clientVelocity.getY() < 0.0) {
                     player.clientVelocity.setY(-player.clientVelocity.getY() * 0.6600000262260437 *
-                            (player.compensatedEntities.getSelf().getRiding() != null && !player.compensatedEntities.getSelf().getRiding().isLivingEntity() ? 0.8 : 1.0));
+                            (riding != null && !riding.isLivingEntity() ? 0.8 : 1.0));
                 }
             } else {
                 player.clientVelocity.setY(0);

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -736,7 +736,7 @@ public class PredictionEngine {
 
     public boolean canSwimHop(GrimPlayer player) {
         // Boats cannot swim hop, all other living entities should be able to.
-        if (player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT))
+        if (player.compensatedEntities.getSelf().getRiding() != null && player.compensatedEntities.getSelf().getRiding().isBoat())
             return false;
 
         // Vanilla system ->

--- a/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
@@ -690,7 +690,7 @@ public enum CollisionData {
 
     LILYPAD((player, version, data, x, y, z) -> {
         // Boats break lilypads client sided on 1.12- clients.
-        if (player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT) && version.isOlderThanOrEquals(ClientVersion.V_1_12_2))
+        if (player.compensatedEntities.getSelf().getRiding() != null && player.compensatedEntities.getSelf().getRiding().isBoat() && version.isOlderThanOrEquals(ClientVersion.V_1_12_2))
             return NoCollisionBox.INSTANCE;
 
         if (version.isOlderThan(ClientVersion.V_1_9))

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -46,7 +46,7 @@ public class ReachInterpolationData {
             targetLocation.expand(0.03125);
         }
 
-        if (EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT)) {
+        if (entity.isBoat()) {
             interpolationSteps = 10;
         } else if (entity.isMinecart()) {
             interpolationSteps = 5;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
@@ -6,7 +6,7 @@ import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 public abstract class TypedPacketEntity {
 
     private final EntityType type;
-    private final boolean isLiving, isSize, isMinecart, isHorse, isAgeable, isAnimal;
+    private final boolean isLiving, isSize, isMinecart, isHorse, isAgeable, isAnimal, isBoat;
 
     public TypedPacketEntity(EntityType type) {
         this.type = type;
@@ -16,6 +16,7 @@ public abstract class TypedPacketEntity {
         this.isHorse = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_HORSE);
         this.isAgeable = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_AGEABLE);
         this.isAnimal = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_ANIMAL);
+        this.isBoat = EntityTypes.isTypeInstanceOf(type, EntityTypes.BOAT);
     }
 
     public boolean isLivingEntity() {
@@ -40,6 +41,18 @@ public abstract class TypedPacketEntity {
 
     public boolean isAnimal() {
         return isAnimal;
+    }
+
+    public boolean isBoat() {
+        return isBoat;
+    }
+
+    public boolean isPushable() {
+        // Players can only push living entities
+        // Minecarts and boats are the only non-living that can push
+        // Bats, parrots, and armor stands cannot
+        if (type == EntityTypes.ARMOR_STAND || type == EntityTypes.BAT || type == EntityTypes.PARROT) return false;
+        return isLiving || isBoat || isMinecart;
     }
 
     public EntityType getType() {

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -201,7 +201,7 @@ public class CompensatedWorld {
 
     public boolean isNearHardEntity(SimpleCollisionBox playerBox) {
         for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-            if ((EntityTypes.isTypeInstanceOf(entity.getType(), EntityTypes.BOAT) || entity.getType() == EntityTypes.SHULKER) && player.compensatedEntities.getSelf().getRiding() != entity) {
+            if ((entity.isBoat() || entity.getType() == EntityTypes.SHULKER) && player.compensatedEntities.getSelf().getRiding() != entity) {
                 SimpleCollisionBox box = entity.getPossibleCollisionBoxes();
                 if (box.isIntersected(playerBox)) {
                     return true;

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -13,7 +13,6 @@ import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.math.VectorUtils;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.chunk.BaseChunk;
 import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
@@ -428,7 +427,7 @@ public class Collisions {
                     if (blockType == StateTypes.BUBBLE_COLUMN && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13)) {
                         WrappedBlockState blockAbove = player.compensatedWorld.getWrappedBlockStateAt(i, j + 1, k);
 
-                        if (player.compensatedEntities.getSelf().getRiding() != null && EntityTypes.isTypeInstanceOf(player.compensatedEntities.getSelf().getRiding().getType(), EntityTypes.BOAT)) {
+                        if (player.compensatedEntities.getSelf().getRiding() != null && player.compensatedEntities.getSelf().getRiding().isBoat()) {
                             if (!blockAbove.getType().isAir()) {
                                 if (block.isDrag()) {
                                     player.clientVelocity.setY(Math.max(-0.3D, player.clientVelocity.getY() - 0.03D));


### PR DESCRIPTION
Fixes being able to connect a fishing rod to a boat, entering it, and being able to fly around.

`boatCollision` was considering the fishing rod because it's not actually a passenger, I've fixed this by checking for pushable entities only. Also optimised and cleaned up stuff by adding `isBoat` to `TypedPacketEntity`.