### PR TITLE
patch autoblock in 1.8

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
@@ -13,13 +13,10 @@ import com.github.retrooper.packetevents.protocol.attribute.Attributes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
-import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
-
-import static ac.grim.grimac.utils.inventory.Inventory.HOTBAR_OFFSET;
 
 public class PacketPlayerAttack extends PacketListenerAbstract {
 
@@ -48,15 +45,7 @@ public class PacketPlayerAttack extends PacketListenerAbstract {
                 ItemStack heldItem = player.getInventory().getHeldItem();
                 PacketEntity entity = player.compensatedEntities.getEntity(interact.getEntityId());
 
-                // You don't get a release use item with block hitting with a sword?
-                if (player.getClientVersion().isOlderThan(ClientVersion.V_1_9) && player.packetStateData.isSlowedByUsingItem()) {
-                    ItemStack item = player.getInventory().inventory.getPlayerInventoryItem(player.packetStateData.getSlowedByUsingItemSlot() + HOTBAR_OFFSET);
-                    if (item.getType().hasAttribute(ItemTypes.ItemAttribute.SWORD)) {
-                        player.packetStateData.setSlowedByUsingItem(false);
-                    }
-                }
-
-                if (entity != null && (!(entity.isLivingEntity()) || entity.getType() == EntityTypes.PLAYER)) {
+                if (entity != null && (!entity.isLivingEntity() || entity.getType() == EntityTypes.PLAYER)) {
                     boolean hasKnockbackSword = heldItem != null && heldItem.getEnchantmentLevel(EnchantmentTypes.KNOCKBACK, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) > 0;
                     boolean isLegacyPlayer = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8);
                     boolean hasNegativeKB = heldItem != null && heldItem.getEnchantmentLevel(EnchantmentTypes.KNOCKBACK, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) < 0;


### PR DESCRIPTION
The cause of not receiving a release packet is the server sending the durability decrease of the sword and the player unblocking in the same tick, which we already handle elsewhere

closes #1160