### PR TITLE
Make relocate read from project properties --> environment variable --> default to true

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,10 @@ java {
 
 // Set to false for debug builds
 // You cannot live reload classes if the jar relocates dependencies
-var relocate = true;
+// Checks Project properties -> environment variable -> defaults true
+val relocate: Boolean = project.findProperty("relocate")?.toString()?.toBoolean()
+    ?: System.getenv("RELOCATE_JAR")?.toBoolean()
+    ?: true
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Prevents having to modify build.gradle.kts when disabling relocating. You can instead just set an environment variable, for example.