### PR TITLE
fix: Legacy cauldron collision box.

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsX.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsX.java
@@ -9,10 +9,8 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.DiggingAction;
-import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
-import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 

--- a/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/CollisionData.java
@@ -680,7 +680,7 @@ public enum CollisionData {
     }, StateTypes.END_ROD, StateTypes.LIGHTNING_ROD),
 
     CAULDRON((player, version, data, x, y, z) -> {
-        if (version.isNewerThan(ClientVersion.getById(467))) { // changed in 19w13a, 1.14 Snapshot
+        if (version.isNewerThan(ClientVersion.V_1_13_2)) { // changed in 19w13a, 1.14 Snapshot
             return new ComplexCollisionBox(15,
                     new SimpleCollisionBox(0.0, 0.0, 0.0, 0.125, 1.0, 0.25, false),
                     new SimpleCollisionBox(0.0, 0.0, 0.75, 0.125, 1.0, 1.0, false),


### PR DESCRIPTION
closes #1826

Protocol `467` is not registered in PE, and returns `UNKNOWN` (Protocol: -1)