### PR TITLE
Work around compiler warnings by using wrapper classes

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -190,7 +190,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
 
                 player.compensatedEntities.serverPlayerVehicle = null; // All entities get removed on respawn
                 player.compensatedEntities.self = new PacketEntitySelf(player, player.compensatedEntities.self);
-                player.compensatedEntities.selfTrackedEntity = new TrackerData(0, 0, 0, 0, 0, EntityTypes.PLAYER, player.lastTransactionSent.get());
+                player.compensatedEntities.selfTrackedEntity = new TrackerData(0.0, 0.0, 0.0, 0f, 0f, EntityTypes.PLAYER, player.lastTransactionSent.get());
 
                 if (player.getClientVersion().isOlderThan(ClientVersion.V_1_14)) { // 1.14+ players send a packet for this, listen for it instead
                     player.isSprinting = false;

--- a/src/main/java/ac/grim/grimac/utils/data/TrackerData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/TrackerData.java
@@ -8,13 +8,14 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor
 public class TrackerData {
+    // Using wrapper classes for numbers so the compiler shuts up about using annotations on primitives
     @NonNull
-    double x, y, z;
+    Double x, y, z;
     @NonNull
-    float xRot, yRot;
+    Float xRot, yRot;
     @NonNull
     EntityType entityType;
     @NonNull
-    int lastTransactionHung;
+    Integer lastTransactionHung;
     int legacyPointEightMountedUpon;
 }

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -48,7 +48,7 @@ public class CompensatedEntities {
     public CompensatedEntities(GrimPlayer player) {
         this.player = player;
         this.self = new PacketEntitySelf(player);
-        this.selfTrackedEntity = new TrackerData(0, 0, 0, 0, 0, EntityTypes.PLAYER, player.lastTransactionSent.get());
+        this.selfTrackedEntity = new TrackerData(0.0, 0.0, 0.0, 0f, 0f, EntityTypes.PLAYER, player.lastTransactionSent.get());
     }
 
     public int getPacketEntityID(PacketEntity entity) {


### PR DESCRIPTION
Fix the stupid compiler warnings by using wrapper classes for primitives in `TrackerData`.

![image](https://github.com/user-attachments/assets/9ef4ee42-6b2c-4227-97f0-572c50872406)
