### PR TITLE
Fix teleporting on Folia servers

### DIFF
--- a/src/main/java/ac/grim/grimac/commands/GrimSpectate.java
+++ b/src/main/java/ac/grim/grimac/commands/GrimSpectate.java
@@ -46,6 +46,6 @@ public class GrimSpectate extends BaseCommand {
         }
 
         player.setGameMode(GameMode.SPECTATOR);
-        player.teleport(target.getPlayer());
+        player.teleportAsync(target.getPlayer().getLocation());
     }
 }


### PR DESCRIPTION
On Folia servers, you *have* to teleport using teleportAsync, otherwhise you get this error:
This happens when you use the spectate command

`[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF] java.lang.UnsupportedOperationException: Must use teleportAsync while in region threading
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at org.bukkit.craftbukkit.entity.CraftPlayer.teleport(CraftPlayer.java:1408)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at org.bukkit.craftbukkit.entity.CraftPlayer.teleport(CraftPlayer.java:1377)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at org.bukkit.craftbukkit.entity.CraftEntity.teleport(CraftEntity.java:237)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.manager.SpectateManager.disable(SpectateManager.java:64)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.commands.GrimStopSpectating.onStopSpectate(GrimStopSpectating.java:29)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.shaded.acf.RegisteredCommand.invoke(RegisteredCommand.java:152)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.shaded.acf.BaseCommand.executeCommand(BaseCommand.java:578)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.shaded.acf.BaseCommand.execute(BaseCommand.java:513)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.shaded.acf.RootCommand.execute(RootCommand.java:99)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at grimac-2.3.68.jar//ac.grim.grimac.shaded.acf.BukkitRootCommand.execute(BukkitRootCommand.java:84)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:82)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:105)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:435)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.Commands.performCommand(Commands.java:342)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.Commands.performCommand(Commands.java:332)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.commands.Commands.performCommand(Commands.java:326)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2252)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$14(ServerGamePacketListenerImpl.java:2225)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$tryHandleChat$17(ServerGamePacketListenerImpl.java:2382)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:181)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1658)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:407)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:418)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:546)
[13:29:41] [Region Scheduler Thread #0/ERROR]: [GrimAC] [ACF]   at java.base/java.lang.Thread.run(Thread.java:1575)`

I have implemented this quick fix in this PR
