### PR TITLE
Make the placeholders persist

### DIFF
--- a/src/main/java/ac/grim/grimac/manager/init/start/PlaceholderAPIExpansion.java
+++ b/src/main/java/ac/grim/grimac/manager/init/start/PlaceholderAPIExpansion.java
@@ -29,6 +29,11 @@ public class PlaceholderAPIExpansion extends PlaceholderExpansion {
     }
 
     @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
     public @NotNull List<String> getPlaceholders() {
         Set<String> placeholders = GrimAPI.INSTANCE.getExternalAPI().getStaticReplacements().keySet();
         placeholders.addAll(GrimAPI.INSTANCE.getExternalAPI().getVariableReplacements().keySet());


### PR DESCRIPTION
Without the persist method set to true, the Grim placeholders are unregistered whenever the /papi reload command is ran.