### PR TITLE
fix wrongly ported reach changes from grim 3.0

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/nmsutil/ReachUtils.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/ReachUtils.java
@@ -176,14 +176,14 @@ public class ReachUtils {
     }
 
     public static double getMinReachToBox(GrimPlayer player, SimpleCollisionBox targetBox) {
-        boolean giveMovementThresholdLenience = player.packetStateData.didLastMovementIncludePosition || player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
+        boolean giveMovementThresholdLenience = !player.packetStateData.didLastMovementIncludePosition || player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) targetBox.expand(0.1);
 
         double lowest = Double.MAX_VALUE;
 
+        if (giveMovementThresholdLenience) targetBox.expand(player.getMovementThreshold());
         final double[] possibleEyeHeights = player.getPossibleEyeHeights();
         for (double eyes : possibleEyeHeights) {
-            if (giveMovementThresholdLenience) targetBox.expand(player.getMovementThreshold());
             Vector from = new Vector(player.x, player.y + eyes, player.z);
             Vector closestPoint = VectorUtils.cutBoxToVector(from, targetBox);
             lowest = Math.min(lowest, closestPoint.distance(from));


### PR DESCRIPTION
after reviewing the changes in https://github.com/GrimAnticheat/Grim/pull/1221

I found out that earlier targetBox was recreated every loop, but now its created only once
this lead to collisionbox being expanded (0.09 blocks wider, for <=1.17)

also giving movement threshold when we actually received position in last movement packet does not make sense to me
especially when PositionPlace check seems to do it right
https://github.com/GrimAnticheat/Grim/blob/0293606dc90ec5425ebba584facaee6f943d6718/src/main/java/ac/grim/grimac/checks/impl/scaffolding/PositionPlace.java#L33-L35