### PR TITLE
warn about `ViaVersion rotation-place fix`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("org.jetbrains:annotations:24.1.0")
     compileOnly("org.geysermc.floodgate:api:2.0-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT")
-    compileOnly("com.viaversion:viaversion-api:4.9.4-SNAPSHOT")
+    compileOnly("com.viaversion:viaversion-api:5.0.4-SNAPSHOT")
     //
     compileOnly("io.netty:netty-all:4.1.85.Final")
 }

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -46,7 +46,9 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.client.*;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
+import com.viaversion.viaversion.api.Via;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -324,7 +326,15 @@ public class CheckManagerListener extends PacketListenerAbstract {
 
     private boolean isMojangStupid(GrimPlayer player, WrapperPlayClientPlayerFlying flying) {
         // Mojang has become less stupid!
-        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) return false;
+        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) {
+            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
+                return false;
+            }
+
+            if (!ViaVersionUtil.isAvailable() || !Via.getConfig().fix1_21PlacementRotation()) {
+                return false;
+            }
+        }
 
         final Location location = flying.getLocation();
         final double threshold = player.getMovementThreshold();

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -46,9 +46,7 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.client.*;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
-import com.viaversion.viaversion.api.Via;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
-import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -326,15 +324,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
 
     private boolean isMojangStupid(GrimPlayer player, WrapperPlayClientPlayerFlying flying) {
         // Mojang has become less stupid!
-        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) {
-            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
-                return false;
-            }
-
-            if (!ViaVersionUtil.isAvailable() || !Via.getConfig().fix1_21PlacementRotation()) {
-                return false;
-            }
-        }
+        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)) return false;
 
         final Location location = flying.getLocation();
         final double threshold = player.getMovementThreshold();

--- a/src/main/java/ac/grim/grimac/manager/InitManager.java
+++ b/src/main/java/ac/grim/grimac/manager/InitManager.java
@@ -33,6 +33,7 @@ public class InitManager {
                 .put(SpectateManager.class, GrimAPI.INSTANCE.getSpectateManager())
                 .put(GrimExternalAPI.class, GrimAPI.INSTANCE.getExternalAPI())
                 .put(JavaVersion.class, new JavaVersion())
+                .put(ViaVersion.class, new ViaVersion())
                 .build();
 
         initializersOnStop = new ImmutableClassToInstanceMap.Builder<Initable>()

--- a/src/main/java/ac/grim/grimac/manager/init/start/ViaVersion.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/ViaVersion.java
@@ -1,0 +1,19 @@
+package ac.grim.grimac.manager.init.start;
+
+import ac.grim.grimac.manager.init.Initable;
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.viaversion.viaversion.api.Via;
+import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
+
+public class ViaVersion implements Initable {
+    @Override
+    public void start() {
+        if (!ViaVersionUtil.isAvailable() || !Via.getConfig().fix1_21PlacementRotation()) {
+            return;
+        }
+
+        LogUtil.warn("GrimAC has detected that you are using ViaVersion with the `fix-1_21-placement-rotation` option enabled.");
+        LogUtil.warn("This option is known to cause issues with GrimAC and may result in false positives and bypasses.");
+        LogUtil.warn("Please disable this option in your ViaVersion configuration to prevent these issues.");
+    }
+}


### PR DESCRIPTION
this pr makes sure that Grim at least tries to handle new option correctly, and warn server admin about that option.
maybe we should do the same thing as ViaBackwardsManager
```java
System.setProperty("com.viaversion.handlePingsAsInvAcknowledgements", "true");
```
but I don't know if it's possible here

this pr should wait till new ViaVersion release and Grim finally updating to Java 17 (I guess ViaVersion 5.0 in dependencies will break with Java 8)