### PR TITLE
[1.21.3] Limit jump possibilities

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineNormal.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineNormal.java
@@ -37,6 +37,10 @@ public class PredictionEngineNormal extends PredictionEngine {
 
     @Override
     public void addJumpsToPossibilities(GrimPlayer player, Set<VectorData> existingVelocities) {
+        if (player.supportsEndTick() && !player.packetStateData.knownInput.jump()) {
+            return;
+        }
+
         for (VectorData vector : new HashSet<>(existingVelocities)) {
             Vector jump = vector.vector.clone();
 


### PR DESCRIPTION
made there and not globally because of false positives while riding entities, also seems to work with water prediction