### PR TITLE
Fix config for Timer

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/movement/TimerCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/movement/TimerCheck.java
@@ -19,9 +19,9 @@ public class TimerCheck extends Check implements PacketCheck {
 
     // How long should the player be able to fall back behind their ping?
     // Default: 120 milliseconds
-    long clockDrift = (long) 120e6;
+    long clockDrift;
 
-    long limitAbuseOverPing = 1000;
+    long limitAbuseOverPing;
 
     boolean hasGottenMovementAfterTransaction = false;
 


### PR DESCRIPTION
The default value in TimerCheck is assigned after loading from config, this pr is fixing it.

Already checked all other checks for this.