### PR TITLE
Add a check to prevent placing block while looking at a wrong block face

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -32,6 +32,12 @@ public class CorrectPlace extends BlockPlaceCheck {
 
         double diffY = player.y - event.getPlacedBlockPos().toVector3d().getY();
 
+        // player is too distant from the block and he isn't placing a block above him but like 2 blocks below
+        // ^ this isn't related to scaffold cheat. Scaffold cheat place a block below you
+        if (diffY > 2) {
+            return;
+        }
+
         double adjustedPitch = 2.33d * diffY;
 
         if (player.yRot < 80.97d + adjustedPitch && player.yRot > 74.5 - adjustedPitch) return;

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -28,7 +28,7 @@ public class CorrectPlace extends BlockPlaceCheck {
         Vector3f cursor = event.getCursor();
 
         // player is looking at the end of block (at left or right), this won't affect the center
-        if ((cursor.getX() < 0.2 && cursor.getX() > 0.8) || (cursor.getZ() < 0.2 && cursor.getZ() > 0.8)) return;
+        if ((cursor.getX() < 0.2 || cursor.getX() > 0.8) || (cursor.getZ() < 0.2 || cursor.getZ() > 0.8)) return;
 
         double diffY = player.y - event.getPlacedBlockPos().toVector3d().getY();
 

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -4,6 +4,7 @@ import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
+import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.util.Vector3i;
@@ -13,14 +14,13 @@ public class CorrectPlace extends BlockPlaceCheck {
 
     private Vector3i previousBlockPlaced = null;
 
-    private double maxPitch = 0; // when player is Jumping can place a block with a 85.4
-
     public CorrectPlace(GrimPlayer player) {
         super(player);
     }
 
     @Override
     public void onBlockPlace(BlockPlace event) {
+        if (player.getInventory().inventory.getHeldItem().getType().equals(ItemTypes.AIR)) return;
         if (player.y < event.getPlacedBlockPos().getY()) return;
 
         Vector3f cursor = event.getCursor();
@@ -30,9 +30,9 @@ public class CorrectPlace extends BlockPlaceCheck {
 
         double diffY = player.y - event.getPlacedBlockPos().toVector3d().getY();
 
-        maxPitch = 2.33d * diffY + 80.97d;
+        double adjustedPitch = 2.33d * diffY;
 
-        if (player.yRot < maxPitch && player.yRot > 74.5) return;
+        if (player.yRot < 80.97d + adjustedPitch && player.yRot > 74.5 - adjustedPitch) return;
 
         Vector3d pos = event.getPlacedBlockPos().toVector3d().subtract(0, 0.6, 0);
         if (!player.compensatedWorld.getWrappedBlockStateAt(pos.toVector3i()).getType().isAir()) return;

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -5,6 +5,9 @@ import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import com.github.retrooper.packetevents.util.Vector3i;
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import org.bukkit.Location;
+import org.bukkit.Material;
 
 @CheckData(name = "CorrectPlace", experimental = true)
 public class CorrectPlace extends BlockPlaceCheck {
@@ -19,6 +22,12 @@ public class CorrectPlace extends BlockPlaceCheck {
     public void onBlockPlace(BlockPlace event) {
         if (player.y < event.getPlacedBlockPos().getY()) return;
         if (player.yRot < 82.6 && player.yRot > 76.7) return;
+
+        Vector3i pos = event.getPlacedBlockPos();
+
+        Location loc = new Location(player.bukkitPlayer.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+
+        if (!loc.subtract(0, 0.6, 0).getBlock().getType().equals(Material.AIR)) return;
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
             if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -17,6 +17,7 @@ public class CorrectPlace extends BlockPlaceCheck {
 
     @Override
     public void onBlockPlace(BlockPlace event) {
+        if (player.y < event.getPlacedBlockPos().getY()) return;
         if (player.yRot < 82.6 && player.yRot > 76.7) return;
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -4,6 +4,7 @@ import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
+import ac.grim.grimac.utils.nmsutil.ReachUtils;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3f;
@@ -13,6 +14,7 @@ import com.github.retrooper.packetevents.util.Vector3i;
 public class CorrectPlace extends BlockPlaceCheck {
 
     private Vector3i previousBlockPlaced = null;
+    private int lastBlockFaceID = -1;
 
     public CorrectPlace(GrimPlayer player) {
         super(player);
@@ -37,11 +39,15 @@ public class CorrectPlace extends BlockPlaceCheck {
         Vector3d pos = event.getPlacedBlockPos().toVector3d().subtract(0, 0.6, 0);
         if (!player.compensatedWorld.getWrappedBlockStateAt(pos.toVector3i()).getType().isAir()) return;
 
-        if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
-            if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {
-                event.resync();
+        if (lastBlockFaceID == event.getFaceId()) {
+            if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
+                if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {
+                    event.resync();
+                }
             }
         }
+
         previousBlockPlaced = event.getPlacedBlockPos();
+        lastBlockFaceID = event.getFaceId();
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -4,10 +4,8 @@ import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
+import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3i;
-import io.github.retrooper.packetevents.util.SpigotConversionUtil;
-import org.bukkit.Location;
-import org.bukkit.Material;
 
 @CheckData(name = "CorrectPlace", experimental = true)
 public class CorrectPlace extends BlockPlaceCheck {
@@ -23,11 +21,9 @@ public class CorrectPlace extends BlockPlaceCheck {
         if (player.y < event.getPlacedBlockPos().getY()) return;
         if (player.yRot < 82.6 && player.yRot > 76.7) return;
 
-        Vector3i pos = event.getPlacedBlockPos();
+        Vector3d pos = event.getPlacedBlockPos().toVector3d().subtract(0, 0.6, 0);
 
-        Location loc = new Location(player.bukkitPlayer.getWorld(), pos.getX(), pos.getY(), pos.getZ());
-
-        if (!loc.subtract(0, 0.6, 0).getBlock().getType().equals(Material.AIR)) return;
+        if (!player.compensatedWorld.getWrappedBlockStateAt(pos.toVector3i()).getType().isAir()) return;
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
             if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -1,0 +1,35 @@
+package ac.grim.grimac.checks.impl.scaffolding;
+
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.BlockPlaceCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.anticheat.update.BlockPlace;
+import com.github.retrooper.packetevents.util.Vector3i;
+import org.bukkit.Bukkit;
+
+@CheckData(name = "CorrectPlace")
+public class CorrectPlace extends BlockPlaceCheck {
+
+    private Vector3i previousBlockPlaced = null;
+
+    public CorrectPlace(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onBlockPlace(BlockPlace event) {
+        if (player.yRot < 82.6 && player.yRot > 76.7) {
+            Bukkit.broadcastMessage("§aLegit");
+            return;
+        }
+
+        if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
+            if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {
+                Bukkit.broadcastMessage("§cIncorrect Looking");
+                event.resync();
+            }
+        }
+        previousBlockPlaced = event.getPlacedBlockPos();
+    }
+
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -5,9 +5,8 @@ import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import com.github.retrooper.packetevents.util.Vector3i;
-import org.bukkit.Bukkit;
 
-@CheckData(name = "CorrectPlace")
+@CheckData(name = "CorrectPlace", experimental = true)
 public class CorrectPlace extends BlockPlaceCheck {
 
     private Vector3i previousBlockPlaced = null;
@@ -19,13 +18,11 @@ public class CorrectPlace extends BlockPlaceCheck {
     @Override
     public void onBlockPlace(BlockPlace event) {
         if (player.yRot < 82.6 && player.yRot > 76.7) {
-            Bukkit.broadcastMessage("§aLegit");
             return;
         }
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
             if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {
-                Bukkit.broadcastMessage("§cIncorrect Looking");
                 event.resync();
             }
         }

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -5,12 +5,15 @@ import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import com.github.retrooper.packetevents.util.Vector3d;
+import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.util.Vector3i;
 
 @CheckData(name = "CorrectPlace", experimental = true)
 public class CorrectPlace extends BlockPlaceCheck {
 
     private Vector3i previousBlockPlaced = null;
+
+    private double maxPitch = 0; // when player is Jumping can place a block with a 85.4
 
     public CorrectPlace(GrimPlayer player) {
         super(player);
@@ -19,10 +22,19 @@ public class CorrectPlace extends BlockPlaceCheck {
     @Override
     public void onBlockPlace(BlockPlace event) {
         if (player.y < event.getPlacedBlockPos().getY()) return;
-        if (player.yRot < 82.6 && player.yRot > 76.7) return;
+
+        Vector3f cursor = event.getCursor();
+
+        // player is looking at the end of block (at left or right), this won't affect the center
+        if ((cursor.getX() < 0.2 && cursor.getX() > 0.8) || (cursor.getZ() < 0.2 && cursor.getZ() > 0.8)) return;
+
+        double diffY = player.y - event.getPlacedBlockPos().toVector3d().getY();
+
+        maxPitch = 2.33d * diffY + 80.97d;
+
+        if (player.yRot < maxPitch && player.yRot > 74.5) return;
 
         Vector3d pos = event.getPlacedBlockPos().toVector3d().subtract(0, 0.6, 0);
-
         if (!player.compensatedWorld.getWrappedBlockStateAt(pos.toVector3i()).getType().isAir()) return;
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
@@ -32,5 +44,4 @@ public class CorrectPlace extends BlockPlaceCheck {
         }
         previousBlockPlaced = event.getPlacedBlockPos();
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/CorrectPlace.java
@@ -17,9 +17,7 @@ public class CorrectPlace extends BlockPlaceCheck {
 
     @Override
     public void onBlockPlace(BlockPlace event) {
-        if (player.yRot < 82.6 && player.yRot > 76.7) {
-            return;
-        }
+        if (player.yRot < 82.6 && player.yRot > 76.7) return;
 
         if (previousBlockPlaced != null && previousBlockPlaced.getY() - event.getPlacedBlockPos().getY() == 0) {
             if (flagAndAlert() && shouldCancel() && shouldModifyPackets()) {

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -144,6 +144,7 @@ public class CheckManager {
                 .put(PositionPlace.class, new PositionPlace(player))
                 .put(RotationPlace.class, new RotationPlace(player))
                 .put(DuplicateRotPlace.class, new DuplicateRotPlace(player))
+                .put(CorrectPlace.class, new CorrectPlace(player))
                 .put(GhostBlockMitigation.class, new GhostBlockMitigation(player))
                 .build();
 


### PR DESCRIPTION
This check is designed to prevent players from exploiting the scaffold mechanic in a way that allows them to place blocks beneath themselves without properly aiming at the correct face of the previous block. Specifically, it ensures that players cannot place a block directly beneath them unless they are actually looking at the correct face of the block they intend to place it against.

https://imgur.com/a/fJLFHQC -> video of the check