### PR TITLE
Don't setback on CrashB

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
@@ -18,7 +18,6 @@ public class CrashB extends Check implements PacketCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.CREATIVE_INVENTORY_ACTION) {
             if (player.gamemode != GameMode.CREATIVE) {
-                player.getSetbackTeleportUtil().executeViolationSetback();
                 event.setCancelled(true);
                 player.onPacketCancel();
                 flagAndAlert(); // Could be transaction split, no need to setback though


### PR DESCRIPTION
I believe the check was set to setback by accident, as the comment specifies that this check does not need to setback due to potential transaction splits.

Regardless of that, CrashB shouldn't need to setback, as the check has nothing to do with movement.