### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+tab_width = 4
+
+# intellij specific configuration
+ij_continuation_indent_size = 8
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = false
+ij_smart_tabs = false
+ij_wrap_on_typing = false


### PR DESCRIPTION
Add `.editorconfig` file to standardize code style (e.g., spaces vs. tabs, charset).
Ensures uniform formatting, improving collaboration (no need for manual setup when using different IDEs).

This is supported by all major IDEs like IntelliJ, Visual Studio, VIM...