### PR TITLE
Attribute rework

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
@@ -49,7 +49,7 @@ public class BadPacketsT extends Check implements PacketCheck {
                 //  27/12/2023 - Dynamic values for more than just one entity type?
                 //  28/12/2023 - Player-only is fine
                 //  30/12/2023 - Expansions differ in 1.9+
-                final float scale = (float) packetEntity.getAttribute(Attributes.GENERIC_SCALE).get();
+                final float scale = (float) packetEntity.getAttributeValue(Attributes.GENERIC_SCALE);
                 if (targetVector.y > (minVerticalDisplacement * scale) && targetVector.y < (maxVerticalDisplacement * scale)
                         && Math.abs(targetVector.x) < (maxHorizontalDisplacement * scale)
                         && Math.abs(targetVector.z) < (maxHorizontalDisplacement * scale)) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -48,7 +49,7 @@ public class BadPacketsT extends Check implements PacketCheck {
                 //  27/12/2023 - Dynamic values for more than just one entity type?
                 //  28/12/2023 - Player-only is fine
                 //  30/12/2023 - Expansions differ in 1.9+
-                final float scale = packetEntity.scale;
+                final float scale = (float) packetEntity.getAttribute(Attributes.GENERIC_SCALE).get();
                 if (targetVector.y > (minVerticalDisplacement * scale) && targetVector.y < (maxVerticalDisplacement * scale)
                         && Math.abs(targetVector.x) < (maxHorizontalDisplacement * scale)
                         && Math.abs(targetVector.z) < (maxHorizontalDisplacement * scale)) {

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -136,7 +136,7 @@ public class Reach extends Check implements PacketCheck {
             if (reachEntity.getType() == EntityTypes.END_CRYSTAL) {
                 targetBox = new SimpleCollisionBox(reachEntity.trackedServerPosition.getPos().subtract(1, 0, 1), reachEntity.trackedServerPosition.getPos().add(1, 2, 1));
             }
-            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get();
+            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_ENTITY_INTERACTION_RANGE);
         }
     }
 
@@ -200,7 +200,7 @@ public class Reach extends Check implements PacketCheck {
         }
 
         // +3 would be 3 + 3 = 6, which is the pre-1.20.5 behaviour, preventing "Missed Hitbox"
-        final double distance = player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get() + 3;
+        final double distance = player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_ENTITY_INTERACTION_RANGE) + 3;
         for (Vector lookVec : possibleLookDirs) {
             for (double eye : player.getPossibleEyeHeights()) {
                 Vector eyePos = new Vector(from.getX(), from.getY() + eye, from.getZ());
@@ -224,7 +224,7 @@ public class Reach extends Check implements PacketCheck {
             if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return "Missed hitbox";
-            } else if (minDistance > player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get()) {
+            } else if (minDistance > player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_ENTITY_INTERACTION_RANGE)) {
                 cancelBuffer = 1;
                 return String.format("%.5f", minDistance) + " blocks";
             } else {

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -24,6 +24,7 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.data.packetentity.dragon.PacketEntityEnderDragonPart;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -135,7 +136,7 @@ public class Reach extends Check implements PacketCheck {
             if (reachEntity.getType() == EntityTypes.END_CRYSTAL) {
                 targetBox = new SimpleCollisionBox(reachEntity.trackedServerPosition.getPos().subtract(1, 0, 1), reachEntity.trackedServerPosition.getPos().add(1, 2, 1));
             }
-            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getEntityInteractRange();
+            return ReachUtils.getMinReachToBox(player, targetBox) > player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get();
         }
     }
 
@@ -199,7 +200,7 @@ public class Reach extends Check implements PacketCheck {
         }
 
         // +3 would be 3 + 3 = 6, which is the pre-1.20.5 behaviour, preventing "Missed Hitbox"
-        final double distance = player.compensatedEntities.getSelf().getEntityInteractRange() + 3;
+        final double distance = player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get() + 3;
         for (Vector lookVec : possibleLookDirs) {
             for (double eye : player.getPossibleEyeHeights()) {
                 Vector eyePos = new Vector(from.getX(), from.getY() + eye, from.getZ());
@@ -223,7 +224,7 @@ public class Reach extends Check implements PacketCheck {
             if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return "Missed hitbox";
-            } else if (minDistance > player.compensatedEntities.getSelf().getEntityInteractRange()) {
+            } else if (minDistance > player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_ENTITY_INTERACTION_RANGE).get()) {
                 cancelBuffer = 1;
                 return String.format("%.5f", minDistance) + " blocks";
             } else {

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/FarPlace.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.math.VectorUtils;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
@@ -34,7 +35,7 @@ public class FarPlace extends BlockPlaceCheck {
 
         // getPickRange() determines this?
         // With 1.20.5+ the new attribute determines creative mode reach using a modifier
-        double maxReach = player.compensatedEntities.getSelf().getBlockInteractRange();
+        double maxReach = player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_BLOCK_INTERACTION_RANGE);
         double threshold = player.getMovementThreshold();
         maxReach += Math.hypot(threshold, threshold);
 

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -8,6 +8,7 @@ import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.Pair;
 import ac.grim.grimac.utils.nmsutil.Ray;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
@@ -94,7 +95,7 @@ public class RotationPlace extends BlockPlaceCheck {
             possibleLookDirs = Collections.singletonList(new Vector3f(player.xRot, player.yRot, 0));
         }
 
-        final double distance = player.compensatedEntities.getSelf().getBlockInteractRange();
+        final double distance = player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_BLOCK_INTERACTION_RANGE);
         for (double d : player.getPossibleEyeHeights()) {
             for (Vector3f lookDir : possibleLookDirs) {
                 // x, y, z are correct for the block placement even after post tick because of code elsewhere

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -24,6 +24,7 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.type.ItemType;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
@@ -781,7 +782,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
         Vector3d startingPos = new Vector3d(player.x, player.y + player.getEyeHeight(), player.z);
         Vector startingVec = new Vector(startingPos.getX(), startingPos.getY(), startingPos.getZ());
         Ray trace = new Ray(player, startingPos.getX(), startingPos.getY(), startingPos.getZ(), player.xRot, player.yRot);
-        final double distance = player.compensatedEntities.getSelf().getBlockInteractRange();
+        final double distance = player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_BLOCK_INTERACTION_RANGE);
         Vector endVec = trace.getPointAtDistance(distance);
         Vector3d endPos = new Vector3d(endVec.getX(), endVec.getY(), endVec.getZ());
 

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -186,14 +186,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 // TODO And there should probably be some attribute holder that we can just call reset() on.
                 if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16) && !this.hasFlag(respawn, KEEP_ATTRIBUTES)) {
                     // Reset attributes if not kept
-                    final PacketEntitySelf self = player.compensatedEntities.getSelf();
-                    self.gravityAttribute = 0.08d;
-                    self.stepHeight = 0.6f;
-                    self.scale = 1.0f;
-                    self.setJumpStrength(0.42f);
-                    self.setBreakSpeedMultiplier(1.0f);
-                    self.setBlockInteractRange(4.5);
-                    self.setEntityInteractRange(3.0);
+                    player.compensatedEntities.getSelf().resetAttributes();
                     player.compensatedEntities.hasSprintingAttributeEnabled = false;
                 }
             });

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -55,9 +55,10 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
 
     private boolean hasFlag(WrapperPlayServerRespawn respawn, byte flag) {
         // This packet was added in 1.16
-        // On versions older than 1.16, via keeps all data.
-        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_16)) {
-            return true;
+        // On versions older than 1.15, via does not keep all data.
+        // https://github.com/ViaVersion/ViaVersion/blob/master/common/src/main/java/com/viaversion/viaversion/protocols/v1_15_2to1_16/rewriter/EntityPacketRewriter1_16.java#L124
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_15)) {
+            return false;
         }
         return (respawn.getKeptData() & flag) != 0;
     }

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -350,14 +350,14 @@ public class GrimPlayer implements GrimUser {
     public float getMaxUpStep() {
         final PacketEntitySelf self = compensatedEntities.getSelf();
         final PacketEntity riding = self.getRiding();
-        if (riding == null) return (float) self.getAttribute(Attributes.GENERIC_STEP_HEIGHT).get();
+        if (riding == null) return (float) self.getAttributeValue(Attributes.GENERIC_STEP_HEIGHT);
 
         if (riding.isBoat()) {
             return 0f;
         }
 
         // Pigs, horses, striders, and other vehicles all have 1 stepping height by default
-        return (float) riding.getAttribute(Attributes.GENERIC_STEP_HEIGHT).get();
+        return (float) riding.getAttributeValue(Attributes.GENERIC_STEP_HEIGHT);
     }
 
     public void sendTransaction() {
@@ -553,7 +553,7 @@ public class GrimPlayer implements GrimUser {
 
     public List<Double> getPossibleEyeHeights() { // We don't return sleeping eye height
         if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_14)) { // Elytra, sneaking (1.14), standing
-            final float scale = (float) compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_SCALE).get();
+            final float scale = (float) compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_SCALE);
             return Arrays.asList(0.4 * scale, 1.27 * scale, 1.62 * scale);
         } else if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) { // Elytra, sneaking, standing
             return Arrays.asList(0.4, 1.54, 1.62);

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -28,6 +28,7 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
@@ -349,14 +350,14 @@ public class GrimPlayer implements GrimUser {
     public float getMaxUpStep() {
         final PacketEntitySelf self = compensatedEntities.getSelf();
         final PacketEntity riding = self.getRiding();
-        if (riding == null) return self.stepHeight;
+        if (riding == null) return (float) self.getAttribute(Attributes.GENERIC_STEP_HEIGHT).get();
 
         if (riding.isBoat()) {
             return 0f;
         }
 
         // Pigs, horses, striders, and other vehicles all have 1 stepping height by default
-        return riding.stepHeight;
+        return (float) riding.getAttribute(Attributes.GENERIC_STEP_HEIGHT).get();
     }
 
     public void sendTransaction() {
@@ -552,7 +553,7 @@ public class GrimPlayer implements GrimUser {
 
     public List<Double> getPossibleEyeHeights() { // We don't return sleeping eye height
         if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_14)) { // Elytra, sneaking (1.14), standing
-            final float scale = compensatedEntities.getSelf().scale;
+            final float scale = (float) compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_SCALE).get();
             return Arrays.asList(0.4 * scale, 1.27 * scale, 1.62 * scale);
         } else if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) { // Elytra, sneaking, standing
             return Arrays.asList(0.4, 1.54, 1.62);

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -445,24 +445,14 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             wasChecked = true;
 
             // Depth strider was added in 1.8
-            final boolean hasAttributes = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21);
-            if (hasAttributes && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
                 player.depthStriderLevel = (float) player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY).get();
             } else {
-                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
-                    player.depthStriderLevel = EnchantmentHelper.getMaximumEnchantLevel(player.getInventory(), EnchantmentTypes.DEPTH_STRIDER, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
-                    if (hasAttributes && PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_21)) {
-                        // This is what via does
-                        player.depthStriderLevel /= 3.0;
-                    }
-                } else {
-                    player.depthStriderLevel = 0;
-                }
+                player.depthStriderLevel = 0;
             }
 
             if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19)) {
-                ItemStack leggings = player.getInventory().getLeggings();
-                player.sneakingSpeedMultiplier = GrimMath.clampFloat(0.3F + (leggings.getEnchantmentLevel(EnchantmentTypes.SWIFT_SNEAK, player.getClientVersion()) * 0.15F), 0f, 1f);
+                player.sneakingSpeedMultiplier = (float) player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_SNEAKING_SPEED).get();
             } else {
                 player.sneakingSpeedMultiplier = 0.3F;
             }

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -190,7 +190,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
                 SimpleCollisionBox interTruePositions = riding.getPossibleCollisionBoxes();
 
                 // We shrink the expanded bounding box to what the packet positions can be, for a smaller box
-                final float scale = (float) riding.getAttribute(Attributes.GENERIC_SCALE).get();
+                final float scale = (float) riding.getAttributeValue(Attributes.GENERIC_SCALE);
                 float width = BoundingBoxSize.getWidth(player, riding) * scale;
                 float height = BoundingBoxSize.getHeight(player, riding) * scale;
                 interTruePositions.expand(-width, 0, -width);
@@ -238,7 +238,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         if (player.isInBed) return;
 
         if (!player.compensatedEntities.getSelf().inVehicle()) {
-            player.speed = player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get();
+            player.speed = player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_MOVEMENT_SPEED);
             if (player.hasGravity != player.playerEntityHasGravity) {
                 player.pointThreeEstimator.updatePlayerGravity();
             }
@@ -444,18 +444,8 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         } else if (riding == null) {
             wasChecked = true;
 
-            // Depth strider was added in 1.8
-            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
-                player.depthStriderLevel = (float) player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY).get();
-            } else {
-                player.depthStriderLevel = 0;
-            }
-
-            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19)) {
-                player.sneakingSpeedMultiplier = (float) player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_SNEAKING_SPEED).get();
-            } else {
-                player.sneakingSpeedMultiplier = 0.3F;
-            }
+            player.depthStriderLevel = (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY);
+            player.sneakingSpeedMultiplier = (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_SNEAKING_SPEED);
 
             // This is wrong and the engine was not designed around stuff like this
             player.verticalCollision = false;

--- a/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -31,7 +31,7 @@ public class PlayerBaseTick {
     }
 
     protected static SimpleCollisionBox getBoundingBoxForPose(GrimPlayer player, Pose pose, double x, double y, double z) {
-        final float scale = (float) player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_SCALE).get();
+        final float scale = (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_SCALE);
         final float width = pose.width * scale;
         final float height = pose.height * scale;
         float radius = width / 2.0F;
@@ -150,7 +150,7 @@ public class PlayerBaseTick {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_16_4)) return;
 
         // The client first desync's this attribute
-        final ValuedAttribute playerSpeed = player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_MOVEMENT_SPEED);
+        final ValuedAttribute playerSpeed = player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get();
         playerSpeed.property().get().getModifiers().removeIf(modifier -> modifier.getUUID().equals(CompensatedEntities.SNOW_MODIFIER_UUID) || modifier.getName().getKey().equals("powder_snow"));
         playerSpeed.recalculate();
 

--- a/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -139,7 +139,7 @@ public class UncertaintyHandler {
             if (entity == null) continue;
 
             SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
-            final float scale = (float) entity.getAttribute(Attributes.GENERIC_SCALE).get();
+            final float scale = (float) entity.getAttributeValue(Attributes.GENERIC_SCALE);
             float width = BoundingBoxSize.getWidth(player, entity) * scale;
             float height = BoundingBoxSize.getHeight(player, entity) * scale;
 

--- a/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -10,6 +10,7 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntityStrider;
 import ac.grim.grimac.utils.lists.EvictingQueue;
 import ac.grim.grimac.utils.nmsutil.BoundingBoxSize;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import org.bukkit.util.Vector;
@@ -138,8 +139,9 @@ public class UncertaintyHandler {
             if (entity == null) continue;
 
             SimpleCollisionBox entityBox = entity.getPossibleCollisionBoxes();
-            float width = BoundingBoxSize.getWidth(player, entity) * entity.scale;
-            float height = BoundingBoxSize.getHeight(player, entity) * entity.scale;
+            final float scale = (float) entity.getAttribute(Attributes.GENERIC_SCALE).get();
+            float width = BoundingBoxSize.getWidth(player, entity) * scale;
+            float height = BoundingBoxSize.getHeight(player, entity) * scale;
 
             // Convert back to coordinates instead of hitbox
             entityBox.maxY -= height;

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -10,6 +10,7 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityStrider;
 import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.nmsutil.*;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import ac.grim.grimac.utils.team.EntityPredicates;
 import ac.grim.grimac.utils.team.TeamHandler;
 import com.github.retrooper.packetevents.PacketEvents;
@@ -324,8 +325,8 @@ public class MovementTicker {
 
     public void livingEntityTravel() {
         double playerGravity = player.compensatedEntities.getSelf().getRiding() == null
-                ? player.compensatedEntities.getSelf().gravityAttribute
-                : player.compensatedEntities.getSelf().getRiding().gravityAttribute;
+                ? player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get()
+                : player.compensatedEntities.getSelf().getRiding().getAttribute(Attributes.GENERIC_GRAVITY).get();
 
         boolean isFalling = player.actualMovement.getY() <= 0.0;
         if (isFalling && player.compensatedEntities.getSlowFallingAmplifier() != null) {
@@ -349,7 +350,7 @@ public class MovementTicker {
             swimFriction = player.isSprinting && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) ? 0.9F : (isSkeletonHorse ? 0.96F : 0.8F);
             float swimSpeed = 0.02F;
 
-            if (player.depthStriderLevel > 3.0F) {
+            if (player.getClientVersion().isOlderThan(ClientVersion.V_1_21) && player.depthStriderLevel > 3.0F) {
                 player.depthStriderLevel = 3.0F;
             }
 
@@ -357,9 +358,16 @@ public class MovementTicker {
                 player.depthStriderLevel *= 0.5F;
             }
 
-            if (player.depthStriderLevel > 0.0F) {
-                swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / 3.0F;
-                swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / 3.0F;
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) {
+                if (player.depthStriderLevel > 0.0F) {
+                    swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel;
+                    swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel;
+                }
+            } else {
+                if (player.depthStriderLevel > 0.0F) {
+                    swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / 3.0F;
+                    swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / 3.0F;
+                }
             }
 
             if (player.compensatedEntities.getDolphinsGraceAmplifier() != null) {

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -358,16 +358,10 @@ public class MovementTicker {
                 player.depthStriderLevel *= 0.5F;
             }
 
-            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) {
-                if (player.depthStriderLevel > 0.0F) {
-                    swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel;
-                    swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel;
-                }
-            } else {
-                if (player.depthStriderLevel > 0.0F) {
-                    swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / 3.0F;
-                    swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / 3.0F;
-                }
+            if (player.depthStriderLevel > 0.0F) {
+                final float divisor = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21) ? 1.0F : 3.0F;
+                swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / divisor;
+                swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / divisor;
             }
 
             if (player.compensatedEntities.getDolphinsGraceAmplifier() != null) {

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -361,7 +361,6 @@ public class MovementTicker {
 
             if (player.depthStriderLevel > 0.0F) {
                 final float divisor = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21) ? 1.0F : 3.0F;
-                Bukkit.broadcastMessage("level: " + player.depthStriderLevel);
                 swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / divisor;
                 swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / divisor;
             }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -21,6 +21,7 @@ import com.github.retrooper.packetevents.protocol.world.states.defaulttags.Block
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 import com.github.retrooper.packetevents.util.Vector3d;
+import org.bukkit.Bukkit;
 import com.viaversion.viaversion.api.Via;
 import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import org.bukkit.util.Vector;
@@ -325,8 +326,8 @@ public class MovementTicker {
 
     public void livingEntityTravel() {
         double playerGravity = player.compensatedEntities.getSelf().getRiding() == null
-                ? player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get()
-                : player.compensatedEntities.getSelf().getRiding().getAttribute(Attributes.GENERIC_GRAVITY).get();
+                ? player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_GRAVITY)
+                : player.compensatedEntities.getSelf().getRiding().getAttributeValue(Attributes.GENERIC_GRAVITY);
 
         boolean isFalling = player.actualMovement.getY() <= 0.0;
         if (isFalling && player.compensatedEntities.getSlowFallingAmplifier() != null) {
@@ -360,6 +361,7 @@ public class MovementTicker {
 
             if (player.depthStriderLevel > 0.0F) {
                 final float divisor = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21) ? 1.0F : 3.0F;
+                Bukkit.broadcastMessage("level: " + player.depthStriderLevel);
                 swimFriction += (0.54600006F - swimFriction) * player.depthStriderLevel / divisor;
                 swimSpeed += (player.speed - swimSpeed) * player.depthStriderLevel / divisor;
             }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerHorse.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerHorse.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.predictionengine.movementtick;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.nmsutil.Collisions;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import org.bukkit.util.Vector;
 
@@ -15,7 +16,7 @@ public class MovementTickerHorse extends MovementTickerLivingVehicle {
 
         if (!horsePacket.hasSaddle) return;
 
-        player.speed = horsePacket.movementSpeedAttribute;
+        player.speed = horsePacket.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get();
 
         // Setup player inputs
         float horizInput = player.vehicleData.vehicleHorizontal * 0.5F;

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerHorse.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerHorse.java
@@ -16,7 +16,7 @@ public class MovementTickerHorse extends MovementTickerLivingVehicle {
 
         if (!horsePacket.hasSaddle) return;
 
-        player.speed = horsePacket.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get();
+        player.speed = horsePacket.getAttributeValue(Attributes.GENERIC_MOVEMENT_SPEED);
 
         // Setup player inputs
         float horizInput = player.vehicleData.vehicleHorizontal * 0.5F;

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerPig.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerPig.java
@@ -14,6 +14,6 @@ public class MovementTickerPig extends MovementTickerRideable {
     @Override
     public float getSteeringSpeed() { // Vanilla multiples by 0.225f
         PacketEntityRideable pig = (PacketEntityRideable) player.compensatedEntities.getSelf().getRiding();
-        return (float) pig.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * 0.225f;
+        return (float) pig.getAttributeValue(Attributes.GENERIC_MOVEMENT_SPEED) * 0.225f;
     }
 }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerPig.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerPig.java
@@ -2,6 +2,7 @@ package ac.grim.grimac.predictionengine.movementtick;
 
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityRideable;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import org.bukkit.util.Vector;
 
 public class MovementTickerPig extends MovementTickerRideable {
@@ -13,6 +14,6 @@ public class MovementTickerPig extends MovementTickerRideable {
     @Override
     public float getSteeringSpeed() { // Vanilla multiples by 0.225f
         PacketEntityRideable pig = (PacketEntityRideable) player.compensatedEntities.getSelf().getRiding();
-        return pig.movementSpeedAttribute * 0.225f;
+        return (float) pig.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * 0.225f;
     }
 }

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerStrider.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerStrider.java
@@ -48,7 +48,7 @@ public class MovementTickerStrider extends MovementTickerRideable {
     @Override
     public float getSteeringSpeed() {
         PacketEntityStrider strider = (PacketEntityStrider) player.compensatedEntities.getSelf().getRiding();
-        return (float) strider.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * (strider.isShaking ? 0.23F : 0.55F);
+        return (float) strider.getAttributeValue(Attributes.GENERIC_MOVEMENT_SPEED) * (strider.isShaking ? 0.23F : 0.55F);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerStrider.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTickerStrider.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.predictionengine.movementtick;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityStrider;
 import ac.grim.grimac.utils.nmsutil.BlockProperties;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.world.states.defaulttags.BlockTags;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.util.Vector3d;
@@ -47,7 +48,7 @@ public class MovementTickerStrider extends MovementTickerRideable {
     @Override
     public float getSteeringSpeed() {
         PacketEntityStrider strider = (PacketEntityStrider) player.compensatedEntities.getSelf().getRiding();
-        return strider.movementSpeedAttribute * (strider.isShaking ? 0.23F : 0.55F);
+        return (float) strider.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * (strider.isShaking ? 0.23F : 0.55F);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -549,7 +549,7 @@ public class PredictionEngine {
         // We can't simulate the player's Y velocity, unknown number of ticks with a gravity change
         // Feel free to simulate all 104857600000000000000000000 possibilities!
         if (!player.pointThreeEstimator.canPredictNextVerticalMovement()) {
-            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get());
+            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_GRAVITY));
         }
 
         // Hidden slime block bounces by missing idle tick and 0.03

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -11,6 +11,7 @@ import ac.grim.grimac.utils.nmsutil.Collisions;
 import ac.grim.grimac.utils.nmsutil.GetBoundingBox;
 import ac.grim.grimac.utils.nmsutil.JumpPower;
 import ac.grim.grimac.utils.nmsutil.Riptide;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import org.bukkit.util.Vector;
@@ -548,7 +549,7 @@ public class PredictionEngine {
         // We can't simulate the player's Y velocity, unknown number of ticks with a gravity change
         // Feel free to simulate all 104857600000000000000000000 possibilities!
         if (!player.pointThreeEstimator.canPredictNextVerticalMovement()) {
-            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().gravityAttribute);
+            minVector.setY(minVector.getY() - player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get());
         }
 
         // Hidden slime block bounces by missing idle tick and 0.03

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
@@ -45,7 +45,7 @@ public class PredictionEngineElytra extends PredictionEngine {
         // So we actually use the player's actual movement to get the gravity/slow falling status
         // However, this is wrong with elytra movement because players can control vertical movement after gravity is calculated
         // Yeah, slow falling needs a refactor in grim.
-        double recalculatedGravity = player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get();
+        double recalculatedGravity = player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_GRAVITY);
         if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null) {
             recalculatedGravity = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5) ? 0.01 : Math.min(recalculatedGravity, 0.01);
         }

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineElytra.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.predictionengine.predictions;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.VectorData;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import org.bukkit.util.Vector;
 
@@ -44,7 +45,7 @@ public class PredictionEngineElytra extends PredictionEngine {
         // So we actually use the player's actual movement to get the gravity/slow falling status
         // However, this is wrong with elytra movement because players can control vertical movement after gravity is calculated
         // Yeah, slow falling needs a refactor in grim.
-        double recalculatedGravity = player.compensatedEntities.getSelf().gravityAttribute;
+        double recalculatedGravity = player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_GRAVITY).get();
         if (player.clientVelocity.getY() <= 0 && player.compensatedEntities.getSlowFallingAmplifier() != null) {
             recalculatedGravity = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5) ? 0.01 : Math.min(recalculatedGravity, 0.01);
         }

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/rideable/PredictionEngineRideableUtils.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/rideable/PredictionEngineRideableUtils.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.predictionengine.predictions.PredictionEngineNormal;
 import ac.grim.grimac.utils.data.VectorData;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.nmsutil.JumpPower;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class PredictionEngineRideableUtils {
         //
         // There's a float/double error causing 1e-8 imprecision if anyone wants to debug it
         if (player.vehicleData.horseJump > 0.0F && !player.vehicleData.horseJumping && player.lastOnGround) {
-            double d0 = horse.jumpStrength * player.vehicleData.horseJump * JumpPower.getPlayerJumpFactor(player);
+            double d0 = horse.getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get() * player.vehicleData.horseJump * JumpPower.getPlayerJumpFactor(player);
             double d1;
 
             // This doesn't even work because vehicle jump boost has (likely) been

--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/rideable/PredictionEngineRideableUtils.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/rideable/PredictionEngineRideableUtils.java
@@ -32,7 +32,7 @@ public class PredictionEngineRideableUtils {
         //
         // There's a float/double error causing 1e-8 imprecision if anyone wants to debug it
         if (player.vehicleData.horseJump > 0.0F && !player.vehicleData.horseJumping && player.lastOnGround) {
-            double d0 = horse.getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get() * player.vehicleData.horseJump * JumpPower.getPlayerJumpFactor(player);
+            double d0 = horse.getAttributeValue(Attributes.GENERIC_JUMP_STRENGTH) * player.vehicleData.horseJump * JumpPower.getPlayerJumpFactor(player);
             double d1;
 
             // This doesn't even work because vehicle jump boost has (likely) been

--- a/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
+++ b/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
@@ -587,7 +587,7 @@ public class BlockPlace {
                 for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
                     SimpleCollisionBox interpBox = entity.getPossibleCollisionBoxes();
 
-                    final double scale = entity.getAttribute(Attributes.GENERIC_SCALE).get();
+                    final double scale = entity.getAttributeValue(Attributes.GENERIC_SCALE);
                     double width = BoundingBoxSize.getWidth(player, entity) * scale;
                     double height = BoundingBoxSize.getHeight(player, entity) * scale;
                     double interpWidth = Math.max(interpBox.maxX - interpBox.minX, interpBox.maxZ - interpBox.minZ);
@@ -669,7 +669,7 @@ public class BlockPlace {
         SimpleCollisionBox box = new SimpleCollisionBox(getPlacedAgainstBlockLocation());
         Vector look = ReachUtils.getLook(player, player.xRot, player.yRot);
 
-        final double distance = player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_BLOCK_INTERACTION_RANGE).get() + 3;
+        final double distance = player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_BLOCK_INTERACTION_RANGE) + 3;
         Vector eyePos = new Vector(player.x, player.y + player.getEyeHeight(), player.z);
         Vector endReachPos = eyePos.clone().add(new Vector(look.getX() * distance, look.getY() * distance, look.getZ() * distance));
         Vector intercept = ReachUtils.calculateIntercept(box, eyePos, endReachPos).getFirst();

--- a/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
+++ b/src/main/java/ac/grim/grimac/utils/anticheat/update/BlockPlace.java
@@ -18,6 +18,7 @@ import ac.grim.grimac.utils.nmsutil.Materials;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
@@ -586,8 +587,9 @@ public class BlockPlace {
                 for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
                     SimpleCollisionBox interpBox = entity.getPossibleCollisionBoxes();
 
-                    double width = BoundingBoxSize.getWidth(player, entity) * entity.scale;
-                    double height = BoundingBoxSize.getHeight(player, entity) * entity.scale;
+                    final double scale = entity.getAttribute(Attributes.GENERIC_SCALE).get();
+                    double width = BoundingBoxSize.getWidth(player, entity) * scale;
+                    double height = BoundingBoxSize.getHeight(player, entity) * scale;
                     double interpWidth = Math.max(interpBox.maxX - interpBox.minX, interpBox.maxZ - interpBox.minZ);
                     double interpHeight = interpBox.maxY - interpBox.minY;
 
@@ -667,7 +669,7 @@ public class BlockPlace {
         SimpleCollisionBox box = new SimpleCollisionBox(getPlacedAgainstBlockLocation());
         Vector look = ReachUtils.getLook(player, player.xRot, player.yRot);
 
-        final double distance = player.compensatedEntities.getSelf().getEntityInteractRange() + 3;
+        final double distance = player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_BLOCK_INTERACTION_RANGE).get() + 3;
         Vector eyePos = new Vector(player.x, player.y + player.getEyeHeight(), player.z);
         Vector endReachPos = eyePos.clone().add(new Vector(look.getX() * distance, look.getY() * distance, look.getZ() * distance));
         Vector intercept = ReachUtils.calculateIntercept(box, eyePos, endReachPos).getFirst();

--- a/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
+++ b/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
@@ -1,0 +1,90 @@
+package ac.grim.grimac.utils.data.attribute;
+
+import ac.grim.grimac.utils.math.GrimMath;
+import com.github.retrooper.packetevents.protocol.attribute.Attribute;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
+
+import java.util.List;
+import java.util.Optional;
+
+import static ac.grim.grimac.utils.latency.CompensatedEntities.SPRINTING_MODIFIER_UUID;
+
+public final class ValuedAttribute {
+
+    private final Attribute attribute;
+    // Attribute limits defined by https://minecraft.wiki/w/Attribute
+    // These seem to be clamped on the client, but not the server
+    private final double min, max;
+
+    private WrapperPlayServerUpdateAttributes.Property lastProperty;
+    private final double defaultValue;
+    private double value;
+
+    private ValuedAttribute(Attribute attribute, double defaultValue, double min, double max) {
+        if (defaultValue < min || defaultValue > max) {
+            throw new IllegalArgumentException("Default value must be between min and max!");
+        }
+
+        this.attribute = attribute;
+        this.defaultValue = value;
+        this.value = defaultValue;
+        this.min = min;
+        this.max = max;
+    }
+
+    public static ValuedAttribute ranged(Attribute attribute, double defaultValue, double min, double max) {
+        return new ValuedAttribute(attribute, defaultValue, min, max);
+    }
+
+    public Attribute attribute() {
+        return attribute;
+    }
+
+    public void reset() {
+        this.value = defaultValue;
+    }
+
+    public double get() {
+        return value;
+    }
+
+    public void override(double value) {
+        this.value = value;
+    }
+
+    @Deprecated // Avoid using this, it only exists for special cases
+    public Optional<WrapperPlayServerUpdateAttributes.Property> property() {
+        return Optional.ofNullable(lastProperty);
+    }
+
+    public void recalculate() {
+        with(lastProperty);
+    }
+
+    public double with(WrapperPlayServerUpdateAttributes.Property property) {
+        double d0 = property.getValue();
+
+        List<WrapperPlayServerUpdateAttributes.PropertyModifier> modifiers = property.getModifiers();
+        modifiers.removeIf(modifier -> modifier.getUUID().equals(SPRINTING_MODIFIER_UUID) || modifier.getName().getKey().equals("sprinting"));
+
+        for (WrapperPlayServerUpdateAttributes.PropertyModifier attributemodifier : modifiers) {
+            if (attributemodifier.getOperation() == WrapperPlayServerUpdateAttributes.PropertyModifier.Operation.ADDITION)
+                d0 += attributemodifier.getAmount();
+        }
+
+        double d1 = d0;
+
+        for (WrapperPlayServerUpdateAttributes.PropertyModifier attributemodifier : modifiers) {
+            if (attributemodifier.getOperation() == WrapperPlayServerUpdateAttributes.PropertyModifier.Operation.MULTIPLY_BASE)
+                d1 += d0 * attributemodifier.getAmount();
+        }
+
+        for (WrapperPlayServerUpdateAttributes.PropertyModifier attributemodifier : modifiers) {
+            if (attributemodifier.getOperation() == WrapperPlayServerUpdateAttributes.PropertyModifier.Operation.MULTIPLY_TOTAL)
+                d1 *= 1.0D + attributemodifier.getAmount();
+        }
+
+        this.lastProperty = property;
+        return this.value = GrimMath.clampFloat((float) d1, (float) min, (float) max);
+    }
+}

--- a/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
+++ b/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
@@ -37,7 +37,7 @@ public final class ValuedAttribute {
         }
 
         this.attribute = attribute;
-        this.defaultValue = value;
+        this.defaultValue = defaultValue;
         this.value = defaultValue;
         this.min = min;
         this.max = max;

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -92,6 +92,7 @@ public class PacketEntity extends TypedPacketEntity {
     }
 
     public Optional<ValuedAttribute> getAttribute(Attribute attribute) {
+        if (attribute == null) return Optional.empty();
         return Optional.ofNullable(attributeMap.get(attribute));
     }
 

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -96,9 +96,15 @@ public class PacketEntity extends TypedPacketEntity {
         return Optional.ofNullable(attributeMap.get(attribute));
     }
 
+    public void setAttribute(Attribute attribute, double value) {
+        ValuedAttribute property = getAttribute(attribute).orElse(null);
+        if (property == null) throw new IllegalArgumentException("Cannot set attribute " + attribute.getName() + " for entity " + getType().getName().toString() + "!");
+        property.override(value);
+    }
+
     public double getAttributeValue(Attribute attribute) {
         return getAttribute(attribute).map(ValuedAttribute::get)
-                .orElseThrow(() -> new IllegalArgumentException("No such attribute exists on entity " + getType().getName().toString() + "!"));
+                .orElseThrow(() -> new IllegalArgumentException("Cannot get attribute " + attribute.getName() + " for entity " + getType().getName().toString() + "!"));
     }
 
     public void resetAttributes() {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
@@ -13,8 +13,8 @@ public class PacketEntityCamel extends PacketEntityHorse {
     public PacketEntityCamel(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
 
-        getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get().override(0.42f);
-        getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.09f);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.5f);
+        setAttribute(Attributes.GENERIC_JUMP_STRENGTH, 0.42f);
+        setAttribute(Attributes.GENERIC_MOVEMENT_SPEED, 0.09f);
+        setAttribute(Attributes.GENERIC_STEP_HEIGHT, 1.5f);
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
@@ -13,8 +13,8 @@ public class PacketEntityCamel extends PacketEntityHorse {
     public PacketEntityCamel(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
 
-        getAttribute(Attributes.GENERIC_JUMP_STRENGTH).override(0.42f);
-        getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.09f);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.5f);
+        getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get().override(0.42f);
+        getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.09f);
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.5f);
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityCamel.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.data.packetentity;
 
 import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 
 import java.util.UUID;
@@ -12,9 +13,8 @@ public class PacketEntityCamel extends PacketEntityHorse {
     public PacketEntityCamel(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
 
-        jumpStrength = 0.42F;
-        movementSpeedAttribute = 0.09f;
-        stepHeight = 1.5f;
+        getAttribute(Attributes.GENERIC_JUMP_STRENGTH).override(0.42f);
+        getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.09f);
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.5f);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
@@ -17,19 +17,19 @@ public class PacketEntityHorse extends PacketEntityTrackXRot {
 
     public PacketEntityHorse(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.0f);
+        setAttribute(Attributes.GENERIC_STEP_HEIGHT, 1.0f);
 
         final boolean preAttribute = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5);
         trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_JUMP_STRENGTH, 0.7, 0, preAttribute ? 2 : 32));
         trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.225f, 0, 1024));
 
         if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CHESTED_HORSE)) {
-            getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get().override(0.5);
-            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.175f);
+            setAttribute(Attributes.GENERIC_JUMP_STRENGTH, 0.5);
+            setAttribute(Attributes.GENERIC_MOVEMENT_SPEED, 0.175f);
         }
 
         if (type == EntityTypes.ZOMBIE_HORSE || type == EntityTypes.SKELETON_HORSE) {
-            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.2f);
+            setAttribute(Attributes.GENERIC_MOVEMENT_SPEED, 0.2f);
         }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
@@ -17,19 +17,19 @@ public class PacketEntityHorse extends PacketEntityTrackXRot {
 
     public PacketEntityHorse(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.0f);
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.0f);
 
         final boolean preAttribute = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5);
-        attributeMap.put(Attributes.GENERIC_JUMP_STRENGTH, ValuedAttribute.ranged(Attributes.GENERIC_JUMP_STRENGTH, 0.7, 0, preAttribute ? 2 : 32));
-        attributeMap.put(Attributes.GENERIC_MOVEMENT_SPEED, ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.225f, 0, 1024));
+        trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_JUMP_STRENGTH, 0.7, 0, preAttribute ? 2 : 32));
+        trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.225f, 0, 1024));
 
         if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CHESTED_HORSE)) {
-            getAttribute(Attributes.GENERIC_JUMP_STRENGTH).override(0.5);
-            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.175f);
+            getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get().override(0.5);
+            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.175f);
         }
 
         if (type == EntityTypes.ZOMBIE_HORSE || type == EntityTypes.SKELETON_HORSE) {
-            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.2f);
+            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().override(0.2f);
         }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityHorse.java
@@ -1,29 +1,35 @@
 package ac.grim.grimac.utils.data.packetentity;
 
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.data.attribute.ValuedAttribute;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 
 import java.util.UUID;
 
 public class PacketEntityHorse extends PacketEntityTrackXRot {
+
     public boolean isRearing = false;
     public boolean hasSaddle = false;
     public boolean isTame = false;
-    public double jumpStrength = 0.7;
-    public float movementSpeedAttribute = 0.225f;
 
     public PacketEntityHorse(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z, float xRot) {
         super(player, uuid, type, x, y, z, xRot);
-        this.stepHeight = 1.0f;
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.0f);
+
+        final boolean preAttribute = player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5);
+        attributeMap.put(Attributes.GENERIC_JUMP_STRENGTH, ValuedAttribute.ranged(Attributes.GENERIC_JUMP_STRENGTH, 0.7, 0, preAttribute ? 2 : 32));
+        attributeMap.put(Attributes.GENERIC_MOVEMENT_SPEED, ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.225f, 0, 1024));
 
         if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CHESTED_HORSE)) {
-            jumpStrength = 0.5;
-            movementSpeedAttribute = 0.175f;
+            getAttribute(Attributes.GENERIC_JUMP_STRENGTH).override(0.5);
+            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.175f);
         }
 
         if (type == EntityTypes.ZOMBIE_HORSE || type == EntityTypes.SKELETON_HORSE) {
-            movementSpeedAttribute = 0.2f;
+            getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).override(0.2f);
         }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
@@ -15,7 +15,7 @@ public class PacketEntityRideable extends PacketEntity {
 
     public PacketEntityRideable(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z) {
         super(player, uuid, type, x, y, z);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.0f);
-        attributeMap.put(Attributes.GENERIC_MOVEMENT_SPEED, ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024));
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.0f);
+        trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024));
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
@@ -15,7 +15,7 @@ public class PacketEntityRideable extends PacketEntity {
 
     public PacketEntityRideable(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z) {
         super(player, uuid, type, x, y, z);
-        getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(1.0f);
+        setAttribute(Attributes.GENERIC_STEP_HEIGHT, 1.0f);
         trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024));
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntityRideable.java
@@ -1,6 +1,8 @@
 package ac.grim.grimac.utils.data.packetentity;
 
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.data.attribute.ValuedAttribute;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 
 import java.util.UUID;
@@ -11,10 +13,9 @@ public class PacketEntityRideable extends PacketEntity {
     public int boostTimeMax = 0;
     public int currentBoostTime = 0;
 
-    public float movementSpeedAttribute = 0.1f;
-
     public PacketEntityRideable(GrimPlayer player, UUID uuid, EntityType type, double x, double y, double z) {
         super(player, uuid, type, x, y, z);
-        this.stepHeight = 1.0f;
+        getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(1.0f);
+        attributeMap.put(Attributes.GENERIC_MOVEMENT_SPEED, ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024));
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -56,6 +56,8 @@ public class PacketEntitySelf extends PacketEntity {
                 .requiredVersion(player, ClientVersion.V_1_20_5));
         trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_MINING_EFFICIENCY, 0, 0, 1024)
                 .requiredVersion(player, ClientVersion.V_1_21));
+        trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_SUBMERGED_MINING_SPEED, 0.2, 0, 20)
+                .requiredVersion(player, ClientVersion.V_1_21));
         trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_ENTITY_INTERACTION_RANGE, 3, 0, 64)
                 .requiredVersion(player, ClientVersion.V_1_20_5));
         trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_BLOCK_INTERACTION_RANGE, 4.5, 0, 64)

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -28,17 +28,6 @@ public class PacketEntitySelf extends PacketEntity {
     @Setter
     int opLevel;
 
-    public double getBlockInteractRange() {
-        // Server versions older than 1.20.5 don't send the attribute, if the player is in creative then assume legacy max reach distance.
-        // Or if they are on a client version older than 1.20.5.
-        if (player.gamemode == GameMode.CREATIVE
-                && (player.getClientVersion().isOlderThan(ClientVersion.V_1_20_5)
-                    || PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_20_5))) {
-            return 5.0;
-        }
-        return getAttributeValue(Attributes.PLAYER_BLOCK_INTERACTION_RANGE);
-    }
-
     public PacketEntitySelf(GrimPlayer player) {
         super(player, EntityTypes.PLAYER);
         this.player = player;
@@ -70,6 +59,15 @@ public class PacketEntitySelf extends PacketEntity {
         trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_ENTITY_INTERACTION_RANGE, 3, 0, 64)
                 .requiredVersion(player, ClientVersion.V_1_20_5));
         trackAttribute(ValuedAttribute.ranged(Attributes.PLAYER_BLOCK_INTERACTION_RANGE, 4.5, 0, 64)
+                .withGetRewriter(value -> {
+                    // Server versions older than 1.20.5 don't send the attribute, if the player is in creative then assume legacy max reach distance.
+                    if (player.gamemode == GameMode.CREATIVE
+                            && PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_20_5)) {
+                        return 5.0;
+                    }
+                    // < 1.20.5 is unchanged due to requiredVersion, otherwise controlled by the server
+                    return value;
+                })
                 .requiredVersion(player, ClientVersion.V_1_20_5));
         trackAttribute(ValuedAttribute.ranged(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY, 0, 0, 1)
                 .withGetRewriter(value -> {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -3,8 +3,10 @@ package ac.grim.grimac.utils.data.packetentity;
 import ac.grim.grimac.checks.impl.movement.NoSlowE;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
+import ac.grim.grimac.utils.data.attribute.ValuedAttribute;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
@@ -17,18 +19,11 @@ import lombok.Setter;
 import java.util.ArrayList;
 
 public class PacketEntitySelf extends PacketEntity {
-    public WrapperPlayServerUpdateAttributes.Property playerSpeed = new WrapperPlayServerUpdateAttributes.Property("MOVEMENT_SPEED", 0.1f, new ArrayList<>());
 
     private final GrimPlayer player;
     @Getter
     @Setter
     int opLevel;
-    @Getter
-    @Setter
-    float jumpStrength = 0.42f;
-    @Getter
-    @Setter
-    double breakSpeedMultiplier = 1.0, entityInteractRange = 3, blockInteractRange = 4.5;
 
     public double getBlockInteractRange() {
         // Server versions older than 1.20.5 don't send the attribute, if the player is in creative then assume legacy max reach distance.
@@ -38,27 +33,32 @@ public class PacketEntitySelf extends PacketEntity {
                     || PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_20_5))) {
             return 5.0;
         }
-        return blockInteractRange;
+        return attributeMap.get(Attributes.PLAYER_BLOCK_INTERACTION_RANGE).get();
     }
 
     public PacketEntitySelf(GrimPlayer player) {
         super(EntityTypes.PLAYER);
         this.player = player;
         if (player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) {
-            this.stepHeight = 0.5f;
+            getAttribute(Attributes.GENERIC_STEP_HEIGHT).override(0.5f);
         }
+
+        final ValuedAttribute movementSpeed = ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024);
+        movementSpeed.with(new WrapperPlayServerUpdateAttributes.Property("MOVEMENT_SPEED", 0.1f, new ArrayList<>()));
+        attributeMap.put(Attributes.GENERIC_MOVEMENT_SPEED, movementSpeed);
+        attributeMap.put(Attributes.GENERIC_JUMP_STRENGTH, ValuedAttribute.ranged(Attributes.GENERIC_JUMP_STRENGTH, 0.42f, 0, 32));
+        attributeMap.put(Attributes.PLAYER_BLOCK_BREAK_SPEED, ValuedAttribute.ranged(Attributes.PLAYER_BLOCK_BREAK_SPEED, 1.0, 0, 1024));
+        attributeMap.put(Attributes.PLAYER_ENTITY_INTERACTION_RANGE, ValuedAttribute.ranged(Attributes.PLAYER_ENTITY_INTERACTION_RANGE, 3, 0, 64));
+        attributeMap.put(Attributes.PLAYER_BLOCK_INTERACTION_RANGE, ValuedAttribute.ranged(Attributes.PLAYER_BLOCK_INTERACTION_RANGE, 4.5, 0, 64));
+        attributeMap.put(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY, ValuedAttribute.ranged(Attributes.GENERIC_WATER_MOVEMENT_EFFICIENCY, 0, 0, 1));
+        attributeMap.put(Attributes.PLAYER_SNEAKING_SPEED, ValuedAttribute.ranged(Attributes.PLAYER_SNEAKING_SPEED, 0.3, 0, 1));
     }
 
     public PacketEntitySelf(GrimPlayer player, PacketEntitySelf old) {
         super(EntityTypes.PLAYER);
         this.player = player;
         this.opLevel = old.opLevel;
-        this.jumpStrength = old.jumpStrength;
-        this.gravityAttribute = old.gravityAttribute;
-        this.entityInteractRange = old.entityInteractRange;
-        this.blockInteractRange = old.blockInteractRange;
-        this.scale = old.scale;
-        this.stepHeight = old.stepHeight;
+        this.attributeMap.putAll(old.attributeMap);
     }
 
     public boolean inVehicle() {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -44,7 +44,7 @@ public class PacketEntitySelf extends PacketEntity {
     protected void initAttributes(GrimPlayer player) {
         super.initAttributes(player);
         if (player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) {
-            getAttribute(Attributes.GENERIC_STEP_HEIGHT).get().override(0.5f);
+            setAttribute(Attributes.GENERIC_STEP_HEIGHT, 0.5f);
         }
 
         final ValuedAttribute movementSpeed = ValuedAttribute.ranged(Attributes.GENERIC_MOVEMENT_SPEED, 0.1f, 0, 1024);

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -127,17 +127,17 @@ public class CompensatedEntities {
 
                     // The server can set the player's sprinting attribute
                     hasSprintingAttributeEnabled = found;
-                    player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).with(snapshotWrapper);
+                    player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().with(snapshotWrapper);
                     continue;
                 }
 
-                final ValuedAttribute valuedAttribute = player.compensatedEntities.getSelf().getAttribute(attribute);
-                if (valuedAttribute == null) {
+                final Optional<ValuedAttribute> valuedAttribute = player.compensatedEntities.getSelf().getAttribute(attribute);
+                if (!valuedAttribute.isPresent()) {
                     // Not an attribute we want to track
                     continue;
                 }
 
-                valuedAttribute.with(snapshotWrapper);
+                valuedAttribute.get().with(snapshotWrapper);
             }
             return;
         }
@@ -148,24 +148,24 @@ public class CompensatedEntities {
         if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_20_5)) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
                 final Attribute attribute = snapshotWrapper.getAttribute();
-                final ValuedAttribute valuedAttribute = entity.getAttribute(attribute);
-                if (valuedAttribute == null) {
+                final Optional<ValuedAttribute> valuedAttribute = entity.getAttribute(attribute);
+                if (!valuedAttribute.isPresent()) {
                     // Not an attribute we want to track
                     continue;
                 }
 
-                valuedAttribute.with(snapshotWrapper);
+                valuedAttribute.get().with(snapshotWrapper);
             }
         }
 
         if (entity instanceof PacketEntityHorse) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
                 if (snapshotWrapper.getKey().toUpperCase().contains("MOVEMENT")) {
-                    entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).with(snapshotWrapper);
+                    entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().with(snapshotWrapper);
                 }
 
                 if (snapshotWrapper.getKey().toUpperCase().contains("JUMP")) {
-                    entity.getAttribute(Attributes.GENERIC_JUMP_STRENGTH).with(snapshotWrapper);
+                    entity.getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get().with(snapshotWrapper);
                 }
             }
         }
@@ -173,7 +173,7 @@ public class CompensatedEntities {
         if (entity instanceof PacketEntityRideable) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
                 if (snapshotWrapper.getKey().toUpperCase().contains("MOVEMENT")) {
-                    entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).with(snapshotWrapper);
+                    entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().with(snapshotWrapper);
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -160,6 +160,7 @@ public class CompensatedEntities {
 
         if (entity instanceof PacketEntityHorse) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
+                if (snapshotWrapper.getAttribute() == null) continue;
                 if (snapshotWrapper.getKey().toUpperCase().contains("MOVEMENT")) {
                     entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().with(snapshotWrapper);
                 }
@@ -172,6 +173,7 @@ public class CompensatedEntities {
 
         if (entity instanceof PacketEntityRideable) {
             for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
+                if (snapshotWrapper.getAttribute() == null) continue;
                 if (snapshotWrapper.getKey().toUpperCase().contains("MOVEMENT")) {
                     entity.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get().with(snapshotWrapper);
                 }

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -137,8 +137,14 @@ public class CompensatedEntities {
         if (entity == null) return;
 
         for (WrapperPlayServerUpdateAttributes.Property snapshotWrapper : objects) {
-            final Attribute attribute = snapshotWrapper.getAttribute();
+            Attribute attribute = snapshotWrapper.getAttribute();
             if (attribute == null) continue; // TODO: Warn if this happens? Either modded server or bug in packetevents.
+
+            // Rewrite horse.jumpStrength -> modern equivalent
+            if (attribute == Attributes.HORSE_JUMP_STRENGTH) {
+                attribute = Attributes.GENERIC_JUMP_STRENGTH;
+            }
+
             final Optional<ValuedAttribute> valuedAttribute = entity.getAttribute(attribute);
             if (!valuedAttribute.isPresent()) {
                 // Not an attribute we want to track

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -4,6 +4,7 @@ import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.inventory.EnchantmentHelper;
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
@@ -116,7 +117,7 @@ public class BlockBreakSpeed {
             isCorrectToolForDrop = block.getType() == StateTypes.COBWEB;
         }
 
-        speedMultiplier *= (float) player.compensatedEntities.getSelf().getBreakSpeedMultiplier();
+        speedMultiplier *= (float) player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_BLOCK_BREAK_SPEED).get();
 
         if (speedMultiplier > 1.0f) {
             int digSpeed = tool.getEnchantmentLevel(EnchantmentTypes.BLOCK_EFFICIENCY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -117,14 +117,16 @@ public class BlockBreakSpeed {
             isCorrectToolForDrop = block.getType() == StateTypes.COBWEB;
         }
 
-        speedMultiplier *= (float) player.compensatedEntities.getSelf().getAttribute(Attributes.PLAYER_BLOCK_BREAK_SPEED).get();
-
         if (speedMultiplier > 1.0f) {
+            speedMultiplier += (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_MINING_EFFICIENCY);
+
             int digSpeed = tool.getEnchantmentLevel(EnchantmentTypes.BLOCK_EFFICIENCY, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
             if (digSpeed > 0) {
                 speedMultiplier += digSpeed * digSpeed + 1;
             }
         }
+
+        speedMultiplier *= (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.PLAYER_BLOCK_BREAK_SPEED);
 
         Integer digSpeed = player.compensatedEntities.getPotionLevelForPlayer(PotionTypes.HASTE);
         Integer conduit = player.compensatedEntities.getPotionLevelForPlayer(PotionTypes.CONDUIT_POWER);

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityStrider;
 import ac.grim.grimac.utils.math.GrimMath;
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -31,7 +32,7 @@ public class BlockProperties {
             if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityStrider) {
                 PacketEntityStrider strider = (PacketEntityStrider) player.compensatedEntities.getSelf().getRiding();
                 // Vanilla multiplies by 0.1 to calculate speed
-                return strider.movementSpeedAttribute * (strider.isShaking ? 0.66F : 1.0F) * 0.1f;
+                return (float) strider.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * (strider.isShaking ? 0.66F : 1.0F) * 0.1f;
             }
         }
 

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
@@ -32,7 +32,7 @@ public class BlockProperties {
             if (player.compensatedEntities.getSelf().getRiding() instanceof PacketEntityStrider) {
                 PacketEntityStrider strider = (PacketEntityStrider) player.compensatedEntities.getSelf().getRiding();
                 // Vanilla multiplies by 0.1 to calculate speed
-                return (float) strider.getAttribute(Attributes.GENERIC_MOVEMENT_SPEED).get() * (strider.isShaking ? 0.66F : 1.0F) * 0.1f;
+                return (float) strider.getAttributeValue(Attributes.GENERIC_MOVEMENT_SPEED) * (strider.isShaking ? 0.66F : 1.0F) * 0.1f;
             }
         }
 

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.utils.nmsutil;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 
 public class GetBoundingBox {
     public static SimpleCollisionBox getCollisionBoxForPlayer(GrimPlayer player, double centerX, double centerY, double centerZ) {
@@ -34,7 +35,8 @@ public class GetBoundingBox {
     }
 
     public static SimpleCollisionBox getBoundingBoxFromPosAndSize(PacketEntity entity, double centerX, double minY, double centerZ, float width, float height) {
-        return getBoundingBoxFromPosAndSizeRaw(centerX, minY, centerZ, width * entity.scale, height * entity.scale);
+        final float scale = (float) entity.getAttribute(Attributes.GENERIC_SCALE).get();
+        return getBoundingBoxFromPosAndSizeRaw(centerX, minY, centerZ, width * scale, height * scale);
     }
 
     public static SimpleCollisionBox getBoundingBoxFromPosAndSizeRaw(double centerX, double minY, double centerZ, float width, float height) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -35,7 +35,7 @@ public class GetBoundingBox {
     }
 
     public static SimpleCollisionBox getBoundingBoxFromPosAndSize(PacketEntity entity, double centerX, double minY, double centerZ, float width, float height) {
-        final float scale = (float) entity.getAttribute(Attributes.GENERIC_SCALE).get();
+        final float scale = (float) entity.getAttributeValue(Attributes.GENERIC_SCALE);
         return getBoundingBoxFromPosAndSizeRaw(centerX, minY, centerZ, width * scale, height * scale);
     }
 

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.nmsutil;
 
 import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.util.Vector3d;
 import org.bukkit.util.Vector;
@@ -24,7 +25,7 @@ public class JumpPower {
     }
 
     public static float getJumpPower(GrimPlayer player) {
-        return player.compensatedEntities.getSelf().getJumpStrength() * getPlayerJumpFactor(player);
+        return (float) player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get() * getPlayerJumpFactor(player);
     }
 
     public static float getPlayerJumpFactor(GrimPlayer player) {

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/JumpPower.java
@@ -25,7 +25,7 @@ public class JumpPower {
     }
 
     public static float getJumpPower(GrimPlayer player) {
-        return (float) player.compensatedEntities.getSelf().getAttribute(Attributes.GENERIC_JUMP_STRENGTH).get() * getPlayerJumpFactor(player);
+        return (float) player.compensatedEntities.getSelf().getAttributeValue(Attributes.GENERIC_JUMP_STRENGTH) * getPlayerJumpFactor(player);
     }
 
     public static float getPlayerJumpFactor(GrimPlayer player) {


### PR DESCRIPTION
This rewrites the attribute system and also moves Grim towards using the attribute system more widely instead of manually checking client versions everywhere. 

Attributes have a version requirement, if the player is below a version where that attribute exists then changes sent by the server will be ignored. They also have a get rewriter, this allows modification of the attribute value before being returned, which allows for contextual stuff like checking the player's version.

Fixes #1583

Tested on 1.20.6 and 1.21 server and clients with via.

Latest build: https://github.com/GrimAnticheat/Grim/actions/runs/10333304179/artifacts/1798102852
