### PR TITLE
Fix riptide trident attacks on entities that are non-pushable or the same team as the attacker

### DIFF
--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -292,7 +292,7 @@ public class GrimPlayer implements GrimUser {
         // If the player has that client sided riptide thing and has colliding with an entity
         // This was determined in the previous tick but whatever just include the 2 ticks around it
         // for a bit of safety as I doubt people will try to bypass this, it would be a very useless cheat
-        if (riptideSpinAttackTicks >= 0 && Collections.max(uncertaintyHandler.collidingEntities) > 0) {
+        if (riptideSpinAttackTicks >= 0 && Collections.max(uncertaintyHandler.riptideEntities) > 0) {
             possibleMovements.add(new VectorData(clientVelocity.clone().multiply(-0.2), VectorData.VectorType.Trident));
         }
 

--- a/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -242,6 +242,7 @@ public class GrimPlayer implements GrimUser {
 
         packetStateData = new PacketStateData();
 
+        uncertaintyHandler.riptideEntities.add(0);
         uncertaintyHandler.collidingEntities.add(0);
 
         if (getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_14)) {

--- a/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -64,8 +64,10 @@ public class UncertaintyHandler {
     public boolean lastMovementWasUnknown003VectorReset = false;
     // Handles 0.03 vertical false where actual velocity is greater than predicted because of previous lenience
     public boolean wasZeroPointThreeVertically = false;
-    // How many entities are within 0.5 blocks of the player's bounding box?
+    // How many entities are within 0.5 blocks of the player's bounding box that are pushable?
     public EvictingQueue<Integer> collidingEntities = new EvictingQueue<>(3);
+    // How many entities are within 0.5 blocks of the player's bounding box? Should only exclude entities in spectator
+    public EvictingQueue<Integer> riptideEntities = new EvictingQueue<>(3);
     // Fishing rod pulling is another method of adding to a player's velocity
     public List<Integer> fishingRodPulls = new ArrayList<>();
     public SimpleCollisionBox fireworksBox = null;


### PR DESCRIPTION
Riptide attacks use different logic for attacks than collisions.

Riptide attacks can still false occasionally and will immediately false upon attacking an entity sitting in a boat. This does not change that.

This does fix riptide falsing on non-pushable entities like armor stands and players on the same team when collisions are off.