### PR TITLE
Ignore labymod client brand by default

### DIFF
--- a/src/main/resources/config/de.yml
+++ b/src/main/resources/config/de.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Alle Zuschauer mit der Berechtigung grim.spectator ausblenden, unabhängig davon, ob sie tatsächlich aktiv zuschauen

--- a/src/main/resources/config/en.yml
+++ b/src/main/resources/config/en.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Hide all spectators with the grim.spectator permission regardless if they are actually actively spectating

--- a/src/main/resources/config/es.yml
+++ b/src/main/resources/config/es.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Ocultar todos los espectadores con el permiso grim.spectator sin importar si realmente están espectando

--- a/src/main/resources/config/fr.yml
+++ b/src/main/resources/config/fr.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Masquer tout les spectateurs ayant la permission grim.spectator, peu importe s'ils sont actuellement en train d'observer.

--- a/src/main/resources/config/it.yml
+++ b/src/main/resources/config/it.yml
@@ -26,6 +26,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Nascondi tutti gli spettatori con il permesso grim.spectator indipendentemente dal fatto che stiano effettivamente spettando attivamente

--- a/src/main/resources/config/ja.yml
+++ b/src/main/resources/config/ja.yml
@@ -27,6 +27,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # 'grim.spectator' パーミッションを持つプレイヤーを、実際にスペクテイター状態でなくても非表示にするかどうか。

--- a/src/main/resources/config/nl.yml
+++ b/src/main/resources/config/nl.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Verberg alle toeschouwers met de grim.spectator-toestemming, ongeacht of ze daadwerkelijk actief toeschouwer zijn

--- a/src/main/resources/config/pt.yml
+++ b/src/main/resources/config/pt.yml
@@ -26,6 +26,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Esconde todos espectadores com a permissão 'grim.spectator' mesmo se não estiverem ativamente espectando.

--- a/src/main/resources/config/ru.yml
+++ b/src/main/resources/config/ru.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Скрыть всех зрителей с разрешением grim.spectator, независимо от того, являются ли они активными зрителями.

--- a/src/main/resources/config/tr.yml
+++ b/src/main/resources/config/tr.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # Seyirciler aktif olarak izliyor olsalar bile, grim.spectator iznine sahip tüm seyircileri gizle

--- a/src/main/resources/config/zh.yml
+++ b/src/main/resources/config/zh.yml
@@ -25,6 +25,7 @@ client-brand:
     - "^fabric$"
     - "^lunarclient:v\\d+\\.\\d+\\.\\d+-\\d{4}$"
     - "^Feather Fabric$"
+    - "^labymod$"
 
 spectators:
   # 将拥有 grim.spectator 权限的人进行隐藏,不管他是否在观察玩家


### PR DESCRIPTION
Ignore the labymod brand by default. A very popular legit client in the german community.