### PR TITLE
Fix race condition and exception when registering check permissions during rapid consecutive player joins on server start

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -47,8 +47,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class CheckManager {
     private static boolean inited;
+    private static final AtomicBoolean initedAtomic = new AtomicBoolean(false);
 
     ClassToInstanceMap<PacketCheck> packetChecks;
     ClassToInstanceMap<PositionCheck> positionCheck;
@@ -336,7 +339,12 @@ public class CheckManager {
     }
 
     private void init() {
+        // Fast non-thread safe check
         if (inited) return;
+        // Slow thread safe check
+        if (!initedAtomic.compareAndSet(false, true)) return;
+        inited = true;
+
         for (AbstractCheck check : allChecks.values()) {
             if (check.getCheckName() != null) {
                 String permissionName = "grim.exempt." + check.getCheckName().toLowerCase();
@@ -349,7 +357,5 @@ public class CheckManager {
                 }
             }
         }
-
-        inited = true;
     }
 }


### PR DESCRIPTION
When consecutive players join the server rapidly and they are the first joining players, a data race occurs and the permissions for the checks are registered multiple times causing an exception:

![image](https://github.com/user-attachments/assets/abdfa137-0d83-4539-9217-673a51986c61)

![image](https://github.com/user-attachments/assets/0de89644-45e3-48c5-bb0a-b121fe579d16)

Explanation of the data race:

1. The `init()` method is invoked on Netty threads whenever a player joins the server.
2. The `inited` variable is a non-thread-safe `static boolean` used to determine if initialization has already occurred.
3. The `inited` flag is checked early to return if initialization is complete. However, this check is not thread-safe.
4. Due to the data race on `inited`, if multiple players join rapidly, multiple threads can proceed past the `if (inited)` check, causing `addPermission` to be called multiple times concurrently.