### PR TITLE
Fix legacy (< 1.16.2) hitbox modeling for close non-relative teleports

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/collisions/datatypes/SimpleCollisionBox.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/datatypes/SimpleCollisionBox.java
@@ -393,6 +393,18 @@ public class SimpleCollisionBox implements CollisionBox {
         return hxz - (xwidth + zwidth + bxwidth + bzwidth) / 4;
     }
 
+    public double distanceX(double x) {
+        return x >= this.minX && x <= this.maxX ? 0.0 : Math.min(Math.abs(x - this.minX), Math.abs(x - this.maxX));
+    }
+
+    public double distanceY(double y) {
+        return y >= this.minY && y <= this.maxY ? 0.0 : Math.min(Math.abs(y - this.minY), Math.abs(y - this.maxY));
+    }
+
+    public double distanceZ(double z) {
+        return z >= this.minZ && z <= this.maxZ ? 0.0 : Math.min(Math.abs(z - this.minZ), Math.abs(z - this.maxZ));
+    }
+
     /**
      * Calculates intersection with the given ray between a certain distance
      * interval.

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -32,6 +32,7 @@ public class ReachInterpolationData {
     private int interpolationStepsLowBound = 0;
     private int interpolationStepsHighBound = 0;
     private int interpolationSteps = 1;
+    private boolean expandNonRelative = false;
 
     public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox startingLocation, TrackedPosition position, PacketEntity entity) {
         final boolean isPointNine = !player.compensatedEntities.getSelf().inVehicle() && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
@@ -114,6 +115,9 @@ public class ReachInterpolationData {
                     startingLocation.maxZ + (step * stepMaxZ)));
         }
 
+        if (expandNonRelative)
+            minimumInterpLocation.expand(0.03125D, 0.015625D, 0.03125D);
+
         return minimumInterpLocation;
     }
 
@@ -138,5 +142,9 @@ public class ReachInterpolationData {
                 ", interpolationStepsLowBound=" + interpolationStepsLowBound +
                 ", interpolationStepsHighBound=" + interpolationStepsHighBound +
                 '}';
+    }
+
+    public void expandNonRelative() {
+        expandNonRelative = true;
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -134,6 +134,17 @@ public class PacketEntity extends TypedPacketEntity {
                 }
                 trackedServerPosition.setPos(vec3d);
             } else {
+                // I think we can reduce this but I'm too lazy to minimize interpolations needed so...
+                SimpleCollisionBox clientArea = newPacketLocation.getPossibleLocationCombined();
+                // In versions < 1.16.2 when the client receives non-relative teleport for an entity
+                // And they move less by the thresholds given, the entity does not move client side
+                if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_16_1)
+                        && clientArea.distanceX(relX) < 0.03125D
+                        && clientArea.distanceY(relY) < 0.015625D
+                        && clientArea.distanceZ(relZ) < 0.03125D
+                ) {
+                    newPacketLocation.expandNonRelative();
+                }
                 trackedServerPosition.setPos(new Vector3d(relX, relY, relZ));
                 // ViaVersion desync's here for teleports
                 // It simply teleports the entity with its position divided by 32... ignoring the offset this causes.


### PR DESCRIPTION
I've been furiously trying to figure out what the causes of missed hitbox falses are. They seem to happen at random inconsistently, and rarely.

At least in regards to legacy versions, I may have found the answer (or at least one contributing factor). 

When receiving a teleport packet from the server (which happens periodically to synchronize entity positions even if the entity isn't being teleported) if the teleport packet moves the entity by less than 0.03125D in the X and Z directions and less than 0.015625D in the Y axis then the entity won't actually be moved client side.

However @SamB440 while trying to implement handling for this I noticed that you had a section with some code below it commenting about how we need to do some / 32 unpacking because of Via, yet in the actual code you don't check for via usage and just apply the position change if the player version is < 1.9 regardless if via is being used or not. Could you please clarify the code with additional comments and/or explain what's going on and if this is correct?

This should *hopefully* fix or at least contribute to fixing @ItsClairton described reach falses with Elder Guardians