### PR TITLE
Fix incorrect casting to float before clamping attribute values

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
+++ b/src/main/java/ac/grim/grimac/utils/data/attribute/ValuedAttribute.java
@@ -123,7 +123,7 @@ public final class ValuedAttribute {
                 d1 *= 1.0D + attributemodifier.getAmount();
         }
 
-        double newValue = GrimMath.clampFloat((float) d1, (float) min, (float) max);
+        double newValue = GrimMath.clamp(d1, min, max);
         if (setRewriter != null) {
             newValue = setRewriter.apply(this.value, newValue);
         }


### PR DESCRIPTION
Checking legacy and modern source (1.7 and 1.21) both clamp attributes without casting them to a float first. Our handling of this is wrong.

1.7 ClampedEntityAttribute.java
```java
public ClampedEntityAttribute(String string, double d, double e, double f) {
		super(string, d);
		this.minValue = e;
		this.maxValue = f;
		if (e > f) {
			throw new IllegalArgumentException("Minimum value cannot be bigger than maximum value!");
		} else if (d < e) {
			throw new IllegalArgumentException("Default value cannot be lower than minimum value!");
		} else if (d > f) {
			throw new IllegalArgumentException("Default value cannot be bigger than maximum value!");
		}
	}
        @Override
	public double clamp(double value) {
		if (value < this.minValue) {
			value = this.minValue;
		}

		if (value > this.maxValue) {
			value = this.maxValue;
		}

		return value;
	}
```

1.21 ClampedEntityAttribute.java
```java
public ClampedEntityAttribute(String translationKey, double fallback, double min, double max) {
		super(translationKey, fallback);
		this.minValue = min;
		this.maxValue = max;
		if (min > max) {
			throw new IllegalArgumentException("Minimum value cannot be bigger than maximum value!");
		} else if (fallback < min) {
			throw new IllegalArgumentException("Default value cannot be lower than minimum value!");
		} else if (fallback > max) {
			throw new IllegalArgumentException("Default value cannot be bigger than maximum value!");
		}
	}
        @Override
	public double clamp(double value) {
		return Double.isNaN(value) ? this.minValue : MathHelper.clamp(value, this.minValue, this.maxValue);
	}
```

1.21 MathHelper.java
```java
public static double clamp(double value, double min, double max) {
		return value < min ? min : Math.min(value, max);
	}
```