### PR TITLE
Fix a rare CME in LatencyUtils

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -7,12 +7,17 @@ import ac.grim.grimac.utils.anticheat.MessageUtil;
 import ac.grim.grimac.utils.data.Pair;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.ListIterator;
 
 public class LatencyUtils {
     private final LinkedList<Pair<Integer, Runnable>> transactionMap = new LinkedList<>();
     private final GrimPlayer player;
+
+    // Built from transactionMap and cleared at start of every handleNettySyncTransaction() call
+    // The actual usage scope of this variable's use is limited to within the synchronized block of handleNettySyncTransaction
+    private final ArrayList<Runnable> tasksToRun = new ArrayList<>();
 
     public LatencyUtils(GrimPlayer player) {
         this.player = player;
@@ -41,21 +46,48 @@ public class LatencyUtils {
     }
 
     public void handleNettySyncTransaction(int transaction) {
+        /*
+         * This code uses a two-pass approach within the synchronized block to prevent CMEs.
+         * First we collect and remove tasks using the iterator, then execute all collected tasks.
+         *
+         * The issue:
+         *     We cannot execute tasks during iteration because if a runnable modifies transactionMap
+         *     or calls addRealTimeTask, it will cause a ConcurrentModificationException.
+         *     While only seen on Folia servers, this is theoretically possible everywhere.
+         *
+         * Why this solution:
+         *     Rather than documenting "don't modify transactionMap in runnables" and risking subtle
+         *     bugs from future contributions or Check API usage, we prevent the issue entirely
+         *     at a small performance cost.
+         *
+         * Future considerations:
+         *     If this becomes a performance bottleneck, we may revisit using a single-pass approach
+         *     on non-Folia servers. We could also explore concurrent data structures or parallel
+         *     execution, but this would lose the guarantee that transactions are processed in order.
+         */
         synchronized (this) {
-            for (ListIterator<Pair<Integer, Runnable>> iterator = transactionMap.listIterator(); iterator.hasNext(); ) {
+            tasksToRun.clear();
+
+            // First pass: collect tasks and mark them for removal
+            ListIterator<Pair<Integer, Runnable>> iterator = transactionMap.listIterator();
+            while (iterator.hasNext()) {
                 Pair<Integer, Runnable> pair = iterator.next();
 
                 // We are at most a tick ahead when running tasks based on transactions, meaning this is too far
                 if (transaction + 1 < pair.first())
-                    return;
+                    break;
 
                 // This is at most tick ahead of what we want
                 if (transaction == pair.first() - 1)
                     continue;
 
+                tasksToRun.add(pair.second());
+                iterator.remove();
+            }
+
+            for (Runnable runnable : tasksToRun) {
                 try {
-                    // Run the task
-                    pair.second().run();
+                    runnable.run();
                 } catch (Exception e) {
                     LogUtil.error("An error has occurred when running transactions for player: " + player.user.getName(), e);
                     // Kick the player SO PEOPLE ACTUALLY REPORT PROBLEMS AND KNOW WHEN THEY HAPPEN
@@ -63,8 +95,6 @@ public class LatencyUtils {
                         player.disconnect(MessageUtil.miniMessage(MessageUtil.replacePlaceholders(player, GrimAPI.INSTANCE.getConfigManager().getDisconnectPacketError())));
                     }
                 }
-                // We ran a task, remove it from the list
-                iterator.remove();
             }
         }
     }


### PR DESCRIPTION
## Problem
The original implementation of `handleNettySyncTransaction` could throw a ConcurrentModificationException if a runnable task modified the `transactionMap` (either directly or by calling `addRealTimeTask`). This was observed on Folia servers but could theoretically occur in any environment.

## Solution
Refactored `handleNettySyncTransaction` to use a two-pass approach:
1. First pass: Collect tasks and remove them from `transactionMap` using the iterator
2. Second pass: Execute the collected tasks

Added a class-level `ArrayList<Runnable>` to store tasks between passes, which is cleared and reused each call to avoid unnecessary allocations.

## Implementation Details
- Added `private final ArrayList<Runnable> tasksToRun` field
- Split the original single loop into collection and execution phases
- Maintained synchronization around both phases to preserve thread safety
- Added detailed comments explaining the approach and rationale
- Chose not to use a ConcurrnetLinkedQueue because iteration may not reflect state of data structure and working to ensure this is always correct for our use case was too complicated

## Performance Considerations
- Using ArrayList for `tasksToRun` as it only needs sequential adds and iteration
- Keeping it as a class field to reuse the backing array
- Maintained LinkedList for `transactionMap` due to its frequent size changes and removal patterns

## Testing
- Verified on local server
- Seems to be working, used in prod by lifestealsmp.com who originally reported the issues and hasn't happened again.

This change makes the code more robust by preventing CMEs rather than relying on documentation to prevent them.
```
[14:31:50 WARN]: [ac.grim.grimac.shaded.com.github.retrooper.packetevents.PacketEventsAPI] PacketEvents caught an unhandled exception while calling your listener.
java.util.ConcurrentModificationException: null
        at java.base/java.util.LinkedList$ListItr.checkForComodification(LinkedList.java:978) ~[?:?]
        at java.base/java.util.LinkedList$ListItr.remove(LinkedList.java:933) ~[?:?]
        at grimac-733.jar/ac.grim.grimac.utils.latency.LatencyUtils.handleNettySyncTransaction(LatencyUtils.java:62) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.player.GrimPlayer.addTransactionResponse(GrimPlayer.java:381) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.events.packets.PacketPingListener.onPacketReceive(PacketPingListener.java:62) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.event.PacketReceiveEvent.call(PacketReceiveEvent.java:44) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.event.EventManager.callEvent(EventManager.java:84) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.util.PacketEventsImplHelper.handleServerBoundPacket(PacketEventsImplHelper.java:101) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.read(PacketEventsDecoder.java:57) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.decode(PacketEventsDecoder.java:64) ~[grimac-733.jar:?]
        at grimac-733.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.decode(PacketEventsDecoder.java:41) ~[grimac-733.jar:?]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:88) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202) ~[netty-handler-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:164) ~[netty-handler-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[netty-codec-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[netty-handler-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[netty-handler-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) ~[netty-transport-classes-epoll-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:509) ~[netty-transport-classes-epoll-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407) ~[netty-transport-classes-epoll-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
        at java.base/java.lang.Thread.run(Thread.java:1575) ~[?:?]
```