### PR TITLE
Fix nosuchmethoderror in grimversion in old minecraft versions

### DIFF
--- a/src/main/java/ac/grim/grimac/commands/GrimVersion.java
+++ b/src/main/java/ac/grim/grimac/commands/GrimVersion.java
@@ -57,6 +57,7 @@ public class GrimVersion extends BaseCommand {
     }
 
     // Using UserAgent format recommended by https://docs.modrinth.com/api/
+    @SuppressWarnings("deprecation")
     private static void checkForUpdates(CommandSender sender) {
         String current = GrimAPI.INSTANCE.getExternalAPI().getGrimVersion();
         try {
@@ -77,7 +78,8 @@ public class GrimVersion extends BaseCommand {
                 LogUtil.error("Failed to check latest GrimAC version. Response code: " + response.statusCode());
                 return;
             }
-            JsonObject object = JsonParser.parseString(response.body()).getAsJsonArray().get(0).getAsJsonObject();
+            // Using old JsonParser method, as old versions of Gson don't include the static one
+            JsonObject object = new JsonParser().parse(response.body()).getAsJsonArray().get(0).getAsJsonObject();
             String latest = object.get("version_number").getAsString();
             Status status = compareVersions(current, latest);
             Component msg = switch (status) {


### PR DESCRIPTION
This PR fixes a NoSuchMethodError when running /grim version. The issue was caused by using a Gson method introduced in version 2.8.6, while older versions like Minecraft 1.8.8 include an earlier Gson version. This update ensures compatibility with the older Gson version.

The method used in this PR is deprecated, but I think it's unlikely to be removed anytime soon.