### PR TITLE
Fix modeling teleport packets for entities on clients < 1.16.2

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -71,7 +71,7 @@ public class PacketEntityReplication extends Check implements PacketCheck {
             if (entity == playerVehicle && !player.vehicleData.lastDummy) {
                 // The player has this as their vehicle, so they aren't interpolating it.
                 // And it isn't a dummy position
-                entity.setPositionRaw(entity.getPossibleCollisionBoxes());
+                entity.setPositionRaw(player, entity.getPossibleLocationBoxes());
             } else {
                 entity.onMovement(isTickingReliably);
             }

--- a/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -258,7 +258,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
             player.checkManager.getExplosionHandler().forceExempt();
 
             // When in control of the entity, the player sets the entity position to their current position
-            riding.setPositionRaw(GetBoundingBox.getPacketEntityBoundingBox(player, player.x, player.y, player.z, riding));
+            riding.setPositionRaw(player, new SimpleCollisionBox(player.x, player.y, player.z, player.x, player.y, player.z));
 
             if (riding instanceof PacketEntityTrackXRot boat) {
                 boat.packetYaw = player.xRot;

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -16,6 +16,8 @@
 package ac.grim.grimac.utils.data;
 
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.collisions.datatypes.CollisionBox;
+import ac.grim.grimac.utils.collisions.datatypes.NoCollisionBox;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.nmsutil.GetBoundingBox;
@@ -34,12 +36,19 @@ public class ReachInterpolationData {
     private int interpolationSteps = 1;
     private boolean expandNonRelative = false;
 
+    private GrimPlayer player;
+    private TrackedPosition position;
+    private PacketEntity entity;
+
     public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox startingLocation, TrackedPosition position, PacketEntity entity) {
         final boolean isPointNine = !player.inVehicle() && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
 
         this.startingLocation = startingLocation;
         final Vector3d pos = position.getPos();
-        this.targetLocation = GetBoundingBox.getPacketEntityBoundingBox(player, pos.x, pos.y, pos.z, entity);
+        this.targetLocation = new SimpleCollisionBox(pos.x, pos.y, pos.z, pos.x, pos.y, pos.z, false);
+        this.player = player;
+        this.position = position;
+        this.entity = entity;
 
         // 1.9 -> 1.8 precision loss in packets
         // (ViaVersion is doing some stuff that makes this code difficult)
@@ -83,10 +92,51 @@ public class ReachInterpolationData {
         return new SimpleCollisionBox(minX, minY, minZ, maxX, maxY, maxZ);
     }
 
-    // To avoid huge branching when bruteforcing interpolation -
-    // we combine the collision boxes for the steps.
-    //
-    // Designed around being unsure of minimum interp, maximum interp, and target location on 1.9 clients
+    public static CollisionBox getOverlapHitbox(CollisionBox b1, CollisionBox b2) {
+        if (b1 == NoCollisionBox.INSTANCE || b2 == NoCollisionBox.INSTANCE) {
+            return NoCollisionBox.INSTANCE;
+        } else if (!(b1 instanceof SimpleCollisionBox) || !(b2 instanceof SimpleCollisionBox)) {
+            throw new IllegalArgumentException("Both b1 and b2 must be SimpleCollisionBox instances");
+        }
+
+        SimpleCollisionBox box1 = (SimpleCollisionBox) b1;
+        SimpleCollisionBox box2 = (SimpleCollisionBox) b2;
+
+        // Calculate the potential overlap along each axis
+        double overlapMinX = Math.max(box1.minX, box2.minX);
+        double overlapMaxX = Math.min(box1.maxX, box2.maxX);
+        double overlapMinY = Math.max(box1.minY, box2.minY);
+        double overlapMaxY = Math.min(box1.maxY, box2.maxY);
+        double overlapMinZ = Math.max(box1.minZ, box2.minZ);
+        double overlapMaxZ = Math.min(box1.maxZ, box2.maxZ);
+
+        // Check if there's actual overlap along each axis
+        if (overlapMinX > overlapMaxX || overlapMinY > overlapMaxY || overlapMinZ > overlapMaxZ) {
+            return NoCollisionBox.INSTANCE; // No overlap, return null or an appropriate "empty" box representation
+        }
+
+        // Return the overlapping hitbox
+        return new SimpleCollisionBox(overlapMinX, overlapMinY, overlapMinZ, overlapMaxX, overlapMaxY, overlapMaxZ);
+    }
+
+    /**
+     * Calculates a bounding box that contains all possible positions where the entity could be located
+     * during interpolation. This takes into account:<p>
+     * • The starting position<br>
+     * • The target position<br>
+     * • The number of interpolation steps<br>
+     * • The current interpolation progress (low and high bounds)<p>
+     *
+     * To avoid expensive branching when bruteforcing interpolation, this method combines
+     * the collision boxes for all possible steps into a single bounding box. This approach
+     * was specifically designed to handle the uncertainty of minimum interpolation,
+     * maximum interpolation, and target location on 1.9+ clients while still supporting 1.7-1.8.<p>
+     *
+     * For each possible interpolation step between the bounds, it calculates the position
+     * and combines all these positions into a single bounding box that encompasses all of them.
+     *
+     * @return A SimpleCollisionBox containing all possible positions of the entity during interpolation
+     */
     public SimpleCollisionBox getPossibleLocationCombined() {
         int interpSteps = getInterpolationSteps();
 
@@ -115,8 +165,34 @@ public class ReachInterpolationData {
                     startingLocation.maxZ + (step * stepMaxZ)));
         }
 
+        return minimumInterpLocation;
+    }
+
+    /**
+     * Builds upon getPossibleLocationCombined() to create a larger bounding box that contains
+     * not just where the entity could be located, but where any part of its hitbox could be.
+     * This is done by:<p>
+     *
+     * 1. Getting the possible locations using getPossibleLocationCombined()<br>
+     * 2. If needed expand appropriately due to a recent teleport that moved the entity by:<br>
+     *    • X: 0.03125D<br>
+     *    • Y: 0.015625D<br>
+     *    • Z: 0.03125D<br>
+     * 3. Expanding by the entity's bounding box dimensions, but only expanding:<br>
+     *    • Minimum coordinates by negative bounding box values<br>
+     *    • Maximum coordinates by positive bounding box values<p>
+     *
+     * This ensures we have a box containing all possible hitbox positions during interpolation.
+     *
+     * @return A SimpleCollisionBox containing all possible hitbox positions during interpolation
+     */
+    public SimpleCollisionBox getPossibleHitboxCombined() {
+        SimpleCollisionBox minimumInterpLocation = getPossibleLocationCombined();
+
         if (expandNonRelative)
             minimumInterpLocation.expand(0.03125D, 0.015625D, 0.03125D);
+
+        GetBoundingBox.expandBoundingBoxByEntityDimensions(minimumInterpLocation, player, entity);
 
         return minimumInterpLocation;
     }

--- a/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/ReachInterpolationData.java
@@ -36,9 +36,8 @@ public class ReachInterpolationData {
     private int interpolationSteps = 1;
     private boolean expandNonRelative = false;
 
-    private GrimPlayer player;
-    private TrackedPosition position;
-    private PacketEntity entity;
+    private final GrimPlayer player;
+    private final PacketEntity entity;
 
     public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox startingLocation, TrackedPosition position, PacketEntity entity) {
         final boolean isPointNine = !player.inVehicle() && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
@@ -47,7 +46,6 @@ public class ReachInterpolationData {
         final Vector3d pos = position.getPos();
         this.targetLocation = new SimpleCollisionBox(pos.x, pos.y, pos.z, pos.x, pos.y, pos.z, false);
         this.player = player;
-        this.position = position;
         this.entity = entity;
 
         // 1.9 -> 1.8 precision loss in packets
@@ -72,9 +70,11 @@ public class ReachInterpolationData {
     }
 
     // While riding entities, there is no interpolation.
-    public ReachInterpolationData(SimpleCollisionBox finishedLoc) {
+    public ReachInterpolationData(GrimPlayer player, SimpleCollisionBox finishedLoc, PacketEntity entity) {
         this.startingLocation = finishedLoc;
         this.targetLocation = finishedLoc;
+        this.entity = entity;
+        this.player = player;
     }
 
     private int getInterpolationSteps() {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -133,17 +133,6 @@ public class PacketEntity extends TypedPacketEntity {
                 }
                 trackedServerPosition.setPos(vec3d);
             } else {
-                // I think we can reduce this but I'm too lazy to minimize interpolations needed so...
-                SimpleCollisionBox clientArea = newPacketLocation.getPossibleLocationCombined();
-                // In versions < 1.16.2 when the client receives non-relative teleport for an entity
-                // And they move less by the thresholds given, the entity does not move client side
-                if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_16_1)
-                        && clientArea.distanceX(relX) < 0.03125D
-                        && clientArea.distanceY(relY) < 0.015625D
-                        && clientArea.distanceZ(relZ) < 0.03125D
-                ) {
-                    newPacketLocation.expandNonRelative();
-                }
                 trackedServerPosition.setPos(new Vector3d(relX, relY, relZ));
                 // ViaVersion desync's here for teleports
                 // It simply teleports the entity with its position divided by 32... ignoring the offset this causes.
@@ -153,7 +142,6 @@ public class PacketEntity extends TypedPacketEntity {
                 }
             }
         }
-
         this.oldPacketLocation = newPacketLocation;
         this.newPacketLocation = new ReachInterpolationData(player, oldPacketLocation.getPossibleLocationCombined(), trackedServerPosition, this);
 
@@ -209,6 +197,14 @@ public class PacketEntity extends TypedPacketEntity {
         this.trackedServerPosition.setPos(new Vector3d((box.maxX - box.minX) / 2 + box.minX, box.minY, (box.maxZ - box.minZ) / 2 + box.minZ));
         // This disables interpolation
         this.newPacketLocation = new ReachInterpolationData(player, box, this);
+    }
+
+    public SimpleCollisionBox getPossibleLocationBoxes() {
+        if (oldPacketLocation == null) {
+            return newPacketLocation.getPossibleLocationCombined();
+        }
+
+        return ReachInterpolationData.combineCollisionBox(oldPacketLocation.getPossibleLocationCombined(), newPacketLocation.getPossibleLocationCombined());
     }
 
     public SimpleCollisionBox getPossibleCollisionBoxes() {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntity.java
@@ -203,12 +203,12 @@ public class PacketEntity extends TypedPacketEntity {
     }
 
     // This is for handling riding and entities attached to one another.
-    public void setPositionRaw(SimpleCollisionBox box) {
+    public void setPositionRaw(GrimPlayer player, SimpleCollisionBox box) {
         // I'm disappointed in you mojang.  Please don't set the packet position as it desyncs it...
         // But let's follow this flawed client-sided logic!
         this.trackedServerPosition.setPos(new Vector3d((box.maxX - box.minX) / 2 + box.minX, box.minY, (box.maxZ - box.minZ) / 2 + box.minZ));
         // This disables interpolation
-        this.newPacketLocation = new ReachInterpolationData(box);
+        this.newPacketLocation = new ReachInterpolationData(player, box, this);
     }
 
     public SimpleCollisionBox getPossibleCollisionBoxes() {

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.latency;
 
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.ShulkerData;
 import ac.grim.grimac.utils.data.TrackerData;
 import ac.grim.grimac.utils.data.attribute.ValuedAttribute;
@@ -61,7 +62,7 @@ public class CompensatedEntities {
     }
 
     public void tick() {
-        this.self.setPositionRaw(player.boundingBox);
+        this.self.setPositionRaw(player, new SimpleCollisionBox(player.x, player.y, player.z, player.x, player.y, player.z));
         for (PacketEntity vehicle : entityMap.values()) {
             for (PacketEntity passenger : vehicle.passengers) {
                 tickPassenger(vehicle, passenger);
@@ -150,7 +151,7 @@ public class CompensatedEntities {
             return;
         }
 
-        passenger.setPositionRaw(riding.getPossibleCollisionBoxes().offset(0, BoundingBoxSize.getMyRidingOffset(riding) + BoundingBoxSize.getPassengerRidingOffset(player, passenger), 0));
+        passenger.setPositionRaw(player, riding.getPossibleLocationBoxes().offset(0, BoundingBoxSize.getMyRidingOffset(riding) + BoundingBoxSize.getPassengerRidingOffset(player, passenger), 0));
 
         for (PacketEntity passengerPassenger : riding.passengers) {
             tickPassenger(passenger, passengerPassenger);

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/GetBoundingBox.java
@@ -48,4 +48,25 @@ public class GetBoundingBox {
 
         return new SimpleCollisionBox(minX, minY, minZ, maxX, maxY, maxZ, false);
     }
+
+    public static double[] getEntityDimensions(GrimPlayer player, PacketEntity entity) {
+        final float scale = (float) entity.getAttributeValue(Attributes.SCALE);
+        final float width = BoundingBoxSize.getWidth(player, entity) * scale;
+        final float height = BoundingBoxSize.getHeight(player, entity) * scale;
+        return new double[] { width, height, width};
+    }
+
+    public static void expandBoundingBoxByEntityDimensions(SimpleCollisionBox box, GrimPlayer player, PacketEntity entity) {
+        double[] dimensions = getEntityDimensions(player, entity);
+        double halfWidth = dimensions[0] / 2.0;
+        double height = dimensions[1];
+        double halfDepth = dimensions[2] / 2.0;
+
+        box.minX -= halfWidth;
+        box.minY -= 0; // No downward expansion
+        box.minZ -= halfDepth;
+        box.maxX += halfWidth;
+        box.maxY += height;
+        box.maxZ += halfDepth;
+    }
 }


### PR DESCRIPTION
Tested locally, seems to work. Backported from my fork with hitbox visualization which makes these all appear to be correct.