### PR TITLE
BadPacketsV: fix >= 1.21.2 false flag

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
@@ -21,7 +22,9 @@ public class BadPacketsV extends Check implements PacketCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (!player.canSkipTicks() && isTickPacket(event.getPacketType())) {
             if (event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION || event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION) {
-                if (noReminderTicks < 19 && !player.uncertaintyHandler.lastTeleportTicks.hasOccurredSince(1)) {
+                int positionAtLeastEveryNTicks = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8) ? 20 : 19;
+
+                if (noReminderTicks < positionAtLeastEveryNTicks && !player.uncertaintyHandler.lastTeleportTicks.hasOccurredSince(1)) {
                     final double deltaSq = new WrapperPlayClientPlayerFlying(event).getLocation().getPosition()
                             .distanceSquared(new Vector3d(player.lastX, player.lastY, player.lastZ));
                     if (deltaSq <= player.getMovementThreshold() * player.getMovementThreshold()) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
@@ -21,7 +21,7 @@ public class BadPacketsV extends Check implements PacketCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (!player.canSkipTicks() && isTickPacket(event.getPacketType())) {
             if (event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION || event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION) {
-                if (noReminderTicks < 20 && !player.uncertaintyHandler.lastTeleportTicks.hasOccurredSince(1)) {
+                if (noReminderTicks < 19 && !player.uncertaintyHandler.lastTeleportTicks.hasOccurredSince(1)) {
                     final double deltaSq = new WrapperPlayClientPlayerFlying(event).getLocation().getPosition()
                             .distanceSquared(new Vector3d(player.lastX, player.lastY, player.lastZ));
                     if (deltaSq <= player.getMovementThreshold() * player.getMovementThreshold()) {


### PR DESCRIPTION
The experimental BadPacketsV check falses for vanilla >= 1.21.2 clients when standing still.

Vanilla clients send these movement packets when the player doesn't move:

- version 1.8: Every 21st packet includes a position (20 onground only packets inbetween).
- at least since version 1.12 (possibly changed somewhere between 1.9 and 1.11): Every 20th tick sends a position (19 ticks without a movement packet inbetween).

This is caused by a change in the onUpdateWalkingPlayer (MCP) / sendMovementPackets (Yarn) method: In older versions, the movement packet is sent and the "ticks since position" counter is incremented. If a position was sent, it is set back to 0. In newer versions, the increment happens before the conditions are evaluated, so the counter isn't really reset to 0 when sending a position, but rather to 1. This means there is one fewer tick between two position packets.

To fix this, I changed the noReminderTicks comparison to < 19.

Edit: The falses only affected >= 1.21.2 players and not >= ~1.12 players. Also, >= 1.21.2 players on < 1.21.2 servers did not false this because we do not support the end tick packet there due to ViaVersion.