### PR TITLE
patch fastbreak

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/FastBreak.java
@@ -144,10 +144,6 @@ public class FastBreak extends Check implements PacketCheck {
 
                 lastFinishBreak = System.currentTimeMillis();
             }
-
-            if (digging.getAction() == DiggingAction.CANCELLED_DIGGING) {
-                targetBlock = null;
-            }
         }
     }
 


### PR DESCRIPTION
players can send a cancel for the block they're mining ([this is vanilla](https://github.com/GrimAnticheat/Grim/blob/2.0/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsZ.java#L90)), I don't think we need to set targetBlock to null on cancel.