### PR TITLE
fix false positive when being inside the edge of a block

### DIFF
--- a/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -281,6 +281,8 @@ public final class PlayerBaseTick {
         double d0 = x - floorX;
         double d1 = z - floorZ;
 
+        double pushUncertainty = 0.17;
+
         boolean suffocates;
 
         if (player.isSwimming) {
@@ -313,26 +315,26 @@ public final class PlayerBaseTick {
             }
 
             if (i == 0) { // Negative X
-                player.uncertaintyHandler.xNegativeUncertainty -= 0.1;
-                player.uncertaintyHandler.xPositiveUncertainty += 0.1;
+                player.uncertaintyHandler.xNegativeUncertainty -= pushUncertainty;
+                player.uncertaintyHandler.xPositiveUncertainty += pushUncertainty;
                 player.pointThreeEstimator.setPushing(true);
             }
 
             if (i == 1) { // Positive X
-                player.uncertaintyHandler.xNegativeUncertainty -= 0.1;
-                player.uncertaintyHandler.xPositiveUncertainty += 0.1;
+                player.uncertaintyHandler.xNegativeUncertainty -= pushUncertainty;
+                player.uncertaintyHandler.xPositiveUncertainty += pushUncertainty;
                 player.pointThreeEstimator.setPushing(true);
             }
 
             if (i == 4) { // Negative Z
-                player.uncertaintyHandler.zNegativeUncertainty -= 0.1;
-                player.uncertaintyHandler.zPositiveUncertainty += 0.1;
+                player.uncertaintyHandler.zNegativeUncertainty -= pushUncertainty;
+                player.uncertaintyHandler.zPositiveUncertainty += pushUncertainty;
                 player.pointThreeEstimator.setPushing(true);
             }
 
             if (i == 5) { // Positive Z
-                player.uncertaintyHandler.zNegativeUncertainty -= 0.1;
-                player.uncertaintyHandler.zPositiveUncertainty += 0.1;
+                player.uncertaintyHandler.zNegativeUncertainty -= pushUncertainty;
+                player.uncertaintyHandler.zPositiveUncertainty += pushUncertainty;
                 player.pointThreeEstimator.setPushing(true);
             }
         }

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -534,22 +534,6 @@ public class Collisions {
                         // If honey sliding, fall distance is 0
                         player.fallDistance = 0;
                     }
-
-                    if (blockType.isBlocking()) {
-                        boolean fullyInsideBlock = player.x >= blockX && player.x < blockX + 1 && player.y >= blockY && player.y < blockY + 1 && player.z >= blockZ && player.z < blockZ + 1;
-
-                        if (!fullyInsideBlock) {
-                            // The player is partially inside one or more blocks.
-                            // This can happen if sand falls onto the player and the player.
-                            // actively tries to resist being pushed away.
-                            //
-                            // => player will be stuck on the edge of the block causing weird movement behavior
-                            // which leads to a false positive
-
-                            // Will increase the tolerance for collision checks
-                            player.uncertaintyHandler.isNearGlitchyBlock = true;
-                        }
-                    }
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -534,6 +534,22 @@ public class Collisions {
                         // If honey sliding, fall distance is 0
                         player.fallDistance = 0;
                     }
+
+                    if (blockType.isBlocking()) {
+                        boolean fullyInsideBlock = player.x >= blockX && player.x < blockX + 1 && player.y >= blockY && player.y < blockY + 1 && player.z >= blockZ && player.z < blockZ + 1;
+
+                        if (!fullyInsideBlock) {
+                            // The player is partially inside one or more blocks.
+                            // This can happen if sand falls onto the player and the player.
+                            // actively tries to resist being pushed away.
+                            //
+                            // => player will be stuck on the edge of the block causing weird movement behavior
+                            // which leads to a false positive
+
+                            // Will increase the tolerance for collision checks
+                            player.uncertaintyHandler.isNearGlitchyBlock = true;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
closes #2000 (Happens with all blocks that the player can collide with, not just gravity blocks)

Currently tested on 1.8.8/1.8.9 (same version as in issue).
I will do some more testing on other versions before marking it as ready.

let me know if there is anything important i need to consider when using
``isNearGlitchyBlock``, i just used it here to increase the collision threshold when the player is partially inside a block.