### PR TITLE
Reduce average iterations of RotationPlace

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -71,8 +71,8 @@ public class RotationPlace extends BlockPlaceCheck {
         SimpleCollisionBox box = new SimpleCollisionBox(place.getPlacedAgainstBlockLocation());
 
         List<Vector3f> possibleLookDirs = new ArrayList<>(Arrays.asList(
-                new Vector3f(player.lastXRot, player.yRot, 0),
-                new Vector3f(player.xRot, player.yRot, 0)
+                new Vector3f(player.xRot, player.yRot, 0),
+                new Vector3f(player.lastXRot, player.yRot, 0)
         ));
 
         // Start checking if player is in the block


### PR DESCRIPTION
Change the order of rots being checked. Player is far more likely to be looking at xRot yRot then anything else. We should not be checking lastXRot yRot first.