### PR TITLE
[1.21.3] fix looping through invalid values caused by known input

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -710,6 +710,8 @@ public class PredictionEngine {
 
         // Calculate inputs by the players known inputs on 1.21.2+
         if (player.supportsEndTick()) {
+            forwardMin = forwardMax = strafeMin = strafeMax = 0;
+
             final KnownInput knownInput = player.packetStateData.knownInput;
             if (knownInput.forward()) {
                 forwardMax += 1;


### PR DESCRIPTION
fixes:
> For some reason, sneaking whilst sprinting falses on 1.21.3, yet the movement is the same as older versions. Someone needs to figure out the issue there.