### PR TITLE
Resolve missing JDK 17 configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,8 @@ group = "ac.grim.grimac"
 version = "2.3.69"
 description = "Libre simulation anticheat designed for 1.21 with 1.8-1.21 support, powered by PacketEvents 2.0."
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-}
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17
 
 // Set to false for debug builds
 // You cannot live reload classes if the jar relocates dependencies


### PR DESCRIPTION
Gradle build was failing due to a missing Java 17 toolchain configuration. The error log indicated:

Caused by: org.gradle.jvm.toolchain.internal.NoToolchainAvailableException: 
Cannot find a Java installation on your machine matching this task's requirements: 
{languageVersion=17, vendor=any vendor, implementation=vendor-specific}.```

Additionally:

Caused by: org.gradle.jvm.toolchain.internal.ToolchainDownloadFailedException: 
No locally installed toolchains match and toolchain download repositories have not been configured.

Root Cause

The project requires JDK 17 to compile, but no suitable JDK version was configured for the Gradle toolchain, and automatic toolchain downloads were not enabled.