### PR TITLE
Optimize packet event handling

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
@@ -26,14 +26,14 @@ public class AbstractPacketCheck extends Check implements PacketCheck {
 
     @Override
     public Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> getSendHandlers() {
-        PacketHandlerRegistry<PacketSendEvent> registry = new PacketHandlerRegistry<>();
+        PacketHandlerRegistry<PacketSendEvent> registry = new PacketHandlerRegistry<>(false);
         registerSendHandlers(registry);
         return registry.getHandlers();
     }
 
     @Override
     public Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> getReceiveHandlers() {
-        PacketHandlerRegistry<PacketReceiveEvent> registry = new PacketHandlerRegistry<>();
+        PacketHandlerRegistry<PacketReceiveEvent> registry = new PacketHandlerRegistry<>(true);
         registerReceiveHandlers(registry);
         return registry.getHandlers();
     }

--- a/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-@Getter
 public class AbstractPacketCheck extends Check implements PacketCheck {
 
     public AbstractPacketCheck(GrimPlayer player) {

--- a/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/AbstractPacketCheck.java
@@ -1,0 +1,40 @@
+package ac.grim.grimac.checks;
+
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Getter
+public class AbstractPacketCheck extends Check implements PacketCheck {
+
+    public AbstractPacketCheck(GrimPlayer player) {
+        super(player);
+    }
+
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+    }
+
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+    }
+
+    @Override
+    public Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> getSendHandlers() {
+        PacketHandlerRegistry<PacketSendEvent> registry = new PacketHandlerRegistry<>();
+        registerSendHandlers(registry);
+        return registry.getHandlers();
+    }
+
+    @Override
+    public Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> getReceiveHandlers() {
+        PacketHandlerRegistry<PacketReceiveEvent> registry = new PacketHandlerRegistry<>();
+        registerReceiveHandlers(registry);
+        return registry.getHandlers();
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/src/main/java/ac/grim/grimac/checks/Check.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
 
+
 // Class from https://github.com/Tecnio/AntiCheatBase/blob/master/src/main/java/me/tecnio/anticheat/check/Check.java
 @Getter
 public class Check extends GrimProcessor implements AbstractCheck {
@@ -72,7 +73,8 @@ public class Check extends GrimProcessor implements AbstractCheck {
                     noSetbackPermission = player.bukkitPlayer.hasPermission("grim.nosetback." + id);
                     noModifyPacketPermission = player.bukkitPlayer.hasPermission("grim.nomodifypacket." + id);
                 },
-                () -> {}
+                () -> {
+                }
         );
     }
 
@@ -205,5 +207,4 @@ public class Check extends GrimProcessor implements AbstractCheck {
 
         return isFlying(packetType);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/src/main/java/ac/grim/grimac/checks/Check.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
 
-
 // Class from https://github.com/Tecnio/AntiCheatBase/blob/master/src/main/java/me/tecnio/anticheat/check/Check.java
 @Getter
 public class Check extends GrimProcessor implements AbstractCheck {
@@ -73,8 +72,7 @@ public class Check extends GrimProcessor implements AbstractCheck {
                     noSetbackPermission = player.bukkitPlayer.hasPermission("grim.nosetback." + id);
                     noModifyPacketPermission = player.bukkitPlayer.hasPermission("grim.nomodifypacket." + id);
                 },
-                () -> {
-                }
+                () -> {}
         );
     }
 

--- a/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
+++ b/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
@@ -6,7 +6,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import lombok.Getter;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
 
 public class PacketHandlerRegistry<T extends ProtocolPacketEvent> {
     @Getter
-    private final Map<PacketTypeCommon, List<Consumer<T>>> handlers = new HashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<T>>> handlers = new IdentityHashMap<>();
     private final boolean serverbound;
 
     public PacketHandlerRegistry(boolean serverbound) {

--- a/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
+++ b/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
@@ -1,0 +1,48 @@
+package ac.grim.grimac.checks;
+
+import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+@Getter
+public class PacketHandlerRegistry<T extends ProtocolPacketEvent> {
+    private final Map<PacketTypeCommon, List<Consumer<T>>> handlers = new HashMap<>();
+
+    public void registerHandler(Consumer<T> consumer, PacketTypeCommon... types) {
+        if (types.length == 0) {
+            registerHandler(consumer, type -> true);
+            return;
+        }
+        for (PacketTypeCommon type : types) {
+            handlers.computeIfAbsent(type, __ -> new ArrayList<>()).add(consumer);
+        }
+    }
+
+    public void registerHandler(Consumer<T> consumer, Predicate<PacketTypeCommon> typePredicate) {
+        List<PacketTypeCommon> types = new ArrayList<>();
+        for (PacketType.Play.Server packet : PacketType.Play.Server.values()) {
+            if (typePredicate.test(packet)) types.add(packet);
+        }
+        for (PacketType.Login.Server packet : PacketType.Login.Server.values()) {
+            if (typePredicate.test(packet)) types.add(packet);
+        }
+        for (PacketType.Status.Server packet : PacketType.Status.Server.values()) {
+            if (typePredicate.test(packet)) types.add(packet);
+        }
+        for (PacketType.Configuration.Server packet : PacketType.Configuration.Server.values()) {
+            if (typePredicate.test(packet)) types.add(packet);
+        }
+        for (PacketType.Handshaking.Server packet : PacketType.Handshaking.Server.values()) {
+            if (typePredicate.test(packet)) types.add(packet);
+        }
+        registerHandler(consumer, types.toArray(PacketTypeCommon[]::new));
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
+++ b/src/main/java/ac/grim/grimac/checks/PacketHandlerRegistry.java
@@ -12,9 +12,14 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-@Getter
 public class PacketHandlerRegistry<T extends ProtocolPacketEvent> {
+    @Getter
     private final Map<PacketTypeCommon, List<Consumer<T>>> handlers = new HashMap<>();
+    private final boolean serverbound;
+
+    public PacketHandlerRegistry(boolean serverbound) {
+        this.serverbound = serverbound;
+    }
 
     public void registerHandler(Consumer<T> consumer, PacketTypeCommon... types) {
         if (types.length == 0) {
@@ -28,20 +33,38 @@ public class PacketHandlerRegistry<T extends ProtocolPacketEvent> {
 
     public void registerHandler(Consumer<T> consumer, Predicate<PacketTypeCommon> typePredicate) {
         List<PacketTypeCommon> types = new ArrayList<>();
-        for (PacketType.Play.Server packet : PacketType.Play.Server.values()) {
-            if (typePredicate.test(packet)) types.add(packet);
-        }
-        for (PacketType.Login.Server packet : PacketType.Login.Server.values()) {
-            if (typePredicate.test(packet)) types.add(packet);
-        }
-        for (PacketType.Status.Server packet : PacketType.Status.Server.values()) {
-            if (typePredicate.test(packet)) types.add(packet);
-        }
-        for (PacketType.Configuration.Server packet : PacketType.Configuration.Server.values()) {
-            if (typePredicate.test(packet)) types.add(packet);
-        }
-        for (PacketType.Handshaking.Server packet : PacketType.Handshaking.Server.values()) {
-            if (typePredicate.test(packet)) types.add(packet);
+        if (serverbound) {
+            for (PacketType.Play.Client packet : PacketType.Play.Client.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Login.Client packet : PacketType.Login.Client.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Status.Client packet : PacketType.Status.Client.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Configuration.Client packet : PacketType.Configuration.Client.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Handshaking.Client packet : PacketType.Handshaking.Client.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+        } else {
+            for (PacketType.Play.Server packet : PacketType.Play.Server.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Login.Server packet : PacketType.Login.Server.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Status.Server packet : PacketType.Status.Server.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Configuration.Server packet : PacketType.Configuration.Server.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
+            for (PacketType.Handshaking.Server packet : PacketType.Handshaking.Server.values()) {
+                if (typePredicate.test(packet)) types.add(packet);
+            }
         }
         registerHandler(consumer, types.toArray(PacketTypeCommon[]::new));
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsA.java
@@ -1,15 +1,15 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientHeldItemChange;
 
 @CheckData(name = "BadPacketsA", description = "Sent duplicate slot id")
-public class BadPacketsA extends Check implements PacketCheck {
+public class BadPacketsA extends AbstractPacketCheck {
     int lastSlot = -1;
 
     public BadPacketsA(final GrimPlayer player) {
@@ -17,8 +17,8 @@ public class BadPacketsA extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.HELD_ITEM_CHANGE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final int slot = new WrapperPlayClientHeldItemChange(event).getSlot();
 
             if (slot == lastSlot && flagAndAlert("slot=" + slot) && shouldModifyPackets()) {
@@ -27,6 +27,6 @@ public class BadPacketsA extends Check implements PacketCheck {
             }
 
             lastSlot = slot;
-        }
+        }, PacketType.Play.Client.HELD_ITEM_CHANGE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsC.java
@@ -1,23 +1,23 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 
 @CheckData(name = "BadPacketsC", description = "Interacted with self")
-public class BadPacketsC extends Check implements PacketCheck {
+public class BadPacketsC extends AbstractPacketCheck {
     public BadPacketsC(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (player.gamemode == GameMode.SPECTATOR) return;
             if (new WrapperPlayClientInteractEntity(event).getEntityId() == player.entityID) {
                 // Instant ban
@@ -26,6 +26,6 @@ public class BadPacketsC extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.INTERACT_ENTITY);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsD.java
@@ -1,24 +1,23 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "BadPacketsD", description = "Impossible pitch")
-public class BadPacketsD extends Check implements PacketCheck {
+public class BadPacketsD extends AbstractPacketCheck {
     public BadPacketsD(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.packetStateData.lastPacketWasTeleport) return;
-
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_ROTATION || event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.lastPacketWasTeleport) return;
             final float pitch = new WrapperPlayClientPlayerFlying(event).getLocation().getPitch();
             if (pitch > 90 || pitch < -90) {
                 // Ban.
@@ -33,6 +32,6 @@ public class BadPacketsD extends Check implements PacketCheck {
                     }
                 }
             }
-        }
+        }, PacketType.Play.Client.PLAYER_ROTATION, PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsE.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsE.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -12,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "BadPacketsE")
-public class BadPacketsE extends Check implements PacketCheck {
+public class BadPacketsE extends AbstractPacketCheck {
     private int noReminderTicks;
 
     public BadPacketsE(GrimPlayer player) {
@@ -20,21 +20,23 @@ public class BadPacketsE extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        final boolean isViaPleaseStopUsingProtocolHacksOnYourServer = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21_2) || PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21_2);
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION ||
-                event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION) {
-            noReminderTicks = 0;
-        } else if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
-            noReminderTicks++;
-        } else if (event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE
-                || (isViaPleaseStopUsingProtocolHacksOnYourServer && player.inVehicle())) {
-            noReminderTicks = 0; // Exempt vehicles
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            final boolean isViaPleaseStopUsingProtocolHacksOnYourServer = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21_2) || PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21_2);
+            if (event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION ||
+                    event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION) {
+                noReminderTicks = 0;
+            } else if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+                noReminderTicks++;
+            } else if (event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE
+                    || (isViaPleaseStopUsingProtocolHacksOnYourServer && player.inVehicle())) {
+                noReminderTicks = 0; // Exempt vehicles
+            }
 
-        if (noReminderTicks > 20) {
-            flagAndAlert("ticks=" + noReminderTicks); // ban?  I don't know how this would false
-        }
+            if (noReminderTicks > 20) {
+                flagAndAlert("ticks=" + noReminderTicks); // ban?  I don't know how this would false
+            }
+        });
     }
 
     public void handleRespawn() {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsF.java
@@ -1,15 +1,15 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "BadPacketsF", description = "Sent duplicate sprinting status")
-public class BadPacketsF extends Check implements PacketCheck {
+public class BadPacketsF extends AbstractPacketCheck {
     public boolean lastSprinting;
     public boolean exemptNext = true; // Support 1.14+ clients starting on either true or false sprinting, we don't know
 
@@ -18,8 +18,8 @@ public class BadPacketsF extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientEntityAction packet = new WrapperPlayClientEntityAction(event);
 
             if (packet.getAction() == WrapperPlayClientEntityAction.Action.START_SPRINTING) {
@@ -49,6 +49,6 @@ public class BadPacketsF extends Check implements PacketCheck {
 
                 lastSprinting = false;
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsG.java
@@ -1,15 +1,15 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "BadPacketsG", description = "Sent duplicate sneaking status")
-public class BadPacketsG extends Check implements PacketCheck {
+public class BadPacketsG extends AbstractPacketCheck {
     private boolean lastSneaking, respawn;
 
     public BadPacketsG(GrimPlayer player) {
@@ -17,8 +17,8 @@ public class BadPacketsG extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientEntityAction packet = new WrapperPlayClientEntityAction(event);
 
             if (packet.getAction() == WrapperPlayClientEntityAction.Action.START_SNEAKING) {
@@ -43,7 +43,7 @@ public class BadPacketsG extends Check implements PacketCheck {
                 }
                 respawn = false;
             }
-        }
+        },  PacketType.Play.Client.ENTITY_ACTION);
     }
 
     public void handleRespawn() {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -12,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 
 @CheckData(name = "BadPacketsH", description = "Did not swing for attack")
-public class BadPacketsH extends Check implements PacketCheck {
+public class BadPacketsH extends AbstractPacketCheck {
 
     // 1.9 packet order: INTERACT -> ANIMATION
     // 1.8 packet order: ANIMATION -> INTERACT
@@ -24,10 +24,11 @@ public class BadPacketsH extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ANIMATION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             sentAnimation = true;
-        } else if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+        },  PacketType.Play.Client.ANIMATION);
+        registry.registerHandler(event -> {
             WrapperPlayClientInteractEntity packet = new WrapperPlayClientInteractEntity(event);
             if (packet.getAction() != WrapperPlayClientInteractEntity.InteractAction.ATTACK) return;
 
@@ -49,6 +50,6 @@ public class BadPacketsH extends Check implements PacketCheck {
             }
 
             sentAnimation = false;
-        }
+        },  PacketType.Play.Client.INTERACT_ENTITY);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsI.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsI.java
@@ -1,28 +1,28 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerAbilities;
 
 @CheckData(name = "BadPacketsI", description = "Claimed to be flying while unable to fly")
-public class BadPacketsI extends Check implements PacketCheck {
+public class BadPacketsI extends AbstractPacketCheck {
     public BadPacketsI(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_ABILITIES) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (new WrapperPlayClientPlayerAbilities(event).isFlying() && !player.canFly) {
                 if (flagAndAlert() && shouldModifyPackets()) {
                     event.setCancelled(true);
                     player.onPacketCancel();
                 }
             }
-        }
+        },  PacketType.Play.Client.PLAYER_ABILITIES);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsK.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsK.java
@@ -1,28 +1,28 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 
 @CheckData(name = "BadPacketsK", description = "Sent spectate packets while not in spectator mode")
-public class BadPacketsK extends Check implements PacketCheck {
+public class BadPacketsK extends AbstractPacketCheck {
     public BadPacketsK(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.SPECTATE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (player.gamemode != GameMode.SPECTATOR) {
                 if (flagAndAlert() && shouldModifyPackets()) {
                     event.setCancelled(true);
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.SPECTATE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsL.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -13,18 +13,19 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPl
 import java.util.Locale;
 
 @CheckData(name = "BadPacketsL", description = "Sent impossible dig packet")
-public class BadPacketsL extends Check implements PacketCheck {
+public class BadPacketsL extends AbstractPacketCheck {
 
     public BadPacketsL(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
 
-            if (packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING || packet.getAction() == DiggingAction.CANCELLED_DIGGING) return;
+            if (packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING || packet.getAction() == DiggingAction.CANCELLED_DIGGING)
+                return;
 
             // 1.8 and above clients always send digging packets that aren't used for digging at 0, 0, 0, facing DOWN
             // 1.7 and below clients do the same, except use SOUTH for RELEASE_USE_ITEM
@@ -47,6 +48,6 @@ public class BadPacketsL extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.PLAYER_DIGGING);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsM.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -12,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 
 @CheckData(name = "BadPacketsM")
-public class BadPacketsM extends Check implements PacketCheck {
+public class BadPacketsM extends AbstractPacketCheck {
     public BadPacketsM(final GrimPlayer player) {
         super(player);
     }
@@ -22,9 +22,9 @@ public class BadPacketsM extends Check implements PacketCheck {
     private boolean sentInteractAt = false;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY && !exempt) {
-
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (exempt) return;
             final WrapperPlayClientInteractEntity wrapper = new WrapperPlayClientInteractEntity(event);
 
             final PacketEntity entity = player.compensatedEntities.entityMap.get(wrapper.getEntityId());
@@ -56,6 +56,6 @@ public class BadPacketsM extends Check implements PacketCheck {
                     sentInteractAt = true;
                     break;
             }
-        }
+        },  PacketType.Play.Client.INTERACT_ENTITY);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsN.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsN.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "BadPacketsN", setback = 0)
-public class BadPacketsN extends Check implements PacketCheck {
+public class BadPacketsN extends AbstractPacketCheck {
     public BadPacketsN(final GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsO.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsO.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.Pair;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -15,7 +15,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 @CheckData(name = "BadPacketsO")
-public class BadPacketsO extends Check implements PacketCheck {
+public class BadPacketsO extends AbstractPacketCheck {
     Queue<Pair<Long, Long>> keepaliveMap = new LinkedList<>();
 
     public BadPacketsO(GrimPlayer player) {
@@ -23,16 +23,16 @@ public class BadPacketsO extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.KEEP_ALIVE) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerKeepAlive packet = new WrapperPlayServerKeepAlive(event);
             keepaliveMap.add(new Pair<>(packet.getId(), System.nanoTime()));
-        }
+        }, PacketType.Play.Server.KEEP_ALIVE);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.KEEP_ALIVE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientKeepAlive packet = new WrapperPlayClientKeepAlive(event);
 
             long id = packet.getId();
@@ -57,6 +57,6 @@ public class BadPacketsO extends Check implements PacketCheck {
                     if (data == null) break;
                 } while (data.first() != id);
             }
-        }
+        }, PacketType.Play.Client.KEEP_ALIVE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsP.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsP.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
@@ -12,7 +12,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientCl
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow;
 
 @CheckData(name = "BadPacketsP", experimental = true)
-public class BadPacketsP extends Check implements PacketCheck {
+public class BadPacketsP extends AbstractPacketCheck {
 
     public BadPacketsP(GrimPlayer playerData) {
         super(playerData);
@@ -22,17 +22,17 @@ public class BadPacketsP extends Check implements PacketCheck {
     private int containerId = -1;
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerOpenWindow window = new WrapperPlayServerOpenWindow(event);
             this.containerType = window.getType();
             this.containerId = window.getContainerId();
-        }
+        }, PacketType.Play.Server.OPEN_WINDOW);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientClickWindow wrapper = new WrapperPlayClientClickWindow(event);
             WindowClickType clickType = wrapper.getWindowClickType();
             int button = wrapper.getButton();
@@ -54,6 +54,6 @@ public class BadPacketsP extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.CLICK_WINDOW);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsQ.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsQ.java
@@ -1,23 +1,23 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Client;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction.Action;
 
 @CheckData(name = "BadPacketsQ")
-public class BadPacketsQ extends Check implements PacketCheck {
+public class BadPacketsQ extends AbstractPacketCheck {
     public BadPacketsQ(final GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == Client.ENTITY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientEntityAction wrapper = new WrapperPlayClientEntityAction(event);
             // you are able to send negative jump boost, how and why!?
             if (Math.abs(wrapper.getJumpBoost()) > 100
@@ -28,6 +28,6 @@ public class BadPacketsQ extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsR.java
@@ -1,15 +1,15 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 
 @CheckData(name = "BadPacketsR", decay = 0.25, experimental = true)
-public class BadPacketsR extends Check implements PacketCheck {
+public class BadPacketsR extends AbstractPacketCheck {
     public BadPacketsR(final GrimPlayer player) {
         super(player);
     }
@@ -20,8 +20,9 @@ public class BadPacketsR extends Check implements PacketCheck {
     private int oldTransId = 0;
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (isTransaction(event.getPacketType()) && player.packetStateData.lastTransactionPacketWasValid) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (!player.packetStateData.lastTransactionPacketWasValid) return;
             long ms = (player.getPlayerClockAtLeast() - clock) / 1000000L;
             long diff = (System.currentTimeMillis() - lastTransTime);
             if (diff > 2000 && ms > 2000) {
@@ -36,15 +37,14 @@ public class BadPacketsR extends Check implements PacketCheck {
                 lastTransTime = System.currentTimeMillis();
                 oldTransId = player.lastTransactionSent.get();
             }
-        }
-        //
-        if ((event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION ||
-                event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION) && !player.inVehicle()) {
+        }, this::isTransaction);
+        registry.registerHandler(event -> {
+            if (player.inVehicle()) return;
             positions++;
-        } else if ((event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE || event.getPacketType() == PacketType.Play.Client.VEHICLE_MOVE)
-                && player.inVehicle()) {
+        }, PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION, PacketType.Play.Client.PLAYER_POSITION);
+        registry.registerHandler(event -> {
+            if (!player.inVehicle()) return;
             positions++;
-        }
+        }, PacketType.Play.Client.STEER_VEHICLE, PacketType.Play.Client.VEHICLE_MOVE);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsS.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "BadPacketsS")
-public class BadPacketsS extends Check implements PacketCheck {
+public class BadPacketsS extends AbstractPacketCheck {
     public BadPacketsS(GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsT.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -13,7 +13,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 
 @CheckData(name = "BadPacketsT")
-public class BadPacketsT extends Check implements PacketCheck {
+public class BadPacketsT extends AbstractPacketCheck {
     public BadPacketsT(final GrimPlayer player) {
         super(player);
     }
@@ -27,8 +27,8 @@ public class BadPacketsT extends Check implements PacketCheck {
     private final double maxVerticalDisplacement = 1.8001 + (hasLegacyExpansion ? 0.1 : 0);
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType().equals(PacketType.Play.Client.INTERACT_ENTITY)) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final WrapperPlayClientInteractEntity wrapper = new WrapperPlayClientInteractEntity(event);
             // Only INTERACT_AT actually has an interaction vector
             wrapper.getTarget().ifPresent(targetVector -> {
@@ -62,6 +62,6 @@ public class BadPacketsT extends Check implements PacketCheck {
                 // We could pretty much ban the player at this point
                 flagAndAlert(verbose);
             });
-        }
+        },  PacketType.Play.Client.INTERACT_ENTITY);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsU.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsU.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
@@ -15,14 +15,14 @@ import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerBlockPlacement;
 
 @CheckData(name = "BadPacketsU", description = "Sent impossible use item packet")
-public class BadPacketsU extends Check implements PacketCheck {
+public class BadPacketsU extends AbstractPacketCheck {
     public BadPacketsU(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final WrapperPlayClientPlayerBlockPlacement packet = new WrapperPlayClientPlayerBlockPlacement(event);
             // BlockFace.OTHER is USE_ITEM for pre 1.9
             if (packet.getFace() == BlockFace.OTHER) {
@@ -57,7 +57,7 @@ public class BadPacketsU extends Check implements PacketCheck {
                     }
                 }
             }
-        }
+        },  PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT);
     }
 
     private boolean isEmpty(ItemStack itemStack) {

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsV.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -11,7 +11,7 @@ import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "BadPacketsV", description = "Did not move far enough", experimental = true)
-public class BadPacketsV extends Check implements PacketCheck {
+public class BadPacketsV extends AbstractPacketCheck {
     public BadPacketsV(GrimPlayer player) {
         super(player);
     }
@@ -19,8 +19,9 @@ public class BadPacketsV extends Check implements PacketCheck {
     private int noReminderTicks;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (!player.canSkipTicks() && isTickPacket(event.getPacketType())) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.canSkipTicks() || !isTickPacket(event.getPacketType())) return;
             if (event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION || event.getPacketType() == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION) {
                 int positionAtLeastEveryNTicks = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8) ? 20 : 19;
 
@@ -36,6 +37,6 @@ public class BadPacketsV extends Check implements PacketCheck {
             } else {
                 noReminderTicks++;
             }
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsW.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "BadPacketsW", description = "Interacted with non-existent entity", experimental = true)
-public class BadPacketsW extends Check implements PacketCheck {
+public class BadPacketsW extends AbstractPacketCheck {
     public BadPacketsW(GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsX.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsX.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "BadPacketsX", experimental = true)
-public class BadPacketsX extends Check implements PostPredictionCheck {
+public class BadPacketsX extends AbstractPacketCheck implements PostPredictionCheck {
     public BadPacketsX(GrimPlayer player) {
         super(player);
     }
@@ -41,37 +42,39 @@ public class BadPacketsX extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
-            sprint = sneak = false;
-            return;
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
+                sprint = sneak = false;
+                return;
+            }
 
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
-            switch (new WrapperPlayClientEntityAction(event).getAction()) {
-                case START_SNEAKING, STOP_SNEAKING -> {
-                    if (sneak) {
-                        if (player.canSkipTicks() || flagAndAlert()) {
-                            flags++;
+            if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+                switch (new WrapperPlayClientEntityAction(event).getAction()) {
+                    case START_SNEAKING, STOP_SNEAKING -> {
+                        if (sneak) {
+                            if (player.canSkipTicks() || flagAndAlert()) {
+                                flags++;
+                            }
                         }
-                    }
 
-                    sneak = true;
-                }
-                case START_SPRINTING, STOP_SPRINTING -> {
-                    if (player.inVehicle()) {
-                        return;
+                        sneak = true;
                     }
-
-                    if (sprint) {
-                        if (player.canSkipTicks() || flagAndAlert()) {
-                            flags++;
+                    case START_SPRINTING, STOP_SPRINTING -> {
+                        if (player.inVehicle()) {
+                            return;
                         }
-                    }
 
-                    sprint = true;
+                        if (sprint) {
+                            if (player.canSkipTicks() || flagAndAlert()) {
+                                flags++;
+                            }
+                        }
+
+                        sprint = true;
+                    }
                 }
             }
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsY.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsY.java
@@ -1,29 +1,29 @@
 package ac.grim.grimac.checks.impl.badpackets;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientHeldItemChange;
 
 @CheckData(name = "BadPacketsY", description = "Sent out of bounds slot id")
-public class BadPacketsY extends Check implements PacketCheck {
+public class BadPacketsY extends AbstractPacketCheck {
     public BadPacketsY(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.HELD_ITEM_CHANGE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final int slot = new WrapperPlayClientHeldItemChange(event).getSlot();
             if (slot > 8 || slot < 0) { // ban
-                if (flagAndAlert("slot="+slot) && shouldModifyPackets()) {
+                if (flagAndAlert("slot=" + slot) && shouldModifyPackets()) {
                     event.setCancelled(true);
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.HELD_ITEM_CHANGE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/breaking/FastBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/breaking/FastBreak.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.breaking;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.BlockBreakCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockBreak;
@@ -23,7 +24,7 @@ import java.util.Set;
 // Also based loosely off of NoCheatPlus FastBreak
 // Also based off minecraft wiki: https://minecraft.wiki/w/Breaking#Instant_breaking
 @CheckData(name = "FastBreak", description = "Breaking blocks too quickly")
-public class FastBreak extends Check implements BlockBreakCheck {
+public class FastBreak extends AbstractPacketCheck implements BlockBreakCheck {
 
     // For some reason these states flag and I don't know why.
     // Better to just exempt to not annoy legit players.
@@ -105,12 +106,14 @@ public class FastBreak extends Check implements BlockBreakCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        // Find the most optimal block damage using the animation packet, which is sent at least once a tick when breaking blocks
-        // On 1.8 clients, via screws with this packet meaning we must fall back to the 1.8 idle flying packet
-        if ((player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? event.getPacketType() == PacketType.Play.Client.ANIMATION : WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) && targetBlock != null) {
-            maximumBlockDamage = Math.max(maximumBlockDamage, BlockBreakSpeed.getBlockDamage(player, targetBlock));
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            // Find the most optimal block damage using the animation packet, which is sent at least once a tick when breaking blocks
+            // On 1.8 clients, via screws with this packet meaning we must fall back to the 1.8 idle flying packet
+            if ((player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? event.getPacketType() == PacketType.Play.Client.ANIMATION : WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) && targetBlock != null) {
+                maximumBlockDamage = Math.max(maximumBlockDamage, BlockBreakSpeed.getBlockDamage(player, targetBlock));
+            }
+        }, type -> type == PacketType.Play.Client.ANIMATION || isFlying(type));
     }
 
     private void clampBalance() {

--- a/src/main/java/ac/grim/grimac/checks/impl/breaking/MultiBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/breaking/MultiBreak.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.breaking;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.BlockBreakCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
@@ -17,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @CheckData(name = "MultiBreak", experimental = true)
-public class MultiBreak extends Check implements BlockBreakCheck {
+public class MultiBreak extends AbstractPacketCheck implements BlockBreakCheck {
     public MultiBreak(GrimPlayer player) {
         super(player);
     }
@@ -53,10 +54,12 @@ public class MultiBreak extends Check implements BlockBreakCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
-            hasBroken = false;
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
+                hasBroken = false;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/breaking/NoSwingBreak.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/breaking/NoSwingBreak.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.breaking;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.BlockBreakCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockBreak;
@@ -10,7 +11,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.DiggingAction;
 
 @CheckData(name = "NoSwingBreak", description = "Did not swing while breaking block", experimental = true)
-public class NoSwingBreak extends Check implements BlockBreakCheck {
+public class NoSwingBreak extends AbstractPacketCheck implements BlockBreakCheck {
     public NoSwingBreak(GrimPlayer playerData) {
         super(playerData);
     }
@@ -26,17 +27,15 @@ public class NoSwingBreak extends Check implements BlockBreakCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ANIMATION) {
-            sentAnimation = true;
-        }
-
-        if (isTickPacket(event.getPacketType())) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> sentAnimation = true, PacketType.Play.Client.ANIMATION);
+        registry.registerHandler(event -> {
+            if (!isTickPacket(event.getPacketType())) return;
             if (sentBreak && !sentAnimation) {
                 flagAndAlert();
             }
 
             sentAnimation = sentBreak = false;
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Hitboxes.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Hitboxes.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.combat;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "Hitboxes", setback = 10)
-public class Hitboxes extends Check implements PacketCheck {
+public class Hitboxes extends AbstractPacketCheck {
     public Hitboxes(GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/MultiInteractA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/MultiInteractA.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.combat;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -13,7 +14,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientIn
 import java.util.ArrayList;
 
 @CheckData(name = "MultiInteractA", description = "Interacted with multiple entities in the same tick", experimental = true)
-public class MultiInteractA extends Check implements PostPredictionCheck {
+public class MultiInteractA extends AbstractPacketCheck implements PostPredictionCheck {
     public MultiInteractA(final GrimPlayer player) {
         super(player);
     }
@@ -24,8 +25,8 @@ public class MultiInteractA extends Check implements PostPredictionCheck {
     private boolean hasInteracted = false;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientInteractEntity packet = new WrapperPlayClientInteractEntity(event);
             int entity = packet.getEntityId();
             boolean sneaking = packet.isSneaking().orElse(false);
@@ -46,11 +47,12 @@ public class MultiInteractA extends Check implements PostPredictionCheck {
             lastEntity = entity;
             lastSneaking = sneaking;
             hasInteracted = true;
-        }
-
-        if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
-            hasInteracted = false;
-        }
+        }, PacketType.Play.Client.INTERACT_ENTITY);
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
+                hasInteracted = false;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/MultiInteractB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/MultiInteractB.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.combat;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
@@ -15,7 +16,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientIn
 import java.util.ArrayList;
 
 @CheckData(name = "MultiInteractB", experimental = true)
-public class MultiInteractB extends Check implements PostPredictionCheck {
+public class MultiInteractB extends AbstractPacketCheck implements PostPredictionCheck {
     public MultiInteractB(final GrimPlayer player) {
         super(player);
     }
@@ -25,8 +26,8 @@ public class MultiInteractB extends Check implements PostPredictionCheck {
     private boolean hasInteracted = false;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             Vector3f pos = new WrapperPlayClientInteractEntity(event).getTarget().orElse(null);
 
             if (pos == null) {
@@ -47,11 +48,12 @@ public class MultiInteractB extends Check implements PostPredictionCheck {
 
             lastPos = pos;
             hasInteracted = true;
-        }
-
-        if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
-            hasInteracted = false;
-        }
+        },  PacketType.Play.Client.INTERACT_ENTITY);
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
+                hasInteracted = false;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -16,9 +16,9 @@
 package ac.grim.grimac.checks.impl.combat;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
@@ -38,11 +38,14 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 // You may not copy the check unless you are licensed under GPL
 @CheckData(name = "Reach", setback = 10)
-public class Reach extends Check implements PacketCheck {
+public class Reach extends AbstractPacketCheck {
 
     // Only one flag per reach attack, per entity, per tick.
     // We store position because lastX isn't reliable on teleports.
@@ -61,8 +64,9 @@ public class Reach extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (!player.disableGrim && event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.disableGrim) return;
             WrapperPlayClientInteractEntity action = new WrapperPlayClientInteractEntity(event);
 
             // Don't let the player teleport to bypass reach
@@ -89,9 +93,11 @@ public class Reach extends Check implements PacketCheck {
             if (entity.isDead) return;
 
             // TODO: Remove when in front of via
-            if (entity.getType() == EntityTypes.ARMOR_STAND && player.getClientVersion().isOlderThan(ClientVersion.V_1_8)) return;
+            if (entity.getType() == EntityTypes.ARMOR_STAND && player.getClientVersion().isOlderThan(ClientVersion.V_1_8))
+                return;
 
-            if (player.gamemode == GameMode.CREATIVE || player.gamemode == GameMode.SPECTATOR) return;
+            if (player.gamemode == GameMode.CREATIVE || player.gamemode == GameMode.SPECTATOR)
+                return;
             if (player.inVehicle()) return;
             if (entity.riding != null) return;
 
@@ -106,12 +112,8 @@ public class Reach extends Check implements PacketCheck {
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
-
-        // If the player set their look, or we know they have a new tick
-        if (isUpdate(event.getPacketType())) {
-            tickBetterReachCheckWithAngle();
-        }
+        }, PacketType.Play.Client.INTERACT_ENTITY);
+        registry.registerHandler(event -> tickBetterReachCheckWithAngle(), this::isUpdate);
     }
 
     // This method finds the most optimal point at which the user should be aiming at
@@ -127,7 +129,8 @@ public class Reach extends Check implements PacketCheck {
         if ((blacklisted.contains(reachEntity.getType()) || !reachEntity.isLivingEntity()) && reachEntity.getType() != EntityTypes.END_CRYSTAL)
             return false; // exempt
 
-        if (player.gamemode == GameMode.CREATIVE || player.gamemode == GameMode.SPECTATOR) return false;
+        if (player.gamemode == GameMode.CREATIVE || player.gamemode == GameMode.SPECTATOR)
+            return false;
         if (player.inVehicle()) return false;
 
         // Filter out what we assume to be cheats

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashA.java
@@ -1,14 +1,14 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "CrashA")
-public class CrashA extends Check implements PacketCheck {
+public class CrashA extends AbstractPacketCheck {
     private static final double HARD_CODED_BORDER = 2.9999999E7D;
 
     public CrashA(GrimPlayer player) {
@@ -16,9 +16,9 @@ public class CrashA extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.packetStateData.lastPacketWasTeleport) return;
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.lastPacketWasTeleport) return;
             WrapperPlayClientPlayerFlying packet = new WrapperPlayClientPlayerFlying(event);
 
             if (!packet.hasPositionChanged()) return;
@@ -29,6 +29,6 @@ public class CrashA extends Check implements PacketCheck {
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
+        }, this::isFlying);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashB.java
@@ -1,27 +1,27 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 
 @CheckData(name = "CrashB", description = "Sent creative mode inventory click packets while not in creative mode")
-public class CrashB extends Check implements PacketCheck {
+public class CrashB extends AbstractPacketCheck {
     public CrashB(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CREATIVE_INVENTORY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (player.gamemode != GameMode.CREATIVE) {
                 event.setCancelled(true);
                 player.onPacketCancel();
                 flagAndAlert(); // Could be transaction split, no need to setback though
             }
-        }
+        }, PacketType.Play.Client.CREATIVE_INVENTORY_ACTION);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashC.java
@@ -1,22 +1,22 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.world.Location;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "CrashC", description = "Sent non-finite position or rotation")
-public class CrashC extends Check implements PacketCheck {
+public class CrashC extends AbstractPacketCheck {
     public CrashC(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerFlying flying = new WrapperPlayClientPlayerFlying(event);
             if (flying.hasPositionChanged()) {
                 Location pos = flying.getLocation();
@@ -30,6 +30,6 @@ public class CrashC extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, this::isFlying);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.inventory.inventory.MenuType;
 import com.github.retrooper.packetevents.PacketEvents;
@@ -14,7 +14,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientCl
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow;
 
 @CheckData(name = "CrashD", description = "Clicking slots in lectern window")
-public class CrashD extends Check implements PacketCheck {
+public class CrashD extends AbstractPacketCheck {
 
     public CrashD(GrimPlayer playerData) {
         super(playerData);
@@ -24,17 +24,11 @@ public class CrashD extends Check implements PacketCheck {
     private int lecternId = -1;
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW && isSupportedVersion()) {
-            WrapperPlayServerOpenWindow window = new WrapperPlayServerOpenWindow(event);
-            this.type = MenuType.getMenuType(window.getType());
-            if (type == MenuType.LECTERN) lecternId = window.getContainerId();
-        }
-    }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        if (!isSupportedVersion()) return;
 
-    @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW && isSupportedVersion()) {
+
+        registry.registerHandler(event -> {
             WrapperPlayClientClickWindow click = new WrapperPlayClientClickWindow(event);
             int clickType = click.getWindowClickType().ordinal();
             int button = click.getButton();
@@ -46,11 +40,19 @@ public class CrashD extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.CLICK_WINDOW);
+    }
+
+    @Override
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
+            WrapperPlayServerOpenWindow window = new WrapperPlayServerOpenWindow(event);
+            this.type = MenuType.getMenuType(window.getType());
+            if (type == MenuType.LECTERN) lecternId = window.getContainerId();
+        }, PacketType.Play.Server.OPEN_WINDOW);
     }
 
     private boolean isSupportedVersion() {
         return PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_14);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashE.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashE.java
@@ -1,30 +1,29 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientSettings;
 
 @CheckData(name = "CrashE")
-public class CrashE extends Check implements PacketCheck {
+public class CrashE extends AbstractPacketCheck {
 
     public CrashE(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLIENT_SETTINGS) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientSettings wrapper = new WrapperPlayClientSettings(event);
             int viewDistance = wrapper.getViewDistance();
             if (viewDistance < 2) {
                 flagAndAlert("distance=" + viewDistance);
                 wrapper.setViewDistance(2);
             }
-        }
+        }, PacketType.Play.Client.CLIENT_SETTINGS);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashF.java
@@ -1,23 +1,23 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientClickWindow;
 
 @CheckData(name = "CrashF")
-public class CrashF extends Check implements PacketCheck {
+public class CrashF extends AbstractPacketCheck {
 
     public CrashF(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientClickWindow click = new WrapperPlayClientClickWindow(event);
             int clickType = click.getWindowClickType().ordinal();
             int button = click.getButton();
@@ -37,8 +37,6 @@ public class CrashF extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-
-        }
+        }, PacketType.Play.Client.CLICK_WINDOW);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -14,47 +14,43 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPl
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUseItem;
 
 @CheckData(name = "CrashG", description = "Sent negative sequence id")
-public class CrashG extends Check implements PacketCheck {
+public class CrashG extends AbstractPacketCheck {
 
     public CrashG(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (!isSupportedVersion()) return;
 
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT) {
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerBlockPlacement place = new WrapperPlayClientPlayerBlockPlacement(event);
             if (place.getSequence() < 0) {
                 flagAndAlert();
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
+        }, PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT);
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerDigging dig = new WrapperPlayClientPlayerDigging(event);
             if (dig.getSequence() < 0) {
                 flagAndAlert();
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM) {
+        }, PacketType.Play.Client.PLAYER_DIGGING);
+        registry.registerHandler(event -> {
             WrapperPlayClientUseItem use = new WrapperPlayClientUseItem(event);
             if (use.getSequence() < 0) {
                 flagAndAlert();
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
-
+        }, PacketType.Play.Client.USE_ITEM);
     }
 
     private boolean isSupportedVersion() {
         return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19) && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/crash/CrashH.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/crash/CrashH.java
@@ -1,23 +1,23 @@
 package ac.grim.grimac.checks.impl.crash;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientTabComplete;
 
 @CheckData(name = "CrashH")
-public class CrashH extends Check implements PacketCheck {
+public class CrashH extends AbstractPacketCheck {
 
     public CrashH(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientTabComplete wrapper = new WrapperPlayClientTabComplete(event);
             String text = wrapper.getText();
             final int length = text.length();
@@ -40,8 +40,6 @@ public class CrashH extends Check implements PacketCheck {
                 flagAndAlert("(invalid) length=" + length);
                 return;
             }
-        }
+        }, PacketType.Play.Client.TAB_COMPLETE);
     }
-
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraA", description = "Started gliding while already gliding", experimental = true)
-public class ElytraA extends Check implements PostPredictionCheck {
+public class ElytraA extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraA(GrimPlayer player) {
@@ -34,10 +35,12 @@ public class ElytraA extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThan(ClientVersion.V_1_15) && event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-        ) onStartGliding(event);
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.getClientVersion().isOlderThan(ClientVersion.V_1_15)
+                    && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+            ) onStartGliding(event);
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -10,7 +11,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraB", description = "Started gliding without jumping", experimental = true)
-public class ElytraB extends Check implements PostPredictionCheck {
+public class ElytraB extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean glide;
     private boolean setback;
 
@@ -19,32 +20,32 @@ public class ElytraB extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.supportsEndTick()
-        ) {
-            if (player.packetStateData.knownInput.jump()) {
-                if (flagAndAlert("no release")) {
-                    setback = true;
-                    if (shouldModifyPackets()) {
-                        event.setCancelled(true);
-                        player.onPacketCancel();
-                        player.resyncPose();
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.supportsEndTick()
+            ) {
+                if (player.packetStateData.knownInput.jump()) {
+                    if (flagAndAlert("no release")) {
+                        setback = true;
+                        if (shouldModifyPackets()) {
+                            event.setCancelled(true);
+                            player.onPacketCancel();
+                            player.resyncPose();
+                        }
                     }
+                } else {
+                    glide = true;
                 }
-            } else {
-                glide = true;
             }
-        }
-
-        if (isUpdate(event.getPacketType())) {
+        }, PacketType.Play.Client.ENTITY_ACTION);
+        registry.registerHandler(event -> {
             if (glide && !player.packetStateData.knownInput.jump() && flagAndAlert("no jump")) {
                 setback = true;
             }
 
             glide = false;
-        }
+        }, this::isUpdate);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -12,7 +13,7 @@ import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraC", description = "Started gliding too frequently", experimental = true)
-public class ElytraC extends Check implements PostPredictionCheck {
+public class ElytraC extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean glideThisTick, glideLastTick, setback;
     private int flags;
 
@@ -21,38 +22,39 @@ public class ElytraC extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;
         }
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR) {
+                glideThisTick = glideLastTick = false;
+            }
 
-        if (player.gamemode == GameMode.SPECTATOR) {
-            glideThisTick = glideLastTick = false;
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA) {
-            if (glideThisTick || glideLastTick) {
-                if (player.canSkipTicks()) {
-                    flags++;
-                } else {
-                    if (flagAndAlert()) {
-                        setback = true;
-                        if (shouldModifyPackets()) {
-                            event.setCancelled(true);
-                            player.onPacketCancel();
-                            player.resyncPose();
+            if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA) {
+                if (glideThisTick || glideLastTick) {
+                    if (player.canSkipTicks()) {
+                        flags++;
+                    } else {
+                        if (flagAndAlert()) {
+                            setback = true;
+                            if (shouldModifyPackets()) {
+                                event.setCancelled(true);
+                                player.onPacketCancel();
+                                player.resyncPose();
+                            }
                         }
                     }
                 }
+
+                glideThisTick = true;
             }
 
-            glideThisTick = true;
-        }
-
-        if (isTickPacket(event.getPacketType())) {
-            glideLastTick = glideThisTick;
-            glideThisTick = false;
-        }
+            if (isTickPacket(event.getPacketType())) {
+                glideLastTick = glideThisTick;
+                glideThisTick = false;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraD", description = "Started gliding without an elytra", experimental = true)
-public class ElytraD extends Check implements PostPredictionCheck {
+public class ElytraD extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraD(GrimPlayer player) {
@@ -19,23 +20,23 @@ public class ElytraD extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;
         }
-
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && !player.canGlide()
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && !player.canGlide()
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraE", description = "Started gliding while flying", experimental = true)
-public class ElytraE extends Check implements PostPredictionCheck {
+public class ElytraE extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraE(GrimPlayer player) {
@@ -19,23 +20,23 @@ public class ElytraE extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;
         }
-
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.isFlying
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.isFlying
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraF", description = "Started gliding while on ground", experimental = true)
-public class ElytraF extends Check implements PostPredictionCheck {
+public class ElytraF extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraF(GrimPlayer player) {
@@ -19,23 +20,23 @@ public class ElytraF extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;
         }
-
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.clientClaimsLastOnGround
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.clientClaimsLastOnGround
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -12,7 +13,7 @@ import com.github.retrooper.packetevents.protocol.potion.PotionTypes;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraG", description = "Started gliding with levitation", experimental = true)
-public class ElytraG extends Check implements PostPredictionCheck {
+public class ElytraG extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraG(GrimPlayer player) {
@@ -20,20 +21,21 @@ public class ElytraG extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16)
-                && player.compensatedEntities.self.hasPotionEffect(PotionTypes.LEVITATION)
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16)
+                    && player.compensatedEntities.self.hasPotionEffect(PotionTypes.LEVITATION)
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraH", description = "Started gliding in vehicle", experimental = true)
-public class ElytraH extends Check implements PostPredictionCheck {
+public class ElytraH extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraH(GrimPlayer player) {
@@ -19,23 +20,23 @@ public class ElytraH extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;
         }
-
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.inVehicle()
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.inVehicle()
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.elytra;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "ElytraI", description = "Started gliding in water", experimental = true)
-public class ElytraI extends Check implements PostPredictionCheck {
+public class ElytraI extends AbstractPacketCheck implements PostPredictionCheck {
     private boolean setback;
 
     public ElytraI(GrimPlayer player) {
@@ -19,20 +20,21 @@ public class ElytraI extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.wasTouchingWater
-                && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)
-                && flagAndAlert()
-        ) {
-            setback = true;
-            if (shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-                player.resyncPose();
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
+                    && player.wasTouchingWater
+                    && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)
+                    && flagAndAlert()
+            ) {
+                setback = true;
+                if (shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                    player.resyncPose();
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitA.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.exploit;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -11,15 +11,17 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientTabComplete;
 
 @CheckData(name = "ExploitA", experimental = true)
-public class ExploitA extends Check implements PacketCheck {
+public class ExploitA extends AbstractPacketCheck {
 
     public ExploitA(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_13)) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_13))
+            return;
+        registry.registerHandler(event -> {
             WrapperPlayClientTabComplete wrapper = new WrapperPlayClientTabComplete(event);
             String text = wrapper.getText();
             if (text.equals("/") || text.trim().isEmpty()) {
@@ -28,7 +30,6 @@ public class ExploitA extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.TAB_COMPLETE);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
@@ -1,22 +1,22 @@
 package ac.grim.grimac.checks.impl.exploit;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEditBook;
 
 @CheckData(name = "ExploitB", description = "Too long book title")
-public class ExploitB extends Check implements PacketCheck {
+public class ExploitB extends AbstractPacketCheck {
     public ExploitB(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.EDIT_BOOK) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final String title = new WrapperPlayClientEditBook(event).getTitle();
 
             if (title == null) return; // book was not signed
@@ -27,6 +27,6 @@ public class ExploitB extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.EDIT_BOOK);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitC.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.exploit;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -15,24 +15,25 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientCh
 // this can false from click events, but I doubt this would actually
 // happen unless they're trying to flag, or if the server is set up badly
 @CheckData(name = "ExploitC", description = "Invalid chat message")
-public class ExploitC extends Check implements PacketCheck {
+public class ExploitC extends AbstractPacketCheck {
     public ExploitC(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CHAT_MESSAGE) {
-            String message = new WrapperPlayClientChatMessage(event).getMessage();
-            if (message.isEmpty() || !message.trim().equals(message) || message.startsWith("/") && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19)) {
-                if (flagAndAlert("message=" + message)) {
-                    event.setCancelled(true);
-                    player.onPacketCancel();
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19)) {
+            registry.registerHandler(event -> {
+                String message = new WrapperPlayClientChatMessage(event).getMessage();
+                if (message.isEmpty() || !message.trim().equals(message) || message.startsWith("/")) {
+                    if (flagAndAlert("message=" + message)) {
+                        event.setCancelled(true);
+                        player.onPacketCancel();
+                    }
                 }
-            }
+            }, PacketType.Play.Client.CHAT_MESSAGE);
         }
-
-        if (event.getPacketType() == PacketType.Play.Client.CHAT_COMMAND_UNSIGNED) {
+        registry.registerHandler(event -> {
             String command = "/" + new WrapperPlayClientChatCommandUnsigned(event).getCommand();
             if (!command.stripTrailing().equals(command)) {
                 if (flagAndAlert("command=" + command)) {
@@ -40,9 +41,8 @@ public class ExploitC extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.CHAT_COMMAND) {
+        }, PacketType.Play.Client.CHAT_COMMAND_UNSIGNED);
+        registry.registerHandler(event -> {
             String command = "/" + new WrapperPlayClientChatCommand(event).getCommand();
             if (!command.trim().equals(command)) {
                 if (flagAndAlert("command=" + command)) {
@@ -50,6 +50,6 @@ public class ExploitC extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.CHAT_COMMAND);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/flight/FlightA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/flight/FlightA.java
@@ -1,22 +1,22 @@
 package ac.grim.grimac.checks.impl.flight;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 // This check catches 100% of cheaters.
-public class FlightA extends Check implements PacketCheck {
+public class FlightA extends AbstractPacketCheck {
     public FlightA(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        // If the player sends a flying packet, but they aren't flying, then they are cheating.
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType()) && !player.isFlying) {
-            flag();
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (!player.isFlying) {
+                flag();
+            }
+        }, this::isFlying);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/groundspoof/NoFall.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/groundspoof/NoFall.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.groundspoof;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.predictionengine.GhostBlockDetector;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
@@ -18,7 +18,7 @@ import java.util.List;
 // Catches NoFalls for LOOK and GROUND packets
 // This check runs AFTER the predictions
 @CheckData(name = "NoFall", setback = 10)
-public class NoFall extends Check implements PacketCheck {
+public class NoFall extends AbstractPacketCheck {
 
     public boolean flipPlayerGroundStatus = false;
 
@@ -27,8 +27,8 @@ public class NoFall extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_FLYING || event.getPacketType() == PacketType.Play.Client.PLAYER_ROTATION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             // The player hasn't spawned yet
             if (player.getSetbackTeleportUtil().insideUnloadedChunk()) return;
             // The player has already been flagged, and
@@ -49,9 +49,8 @@ public class NoFall extends Check implements PacketCheck {
                     }
                 }
             }
-        }
-
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+        }, PacketType.Play.Client.PLAYER_FLYING, PacketType.Play.Client.PLAYER_ROTATION);
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerFlying wrapper = new WrapperPlayClientPlayerFlying(event);
             // The prediction based NoFall check (that runs before us without the packet)
             // has asked us to flip the player's onGround status
@@ -73,7 +72,7 @@ public class NoFall extends Check implements PacketCheck {
                     event.markForReEncode(true);
                 }
             }
-        }
+        }, this::isFlying);
     }
 
     public boolean isNearGround(boolean onGround) {

--- a/src/main/java/ac/grim/grimac/checks/impl/misc/ClientBrand.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/ClientBrand.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.misc;
 
 import ac.grim.grimac.GrimAPI;
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -16,7 +16,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
-public class ClientBrand extends Check implements PacketCheck {
+public class ClientBrand extends AbstractPacketCheck {
     @Getter
     private String brand = "vanilla";
     private boolean hasBrand = false;
@@ -26,16 +26,16 @@ public class ClientBrand extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLUGIN_MESSAGE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientPluginMessage packet = new WrapperPlayClientPluginMessage(event);
             handle(packet.getChannelName(), packet.getData());
-        } else if (event.getPacketType() == PacketType.Configuration.Client.PLUGIN_MESSAGE) {
+        }, PacketType.Play.Client.PLUGIN_MESSAGE);
+        registry.registerHandler(event -> {
             WrapperConfigClientPluginMessage packet = new WrapperConfigClientPluginMessage(event);
             handle(packet.getChannelName(), packet.getData());
-        }
+        }, PacketType.Configuration.Client.PLUGIN_MESSAGE);
     }
-
 
     private void handle(String channel, byte[] data) {
         final String expectedChannel = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13) ? "minecraft:brand" : "MC|Brand";

--- a/src/main/java/ac/grim/grimac/checks/impl/misc/TransactionOrder.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/misc/TransactionOrder.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.misc;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "TransactionOrder")
-public class TransactionOrder extends Check implements PacketCheck {
+public class TransactionOrder extends AbstractPacketCheck {
     public TransactionOrder(GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/movement/SetbackBlocker.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/movement/SetbackBlocker.java
@@ -1,71 +1,74 @@
 package ac.grim.grimac.checks.impl.movement;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
-public class SetbackBlocker extends Check implements PacketCheck {
+public class SetbackBlocker extends AbstractPacketCheck {
     public SetbackBlocker(GrimPlayer playerData) {
         super(playerData);
     }
 
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (player.disableGrim) return; // Let's avoid letting people disable grim with grim.nomodifypackets
+    @Override
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.disableGrim) return; // Let's avoid letting people disable grim with grim.nomodifypackets
 
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
-            if (player.getSetbackTeleportUtil().cheatVehicleInterpolationDelay > 0) {
-                event.setCancelled(true); // Player is in the vehicle
-            }
-        }
-
-        // Don't block teleport packets
-        if (player.packetStateData.lastPacketWasTeleport) return;
-
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
-            // The player must obey setbacks
-            if (player.getSetbackTeleportUtil().shouldBlockMovement()) {
-                event.setCancelled(true);
+            if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+                if (player.getSetbackTeleportUtil().cheatVehicleInterpolationDelay > 0) {
+                    event.setCancelled(true); // Player is in the vehicle
+                }
             }
 
-            // Look is the only valid packet to send while in a vehicle
-            if (player.inVehicle() && event.getPacketType() != PacketType.Play.Client.PLAYER_ROTATION && !player.packetStateData.lastPacketWasTeleport) {
-                event.setCancelled(true);
+            // Don't block teleport packets
+            if (player.packetStateData.lastPacketWasTeleport) return;
+
+            if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+                // The player must obey setbacks
+                if (player.getSetbackTeleportUtil().shouldBlockMovement()) {
+                    event.setCancelled(true);
+                }
+
+                // Look is the only valid packet to send while in a vehicle
+                if (player.inVehicle() && event.getPacketType() != PacketType.Play.Client.PLAYER_ROTATION && !player.packetStateData.lastPacketWasTeleport) {
+                    event.setCancelled(true);
+                }
+
+                // The player is sleeping, should be safe to block position packets
+                if (player.isInBed && new Vector3d(player.x, player.y, player.z).distanceSquared(player.bedPosition) > 1) {
+                    event.setCancelled(true);
+                }
+
+                // Player is dead
+                if (player.compensatedEntities.self.isDead) {
+                    event.setCancelled(true);
+                }
             }
 
-            // The player is sleeping, should be safe to block position packets
-            if (player.isInBed && new Vector3d(player.x, player.y, player.z).distanceSquared(player.bedPosition) > 1) {
-                event.setCancelled(true);
-            }
+            if (event.getPacketType() == PacketType.Play.Client.VEHICLE_MOVE) {
+                if (player.getSetbackTeleportUtil().shouldBlockMovement()) {
+                    event.setCancelled(true);
+                }
 
-            // Player is dead
-            if (player.compensatedEntities.self.isDead) {
-                event.setCancelled(true);
-            }
-        }
+                // Don't let a player move a vehicle when not in a vehicle
+                if (!player.inVehicle()) {
+                    event.setCancelled(true);
+                }
 
-        if (event.getPacketType() == PacketType.Play.Client.VEHICLE_MOVE) {
-            if (player.getSetbackTeleportUtil().shouldBlockMovement()) {
-                event.setCancelled(true);
-            }
+                // A player is sleeping while in a vehicle
+                if (player.isInBed) {
+                    event.setCancelled(true);
+                }
 
-            // Don't let a player move a vehicle when not in a vehicle
-            if (!player.inVehicle()) {
-                event.setCancelled(true);
+                // Player is dead
+                if (player.compensatedEntities.self.isDead) {
+                    event.setCancelled(true);
+                }
             }
-
-            // A player is sleeping while in a vehicle
-            if (player.isInBed) {
-                event.setCancelled(true);
-            }
-
-            // Player is dead
-            if (player.compensatedEntities.self.isDead) {
-                event.setCancelled(true);
-            }
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsA.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -10,20 +10,22 @@ import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity;
 
 @CheckData(name = "MultiActionsA", description = "Attacked while using an item", experimental = true)
-public class MultiActionsA extends Check implements PacketCheck {
+public class MultiActionsA extends AbstractPacketCheck {
     public MultiActionsA(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND) && event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
-            if (new WrapperPlayClientInteractEntity(event).getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
-                if (flagAndAlert() && shouldModifyPackets()) {
-                    event.setCancelled(true);
-                    player.onPacketCancel();
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND)) {
+                if (new WrapperPlayClientInteractEntity(event).getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
+                    if (flagAndAlert() && shouldModifyPackets()) {
+                        event.setCancelled(true);
+                        player.onPacketCancel();
+                    }
                 }
             }
-        }
+        }, PacketType.Play.Client.INTERACT_ENTITY);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsB.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -14,28 +14,30 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPl
 import static ac.grim.grimac.events.packets.patch.ResyncWorldUtil.resyncPosition;
 
 @CheckData(name = "MultiActionsB", description = "Breaking blocks while using an item", experimental = true)
-public class MultiActionsB extends Check implements PacketCheck {
+public class MultiActionsB extends AbstractPacketCheck {
     public MultiActionsB(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND) && event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
-            // this is vanilla on 1.7
-            if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10)) {
-                return;
-            }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND)) {
+                // this is vanilla on 1.7
+                if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10)) {
+                    return;
+                }
 
-            final WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
+                final WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
 
-            if (packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.CANCELLED_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING) {
-                if (flagAndAlert() && shouldModifyPackets()) {
-                    event.setCancelled(true);
-                    player.onPacketCancel();
-                    resyncPosition(player, packet.getBlockPosition());
+                if (packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.CANCELLED_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING) {
+                    if (flagAndAlert() && shouldModifyPackets()) {
+                        event.setCancelled(true);
+                        player.onPacketCancel();
+                        resyncPosition(player, packet.getBlockPosition());
+                    }
                 }
             }
-        }
+        }, PacketType.Play.Client.PLAYER_DIGGING);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsC.java
@@ -1,15 +1,15 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 
 @CheckData(name = "MultiActionsC", description = "Clicked in inventory while sprinting", experimental = true)
-public class MultiActionsC extends Check implements PacketCheck {
+public class MultiActionsC extends AbstractPacketCheck {
     public MultiActionsC(GrimPlayer player) {
         super(player);
     }
@@ -17,24 +17,22 @@ public class MultiActionsC extends Check implements PacketCheck {
     private boolean serverOpenedInventoryThisTick;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW) {
-
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (player.isSprinting && !player.isSwimming && !serverOpenedInventoryThisTick && flagAndAlert() && shouldModifyPackets()) {
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
-
-        if (isTickPacket(event.getPacketType())) {
+        }, PacketType.Play.Client.CLICK_WINDOW);
+        registry.registerHandler(event -> {
+            if (!isTickPacket(event.getPacketType())) return;
             serverOpenedInventoryThisTick = false;
-        }
+        });
+
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
-            player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> serverOpenedInventoryThisTick = true);
-        }
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> serverOpenedInventoryThisTick = true), PacketType.Play.Server.OPEN_WINDOW);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsD.java
@@ -1,25 +1,25 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 
 @CheckData(name = "MultiActionsD", description = "Closed inventory while sprinting", experimental = true)
-public class MultiActionsD extends Check implements PacketCheck {
+public class MultiActionsD extends AbstractPacketCheck {
     public MultiActionsD(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLOSE_WINDOW) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (player.isSprinting && !player.isSwimming && flagAndAlert() && shouldModifyPackets()) {
                 event.setCancelled(true);
                 player.onPacketCancel();
             }
-        }
+        }, PacketType.Play.Client.CLOSE_WINDOW);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsE.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsE.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -12,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
 
 @CheckData(name = "MultiActionsE", description = "Swinging while using an item", experimental = true)
-public class MultiActionsE extends Check implements PacketCheck {
+public class MultiActionsE extends AbstractPacketCheck {
     public MultiActionsE(GrimPlayer player) {
         super(player);
     }
@@ -20,24 +20,26 @@ public class MultiActionsE extends Check implements PacketCheck {
     private boolean dropping;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (!dropping && player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND) && event.getPacketType() == PacketType.Play.Client.ANIMATION) {
-            // this is possible to false on 1.7
-            if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10)) {
-                return;
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (!dropping && player.packetStateData.isSlowedByUsingItem() && (player.packetStateData.lastSlotSelected == player.packetStateData.getSlowedByUsingItemSlot() || player.packetStateData.eatingHand == InteractionHand.OFF_HAND) && event.getPacketType() == PacketType.Play.Client.ANIMATION) {
+                // this is possible to false on 1.7
+                if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10)) {
+                    return;
+                }
+
+                if (flagAndAlert() && shouldModifyPackets()) {
+                    event.setCancelled(true);
+                    player.onPacketCancel();
+                }
             }
 
-            if (flagAndAlert() && shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
+            dropping = false;
+
+            if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)) {
+                DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
+                dropping = action == DiggingAction.DROP_ITEM || action == DiggingAction.DROP_ITEM_STACK;
             }
-        }
-
-        dropping = false;
-
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)) {
-            DiggingAction action = new WrapperPlayClientPlayerDigging(event).getAction();
-            dropping = action == DiggingAction.DROP_ITEM || action == DiggingAction.DROP_ITEM_STACK;
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsF.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsF.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.checks.impl.multiactions;
 
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
@@ -39,8 +40,8 @@ public class MultiActionsF extends BlockPlaceCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             entity = true;
             if (block) {
                 if (!player.canSkipTicks()) {
@@ -52,9 +53,8 @@ public class MultiActionsF extends BlockPlaceCheck {
                     flags.add("entity");
                 }
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
+        }, PacketType.Play.Client.INTERACT_ENTITY);
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerDigging packet = new WrapperPlayClientPlayerDigging(event);
             if (packet.getAction() == DiggingAction.START_DIGGING || packet.getAction() == DiggingAction.FINISHED_DIGGING) {
                 block = true;
@@ -70,11 +70,11 @@ public class MultiActionsF extends BlockPlaceCheck {
                     }
                 }
             }
-        }
-
-        if (isTickPacket(event.getPacketType())) {
+        }, PacketType.Play.Client.PLAYER_DIGGING);
+        registry.registerHandler(event -> {
+            if (!isTickPacket(event.getPacketType())) return;
             block = entity = false;
-        }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/post/Post.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/post/Post.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.post;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -24,7 +24,7 @@ import java.util.Locale;
 import static com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Client.*;
 
 @CheckData(name = "Post")
-public class Post extends Check implements PacketCheck, PostPredictionCheck {
+public class Post extends AbstractPacketCheck implements PostPredictionCheck {
     private final ArrayDeque<PacketTypeCommon> post = new ArrayDeque<>();
     // Due to 1.9+ missing the idle packet, we must queue flags
     // 1.8 clients will have the same logic for simplicity, although it's not needed
@@ -53,8 +53,8 @@ public class Post extends Check implements PacketCheck, PostPredictionCheck {
     }
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.ENTITY_ANIMATION) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityAnimation animation = new WrapperPlayServerEntityAnimation(event);
             if (animation.getEntityId() == player.entityID) {
                 if (animation.getType() == WrapperPlayServerEntityAnimation.EntityAnimationType.SWING_MAIN_ARM ||
@@ -62,45 +62,47 @@ public class Post extends Check implements PacketCheck, PostPredictionCheck {
                     isExemptFromSwingingCheck = player.lastTransactionSent.get();
                 }
             }
-        }
+        }, PacketType.Play.Server.ENTITY_ANIMATION);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (isTickPacket(event.getPacketType())) { // Don't count teleports or duplicates as movements
-            post.clear();
-            sentFlying = true;
-        } else {
-            // 1.13+ clients can click inventory outside tick loop, so we can't post check those two packets on 1.13+
-            PacketTypeCommon packetType = event.getPacketType();
-            if (isTransaction(packetType) && player.packetStateData.lastTransactionPacketWasValid) {
-                if (sentFlying && !post.isEmpty()) {
-                    flags.add(post.getFirst().toString().toLowerCase(Locale.ROOT).replace("_", " ") + " v" + player.getClientVersion().getReleaseName());
-                }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (isTickPacket(event.getPacketType())) { // Don't count teleports or duplicates as movements
                 post.clear();
-                sentFlying = false;
-            } else if (PLAYER_ABILITIES.equals(packetType)
-                    || (HELD_ITEM_CHANGE.equals(packetType) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8))
-                    || INTERACT_ENTITY.equals(packetType) || PLAYER_BLOCK_PLACEMENT.equals(packetType)
-                    || USE_ITEM.equals(packetType) || PLAYER_DIGGING.equals(packetType)) {
-                if (sentFlying) post.add(event.getPacketType());
-            } else if (CLICK_WINDOW.equals(packetType) && player.getClientVersion().isOlderThan(ClientVersion.V_1_13)) {
-                // Why do 1.13+ players send the click window packet whenever? This doesn't make sense.
-                if (sentFlying) post.add(event.getPacketType());
-            } else if (ANIMATION.equals(packetType)
-                    && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) // ViaVersion delays animations for 1.8 clients
-                    || PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_8_8)) // when on 1.9+ servers
-                    && player.getClientVersion().isOlderThan(ClientVersion.V_1_13) // 1.13 clicking inventory causes weird animations
-                    && isExemptFromSwingingCheck < player.lastTransactionReceived.get()) { // Exempt when the server sends animations because viaversion
-                if (sentFlying) post.add(event.getPacketType());
-            } else if (ENTITY_ACTION.equals(packetType) // ViaRewind sends START_FALL_FLYING packets async for 1.8 clients on 1.9+ servers
-                    && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) || new WrapperPlayClientEntityAction(event).getAction() != WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA)) {
-                // https://github.com/GrimAnticheat/Grim/issues/824
-                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19_3) && player.inVehicle()) {
-                    return;
+                sentFlying = true;
+            } else {
+                // 1.13+ clients can click inventory outside tick loop, so we can't post check those two packets on 1.13+
+                PacketTypeCommon packetType = event.getPacketType();
+                if (isTransaction(packetType) && player.packetStateData.lastTransactionPacketWasValid) {
+                    if (sentFlying && !post.isEmpty()) {
+                        flags.add(post.getFirst().toString().toLowerCase(Locale.ROOT).replace("_", " ") + " v" + player.getClientVersion().getReleaseName());
+                    }
+                    post.clear();
+                    sentFlying = false;
+                } else if (PLAYER_ABILITIES.equals(packetType)
+                        || (HELD_ITEM_CHANGE.equals(packetType) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8))
+                        || INTERACT_ENTITY.equals(packetType) || PLAYER_BLOCK_PLACEMENT.equals(packetType)
+                        || USE_ITEM.equals(packetType) || PLAYER_DIGGING.equals(packetType)) {
+                    if (sentFlying) post.add(event.getPacketType());
+                } else if (CLICK_WINDOW.equals(packetType) && player.getClientVersion().isOlderThan(ClientVersion.V_1_13)) {
+                    // Why do 1.13+ players send the click window packet whenever? This doesn't make sense.
+                    if (sentFlying) post.add(event.getPacketType());
+                } else if (ANIMATION.equals(packetType)
+                        && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) // ViaVersion delays animations for 1.8 clients
+                        || PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_8_8)) // when on 1.9+ servers
+                        && player.getClientVersion().isOlderThan(ClientVersion.V_1_13) // 1.13 clicking inventory causes weird animations
+                        && isExemptFromSwingingCheck < player.lastTransactionReceived.get()) { // Exempt when the server sends animations because viaversion
+                    if (sentFlying) post.add(event.getPacketType());
+                } else if (ENTITY_ACTION.equals(packetType) // ViaRewind sends START_FALL_FLYING packets async for 1.8 clients on 1.9+ servers
+                        && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) || new WrapperPlayClientEntityAction(event).getAction() != WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA)) {
+                    // https://github.com/GrimAnticheat/Grim/issues/824
+                    if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19_3) && player.inVehicle()) {
+                        return;
+                    }
+                    if (sentFlying) post.add(event.getPacketType());
                 }
-                if (sentFlying) post.add(event.getPacketType());
             }
-        }
+        });
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/scaffolding/MultiPlace.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/scaffolding/MultiPlace.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.checks.impl.scaffolding;
 
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.BlockPlaceCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
@@ -54,10 +55,12 @@ public class MultiPlace extends BlockPlaceCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
-            hasPlaced = false;
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (player.gamemode == GameMode.SPECTATOR || isTickPacket(event.getPacketType())) {
+                hasPlaced = false;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintA.java
@@ -1,22 +1,21 @@
 package ac.grim.grimac.checks.impl.sprint;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 
 @CheckData(name = "SprintA", description = "Sprinting with too low hunger", setback = 0)
-public class SprintA extends Check implements PacketCheck {
+public class SprintA extends AbstractPacketCheck {
 
     public SprintA(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             // Players can sprint if they're able to fly (MCP)
             if (player.canFly) return;
 
@@ -34,6 +33,6 @@ public class SprintA extends Check implements PacketCheck {
             } else {
                 reward();
             }
-        }
+        }, this::isFlying);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintD.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.sprint;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -12,7 +13,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEn
 import static com.github.retrooper.packetevents.protocol.potion.PotionTypes.BLINDNESS;
 
 @CheckData(name = "SprintD", description = "Started sprinting while having blindness", setback = 5, experimental = true)
-public class SprintD extends Check implements PostPredictionCheck {
+public class SprintD extends AbstractPacketCheck implements PostPredictionCheck {
     public SprintD(GrimPlayer player) {
         super(player);
     }
@@ -20,12 +21,12 @@ public class SprintD extends Check implements PostPredictionCheck {
     public boolean startedSprintingBeforeBlind = false;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_SPRINTING) {
                 startedSprintingBeforeBlind = false;
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintE.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintE.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.sprint;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -11,7 +12,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "SprintE", description = "Sprinting while colliding with a wall", setback = 5, experimental = true)
-public class SprintE extends Check implements PostPredictionCheck {
+public class SprintE extends AbstractPacketCheck implements PostPredictionCheck {
     public SprintE(GrimPlayer player) {
         super(player);
     }
@@ -19,12 +20,12 @@ public class SprintE extends Check implements PostPredictionCheck {
     private boolean startedSprintingThisTick, wasHorizontalCollision;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_SPRINTING) {
                 startedSprintingThisTick = true;
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 
     @Override

--- a/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
@@ -1,7 +1,8 @@
 package ac.grim.grimac.checks.impl.timer;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
@@ -9,7 +10,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 
 
 @CheckData(name = "TickTimer", setback = 1)
-public class TickTimer extends Check implements PostPredictionCheck {
+public class TickTimer extends AbstractPacketCheck implements PostPredictionCheck {
 
     private boolean receivedTickEnd = true;
     private int flyingPackets = 0;
@@ -19,21 +20,23 @@ public class TickTimer extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
         if (!player.supportsEndTick()) return;
-        if (isFlying(event.getPacketType()) && !player.packetStateData.lastPacketWasTeleport) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.lastPacketWasTeleport) return;
             if (!receivedTickEnd && flagAndAlertWithSetback("type=flying, packets=" + flyingPackets)) {
                 handleViolation();
             }
             receivedTickEnd = false;
             flyingPackets++;
-        } else if (event.getPacketType() == PacketType.Play.Client.CLIENT_TICK_END) {
+        }, this::isFlying);
+        registry.registerHandler(event -> {
             receivedTickEnd = true;
             if (flyingPackets > 1 && flagAndAlertWithSetback("type=end, packets=" + flyingPackets)) {
                 handleViolation();
             }
             flyingPackets = 0;
-        }
+        }, PacketType.Play.Client.CLIENT_TICK_END);
     }
 
     private void handleViolation() {

--- a/src/main/java/ac/grim/grimac/checks/impl/timer/Timer.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/timer/Timer.java
@@ -1,16 +1,16 @@
 package ac.grim.grimac.checks.impl.timer;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 
 @CheckData(name = "Timer", configName = "TimerA", setback = 10)
-public class Timer extends Check implements PacketCheck {
+public class Timer extends AbstractPacketCheck {
     long timerBalanceRealTime = 0;
 
     // Default value is real time minus max keep-alive time
@@ -57,19 +57,22 @@ public class Timer extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (hasGottenMovementAfterTransaction && checkForTransaction(event.getPacketType())) {
-            knownPlayerClockTime = lastMovementPlayerClock;
-            lastMovementPlayerClock = player.getPlayerClockAtLeast();
-            hasGottenMovementAfterTransaction = false;
-        }
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (hasGottenMovementAfterTransaction) {
+                knownPlayerClockTime = lastMovementPlayerClock;
+                lastMovementPlayerClock = player.getPlayerClockAtLeast();
+                hasGottenMovementAfterTransaction = false;
+            }
+        }, this::checkForTransaction);
+        registry.registerHandler(event -> {
+            if (shouldCountPacketForTimer(event.getPacketType())) {
+                hasGottenMovementAfterTransaction = true;
+                timerBalanceRealTime += 50e6;
 
-        if (!shouldCountPacketForTimer(event.getPacketType())) return;
-
-        hasGottenMovementAfterTransaction = true;
-        timerBalanceRealTime += 50e6;
-
-        doCheck(event);
+                doCheck(event);
+            }
+        });
     }
 
     public void doCheck(final PacketReceiveEvent event) {

--- a/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleA.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleA.java
@@ -1,22 +1,22 @@
 package ac.grim.grimac.checks.impl.vehicle;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientSteerVehicle;
 
 @CheckData(name = "VehicleA", description = "Impossible input values")
-public class VehicleA extends Check implements PacketCheck {
+public class VehicleA extends AbstractPacketCheck {
     public VehicleA(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             final WrapperPlayClientSteerVehicle packet = new WrapperPlayClientSteerVehicle(event);
 
             if (Math.abs(packet.getForward()) > 0.98f || Math.abs(packet.getSideways()) > 0.98f) {
@@ -25,6 +25,6 @@ public class VehicleA extends Check implements PacketCheck {
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.STEER_VEHICLE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleB.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleB.java
@@ -1,27 +1,27 @@
 package ac.grim.grimac.checks.impl.vehicle;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 
 @CheckData(name = "VehicleB", description = "Claimed to be in a vehicle while not in a vehicle")
-public class VehicleB extends Check implements PacketCheck {
+public class VehicleB extends AbstractPacketCheck {
     public VehicleB(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             if (!player.inVehicle()) {
                 if (flagAndAlert() && shouldModifyPackets()) {
                     event.setCancelled(true);
                     player.onPacketCancel();
                 }
             }
-        }
+        }, PacketType.Play.Client.STEER_VEHICLE);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleC.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleC.java
@@ -1,12 +1,11 @@
 package ac.grim.grimac.checks.impl.vehicle;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
 @CheckData(name = "VehicleC")
-public class VehicleC extends Check implements PacketCheck {
+public class VehicleC extends AbstractPacketCheck {
     public VehicleC(GrimPlayer player) {
         super(player);
     }

--- a/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleD.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/vehicle/VehicleD.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.checks.impl.vehicle;
 
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
@@ -11,19 +11,21 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientEntityAction;
 
 @CheckData(name = "VehicleD", experimental = true, description = "Jumped in a vehicle that cannot jump")
-public class VehicleD extends Check implements PacketCheck {
+public class VehicleD extends AbstractPacketCheck {
     public VehicleD(GrimPlayer player) {
         super(player);
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_JUMPING_WITH_HORSE) {
-            final EntityType vehicle = player.inVehicle() ? player.compensatedEntities.self.getRiding().getType() : null;
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_JUMPING_WITH_HORSE) {
+                final EntityType vehicle = player.inVehicle() ? player.compensatedEntities.self.getRiding().getType() : null;
 
-            if (!EntityTypes.isTypeInstanceOf(vehicle, EntityTypes.ABSTRACT_HORSE)) {
-                flagAndAlert("vehicle=" + (vehicle == null ? "null" : vehicle.getName().getKey().toLowerCase()));
+                if (!EntityTypes.isTypeInstanceOf(vehicle, EntityTypes.ABSTRACT_HORSE)) {
+                    flagAndAlert("vehicle=" + (vehicle == null ? "null" : vehicle.getName().getKey().toLowerCase()));
+                }
             }
-        }
+        }, PacketType.Play.Client.ENTITY_ACTION);
     }
 }

--- a/src/main/java/ac/grim/grimac/checks/impl/velocity/ExplosionHandler.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/velocity/ExplosionHandler.java
@@ -1,8 +1,9 @@
 package ac.grim.grimac.checks.impl.velocity;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -28,7 +29,7 @@ import java.util.Deque;
 import java.util.LinkedList;
 
 @CheckData(name = "AntiExplosion", configName = "Explosion", setback = 10)
-public class ExplosionHandler extends Check implements PostPredictionCheck {
+public class ExplosionHandler extends AbstractPacketCheck implements PostPredictionCheck {
     Deque<VelocityData> firstBreadMap = new LinkedList<>();
 
     VelocityData lastExplosionsKnownTaken = null;
@@ -45,8 +46,8 @@ public class ExplosionHandler extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.EXPLOSION) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerExplosion explosion = new WrapperPlayServerExplosion(event);
 
             // Since 1.21.2, the server will instead send these changes via block change packets
@@ -62,7 +63,7 @@ public class ExplosionHandler extends Check implements PostPredictionCheck {
                 addPlayerExplosion(player.lastTransactionSent.get(), velocity);
                 event.getTasksAfterSend().add(player::sendTransaction);
             }
-        }
+        }, PacketType.Play.Server.EXPLOSION);
     }
 
     private void handleBlockExplosions(WrapperPlayServerExplosion explosion) {

--- a/src/main/java/ac/grim/grimac/checks/impl/velocity/KnockbackHandler.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/velocity/KnockbackHandler.java
@@ -2,8 +2,9 @@ package ac.grim.grimac.checks.impl.velocity;
 
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.checks.type.PostPredictionCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
@@ -23,7 +24,7 @@ import java.util.LinkedList;
 
 // We are making a velocity sandwich between two pieces of transaction packets (bread)
 @CheckData(name = "AntiKB", alternativeName = "AntiKnockback", configName = "Knockback", setback = 10, decay = 0.025)
-public class KnockbackHandler extends Check implements PostPredictionCheck {
+public class KnockbackHandler extends AbstractPacketCheck implements PostPredictionCheck {
     Deque<VelocityData> firstBreadMap = new LinkedList<>();
 
     Deque<VelocityData> lastKnockbackKnownTaken = new LinkedList<>();
@@ -41,8 +42,8 @@ public class KnockbackHandler extends Check implements PostPredictionCheck {
     }
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.ENTITY_VELOCITY) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityVelocity velocity = new WrapperPlayServerEntityVelocity(event);
             int entityId = velocity.getEntityId();
 
@@ -73,10 +74,11 @@ public class KnockbackHandler extends Check implements PostPredictionCheck {
             player.sendTransaction();
             addPlayerKnockback(entityId, player.lastTransactionSent.get(), new Vector(playerVelocity.getX(), playerVelocity.getY(), playerVelocity.getZ()));
             event.getTasksAfterSend().add(player::sendTransaction);
-        }
+        }, PacketType.Play.Server.ENTITY_VELOCITY);
     }
 
-    @NotNull public Pair<VelocityData, Vector> getFutureKnockback() {
+    @NotNull
+    public Pair<VelocityData, Vector> getFutureKnockback() {
         // Chronologically in the future
         if (!firstBreadMap.isEmpty()) {
             VelocityData data = firstBreadMap.peek();

--- a/src/main/java/ac/grim/grimac/checks/type/BlockPlaceCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/type/BlockPlaceCheck.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.checks.type;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.AbstractPacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import ac.grim.grimac.utils.collisions.HitboxData;
@@ -16,7 +16,7 @@ import com.github.retrooper.packetevents.util.Vector3i;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockPlaceCheck extends Check implements RotationCheck, PostPredictionCheck {
+public class BlockPlaceCheck extends AbstractPacketCheck implements RotationCheck, PostPredictionCheck {
     private static final List<StateType> weirdBoxes = new ArrayList<>();
     private static final List<StateType> buggyBoxes = new ArrayList<>();
     private final SimpleCollisionBox[] boxes = new SimpleCollisionBox[ComplexCollisionBox.DEFAULT_MAX_COLLISION_BOX_SIZE];

--- a/src/main/java/ac/grim/grimac/checks/type/PacketCheck.java
+++ b/src/main/java/ac/grim/grimac/checks/type/PacketCheck.java
@@ -3,8 +3,18 @@ package ac.grim.grimac.checks.type;
 import ac.grim.grimac.api.AbstractCheck;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 public interface PacketCheck extends AbstractCheck {
-    default void onPacketReceive(final PacketReceiveEvent event) {}
-    default void onPacketSend(final PacketSendEvent event) {}
+    default Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> getSendHandlers() {
+        return Map.of();
+    }
+
+    default Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> getReceiveHandlers() {
+        return Map.of();
+    }
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketChangeGameState.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketChangeGameState.java
@@ -1,22 +1,23 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.GrimAPI;
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChangeGameState;
 
-public class PacketChangeGameState extends Check implements PacketCheck {
+public class PacketChangeGameState extends AbstractPacketCheck {
     public PacketChangeGameState(GrimPlayer playerData) {
         super(playerData);
     }
 
     @Override
-    public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.CHANGE_GAME_STATE) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerChangeGameState packet = new WrapperPlayServerChangeGameState(event);
 
             if (packet.getReason() == WrapperPlayServerChangeGameState.Reason.CHANGE_GAME_MODE) {
@@ -39,6 +40,11 @@ public class PacketChangeGameState extends Check implements PacketCheck {
                     }
                 });
             }
-        }
+        }, PacketType.Play.Server.CHANGE_GAME_STATE);
+    }
+
+    @Override
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+
     }
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.data.TrackerData;
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class PacketEntityReplication extends Check implements PacketCheck {
+public class PacketEntityReplication extends AbstractPacketCheck {
 
     private final AtomicBoolean hasSentPreWavePacket = new AtomicBoolean(true);
 
@@ -61,60 +61,63 @@ public class PacketEntityReplication extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        // Teleports don't interpolate, duplicate 1.17 packets don't interpolate
-        if (!isTickPacket(event.getPacketType())) return;
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            // Teleports don't interpolate, duplicate 1.17 packets don't interpolate
+            if (!isTickPacket(event.getPacketType())) return;
+            boolean isTickingReliably = player.isTickingReliablyFor(3);
 
-        boolean isTickingReliably = player.isTickingReliablyFor(3);
-
-        PacketEntity playerVehicle = player.compensatedEntities.self.getRiding();
-        for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-            if (entity == playerVehicle && !player.vehicleData.lastDummy) {
-                // The player has this as their vehicle, so they aren't interpolating it.
-                // And it isn't a dummy position
-                entity.setPositionRaw(player, entity.getPossibleLocationBoxes());
-            } else {
-                entity.onMovement(isTickingReliably);
+            PacketEntity playerVehicle = player.compensatedEntities.self.getRiding();
+            for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
+                if (entity == playerVehicle && !player.vehicleData.lastDummy) {
+                    // The player has this as their vehicle, so they aren't interpolating it.
+                    // And it isn't a dummy position
+                    entity.setPositionRaw(player, entity.getPossibleLocationBoxes());
+                } else {
+                    entity.onMovement(isTickingReliably);
+                }
             }
-        }
+        });
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
         // ensure grim is the one that sent the transaction
-        if ((event.getPacketType() == PacketType.Play.Server.PING || event.getPacketType() == PacketType.Play.Server.WINDOW_CONFIRMATION) && player.packetStateData.lastServerTransWasValid) {
-            despawnedEntitiesThisTransaction.clear();
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.SPAWN_LIVING_ENTITY) {
+        registry.registerHandler(event -> {
+            if (player.packetStateData.lastServerTransWasValid) {
+                despawnedEntitiesThisTransaction.clear();
+            }
+        }, PacketType.Play.Server.PING, PacketType.Play.Server.WINDOW_CONFIRMATION);
+        registry.registerHandler(event -> {
             WrapperPlayServerSpawnLivingEntity packetOutEntity = new WrapperPlayServerSpawnLivingEntity(event);
             addEntity(packetOutEntity.getEntityId(), packetOutEntity.getEntityUUID(), packetOutEntity.getEntityType(), packetOutEntity.getPosition(), packetOutEntity.getYaw(), packetOutEntity.getPitch(), packetOutEntity.getEntityMetadata(), 0);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.SPAWN_ENTITY) {
+        }, PacketType.Play.Server.SPAWN_LIVING_ENTITY);
+        registry.registerHandler(event -> {
             WrapperPlayServerSpawnEntity packetOutEntity = new WrapperPlayServerSpawnEntity(event);
             addEntity(packetOutEntity.getEntityId(), packetOutEntity.getUUID().orElse(null), packetOutEntity.getEntityType(), packetOutEntity.getPosition(), packetOutEntity.getYaw(), packetOutEntity.getPitch(), null, packetOutEntity.getData());
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.SPAWN_PLAYER) {
+        }, PacketType.Play.Server.SPAWN_ENTITY);
+        registry.registerHandler(event -> {
             WrapperPlayServerSpawnPlayer packetOutEntity = new WrapperPlayServerSpawnPlayer(event);
             addEntity(packetOutEntity.getEntityId(), packetOutEntity.getUUID(), EntityTypes.PLAYER, packetOutEntity.getPosition(), packetOutEntity.getYaw(), packetOutEntity.getPitch(), packetOutEntity.getEntityMetadata(), 0);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.SPAWN_PAINTING) {
+        }, PacketType.Play.Server.SPAWN_PLAYER);
+        registry.registerHandler(event -> {
             WrapperPlayServerSpawnPainting packetOutEntity = new WrapperPlayServerSpawnPainting(event);
             addEntity(packetOutEntity.getEntityId(), packetOutEntity.getUUID(), EntityTypes.PAINTING, packetOutEntity.getPosition().toVector3d(), 0, 0f, null, packetOutEntity.getDirection().getHorizontalIndex());
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_RELATIVE_MOVE) {
+        }, PacketType.Play.Server.SPAWN_PAINTING);
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityRelativeMove move = new WrapperPlayServerEntityRelativeMove(event);
             handleMoveEntity(event, move.getEntityId(), move.getDeltaX(), move.getDeltaY(), move.getDeltaZ(), null, null, true, true);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_RELATIVE_MOVE_AND_ROTATION) {
+        }, PacketType.Play.Server.ENTITY_RELATIVE_MOVE);
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityRelativeMoveAndRotation move = new WrapperPlayServerEntityRelativeMoveAndRotation(event);
             handleMoveEntity(event, move.getEntityId(), move.getDeltaX(), move.getDeltaY(), move.getDeltaZ(), move.getYaw() * 0.7111111F, move.getPitch() * 0.7111111F, true, true);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_TELEPORT) {
+        }, PacketType.Play.Server.ENTITY_RELATIVE_MOVE_AND_ROTATION);
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityTeleport move = new WrapperPlayServerEntityTeleport(event);
             Vector3d pos = move.getPosition();
             handleMoveEntity(event, move.getEntityId(), pos.getX(), pos.getY(), pos.getZ(), move.getYaw(), move.getPitch(), false, true);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_POSITION_SYNC) {
+        }, PacketType.Play.Server.ENTITY_TELEPORT);
+        registry.registerHandler(event -> {
             // ENTITY_TELEPORT but without relative flags
             WrapperPlayServerEntityPositionSync move = new WrapperPlayServerEntityPositionSync(event);
             final EntityPositionData values = move.getValues();
@@ -122,18 +125,20 @@ public class PacketEntityReplication extends Check implements PacketCheck {
             // TODO this isn't technically correct
             // If the position sync is to a pos > 4096 from the entity pos, client does some special stuff without interpolation
             handleMoveEntity(event, move.getId(), pos.getX(), pos.getY(), pos.getZ(), values.getYaw(), values.getPitch(), false, true);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_ROTATION) { // Affects interpolation
+        }, PacketType.Play.Server.ENTITY_POSITION_SYNC);
+        registry.registerHandler(event -> {
+            // Affects interpolation
             WrapperPlayServerEntityRotation move = new WrapperPlayServerEntityRotation(event);
             handleMoveEntity(event, move.getEntityId(), 0, 0, 0, move.getYaw() * 0.7111111F, move.getPitch() * 0.7111111F, true, false);
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_METADATA) {
+        }, PacketType.Play.Server.ENTITY_ROTATION);
+        registry.registerHandler(event -> {
+            // TODO
             WrapperPlayServerEntityMetadata entityMetadata = new WrapperPlayServerEntityMetadata(event);
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.compensatedEntities.updateEntityMetadata(entityMetadata.getEntityId(), entityMetadata.getEntityMetadata()));
-        }
+        }, PacketType.Play.Server.ENTITY_METADATA);
 
         // 1.19.3+
-        else if (event.getPacketType() == PacketType.Play.Server.PLAYER_INFO_UPDATE) {
+        registry.registerHandler(event -> {
             WrapperPlayServerPlayerInfoUpdate info = new WrapperPlayServerPlayerInfoUpdate(event);
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> {
                 for (WrapperPlayServerPlayerInfoUpdate.PlayerInfo entry : info.getEntries()) {
@@ -142,10 +147,12 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     player.compensatedEntities.profiles.put(uuid, gameProfile);
                 }
             });
-        } else if (event.getPacketType() == PacketType.Play.Server.PLAYER_INFO_REMOVE) {
+        }, PacketType.Play.Server.PLAYER_INFO_UPDATE);
+        registry.registerHandler(event -> {
             WrapperPlayServerPlayerInfoRemove remove = new WrapperPlayServerPlayerInfoRemove(event);
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> remove.getProfileIds().forEach(player.compensatedEntities.profiles::remove));
-        } else if (event.getPacketType() == PacketType.Play.Server.PLAYER_INFO) {
+        }, PacketType.Play.Server.PLAYER_INFO_REMOVE);
+        registry.registerHandler(event -> {
             WrapperPlayServerPlayerInfo info = new WrapperPlayServerPlayerInfo(event);
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> {
                 if (info.getAction() == WrapperPlayServerPlayerInfo.Action.ADD_PLAYER) {
@@ -158,9 +165,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     info.getPlayerDataList().forEach(profile -> player.compensatedEntities.profiles.remove(profile.getUserProfile().getUUID()));
                 }
             });
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_EFFECT) {
+        }, PacketType.Play.Server.PLAYER_INFO);
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityEffect effect = new WrapperPlayServerEntityEffect(event);
 
             PotionType type = effect.getPotionType();
@@ -190,9 +196,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
 
                 entity.addPotionEffect(type, effect.getEffectAmplifier());
             });
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.REMOVE_ENTITY_EFFECT) {
+        }, PacketType.Play.Server.ENTITY_EFFECT);
+        registry.registerHandler(event -> {
             WrapperPlayServerRemoveEntityEffect effect = new WrapperPlayServerRemoveEntityEffect(event);
 
             if (isDirectlyAffectingPlayer(player, effect.getEntityId())) player.sendTransaction();
@@ -203,9 +208,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
 
                 entity.removePotionEffect(effect.getPotionType());
             });
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.UPDATE_ATTRIBUTES) {
+        }, PacketType.Play.Server.REMOVE_ENTITY_EFFECT);
+        registry.registerHandler(event -> {
             WrapperPlayServerUpdateAttributes attributes = new WrapperPlayServerUpdateAttributes(event);
 
             int entityID = attributes.getEntityId();
@@ -215,9 +219,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
 
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(),
                     () -> player.compensatedEntities.updateAttributes(entityID, attributes.getProperties()));
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.ENTITY_STATUS) {
+        }, PacketType.Play.Server.UPDATE_ATTRIBUTES);
+        registry.registerHandler(event -> {
             WrapperPlayServerEntityStatus status = new WrapperPlayServerEntityStatus(event);
             // This hasn't changed from 1.7.2 to 1.17
             // Needed to exempt players on dead vehicles, as dead entities have strange physics.
@@ -249,9 +252,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
             if (status.getStatus() >= 24 && status.getStatus() <= 28 && status.getEntityId() == player.entityID) {
                 player.compensatedEntities.self.setOpLevel(status.getStatus() - 24);
             }
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.SET_SLOT) {
+        }, PacketType.Play.Server.ENTITY_STATUS);
+        registry.registerHandler(event -> {
             WrapperPlayServerSetSlot slot = new WrapperPlayServerSetSlot(event);
 
             if (slot.getWindowId() == 0) {
@@ -275,41 +277,39 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     }
                 });
             }
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.WINDOW_ITEMS) {
+        }, PacketType.Play.Server.SET_SLOT);
+        registry.registerHandler(event -> {
             WrapperPlayServerWindowItems items = new WrapperPlayServerWindowItems(event);
 
             if (items.getWindowId() == 0) { // Player inventory
                 player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.packetStateData.setSlowedByUsingItem(false));
                 player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> player.packetStateData.setSlowedByUsingItem(false));
             }
-        }
+        }, PacketType.Play.Server.WINDOW_ITEMS);
 
         // 1.8 clients fail to send the RELEASE_USE_ITEM packet when a window is opened client sided while using an item
-        else if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
+        registry.registerHandler(event -> {
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.packetStateData.setSlowedByUsingItem(false));
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> player.packetStateData.setSlowedByUsingItem(false));
-        }
-        else if (event.getPacketType() == PacketType.Play.Server.OPEN_HORSE_WINDOW) {
+        }, PacketType.Play.Server.OPEN_WINDOW);
+        registry.registerHandler(event -> {
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.packetStateData.setSlowedByUsingItem(false));
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> player.packetStateData.setSlowedByUsingItem(false));
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.SET_PASSENGERS) {
+        }, PacketType.Play.Server.OPEN_HORSE_WINDOW);
+        registry.registerHandler(event -> {
             WrapperPlayServerSetPassengers mount = new WrapperPlayServerSetPassengers(event);
 
             int vehicleID = mount.getEntityId();
             int[] passengers = mount.getPassengers();
 
             handleMountVehicle(event, vehicleID, passengers);
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.ATTACH_ENTITY) {
+        }, PacketType.Play.Server.SET_PASSENGERS);
+        registry.registerHandler(event -> {
             WrapperPlayServerAttachEntity attach = new WrapperPlayServerAttachEntity(event);
 
             // This packet was replaced by the mount packet on 1.9+ servers - to support multiple passengers on one vehicle
-            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_9)) return;
+            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_9))
+                return;
 
             // If this is mounting rather than leashing
             if (!attach.isLeash()) {
@@ -333,9 +333,8 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     LogUtil.warn("Server sent an invalid attach entity packet for entity " + attach.getHoldingId() + " with passenger " + attach.getAttachedId() + "! The client ignores this.");
                 }
             }
-        }
-
-        else if (event.getPacketType() == PacketType.Play.Server.DESTROY_ENTITIES) {
+        }, PacketType.Play.Server.ATTACH_ENTITY);
+        registry.registerHandler(event -> {
             WrapperPlayServerDestroyEntities destroy = new WrapperPlayServerDestroyEntities(event);
 
             int[] destroyEntityIds = destroy.getEntityIds();
@@ -371,7 +370,7 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     }
                 }, maxFireworkBoostPing);
             }
-        }
+        }, PacketType.Play.Server.DESTROY_ENTITIES);
     }
 
     private void handleMountVehicle(PacketSendEvent event, int vehicleID, int[] passengers) {

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAbilities.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAbilities.java
@@ -1,8 +1,8 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.api.config.ConfigManager;
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
@@ -13,7 +13,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPl
 // The client can send ability packets out of order due to Mojang's excellent netcode design.
 // We must delay the second ability packet until the tick after the first is received
 // Else the player will fly for a tick, and we won't know about it, which is bad.
-public class PacketPlayerAbilities extends Check implements PacketCheck {
+public class PacketPlayerAbilities extends AbstractPacketCheck {
 
     public PacketPlayerAbilities(GrimPlayer player) {
         super(player);
@@ -22,16 +22,16 @@ public class PacketPlayerAbilities extends Check implements PacketCheck {
     boolean lastSentPlayerCanFly = false;
 
     @Override
-    public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_ABILITIES) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerAbilities abilities = new WrapperPlayClientPlayerAbilities(event);
             player.isFlying = abilities.isFlying() && player.canFly;
-        }
+        }, PacketType.Play.Client.PLAYER_ABILITIES);
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.PLAYER_ABILITIES) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerPlayerAbilities abilities = new WrapperPlayServerPlayerAbilities(event);
             player.sendTransaction();
 
@@ -52,8 +52,7 @@ public class PacketPlayerAbilities extends Check implements PacketCheck {
                 player.canFly = abilities.isFlightAllowed();
                 player.isFlying = abilities.isFlying();
             });
-
-        }
+        }, PacketType.Play.Server.PLAYER_ABILITIES);
     }
 
     int maxFlyingPing = 1000;
@@ -62,5 +61,4 @@ public class PacketPlayerAbilities extends Check implements PacketCheck {
     public void onReload(ConfigManager config) {
         maxFlyingPing = config.getIntElse("max-ping-out-of-flying", 1000);
     }
-
 }

--- a/src/main/java/ac/grim/grimac/events/packets/PacketWorldBorder.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketWorldBorder.java
@@ -1,14 +1,14 @@
 package ac.grim.grimac.events.packets;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.math.GrimMath;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.server.*;
 
-public class PacketWorldBorder extends Check implements PacketCheck {
+public class PacketWorldBorder extends AbstractPacketCheck {
     double centerX;
     double centerZ;
     double oldDiameter;
@@ -35,8 +35,8 @@ public class PacketWorldBorder extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.WORLD_BORDER) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerWorldBorder packet = new WrapperPlayServerWorldBorder(event);
 
             player.sendTransaction();
@@ -52,32 +52,29 @@ public class PacketWorldBorder extends Check implements PacketCheck {
                 setLerp(packet.getOldRadius(), packet.getNewRadius(), packet.getSpeed());
                 setAbsoluteMaxSize(packet.getPortalTeleportBoundary());
             }
-        }
-        if (event.getPacketType() == PacketType.Play.Server.INITIALIZE_WORLD_BORDER) {
+        }, PacketType.Play.Server.WORLD_BORDER);
+        registry.registerHandler(event -> {
             player.sendTransaction();
             WrapperPlayServerInitializeWorldBorder border = new WrapperPlayServerInitializeWorldBorder(event);
             setCenter(border.getX(), border.getZ());
             setLerp(border.getOldDiameter(), border.getNewDiameter(), border.getSpeed());
             setAbsoluteMaxSize(border.getPortalTeleportBoundary());
-        }
-
-        if (event.getPacketType() == PacketType.Play.Server.WORLD_BORDER_CENTER) {
+        }, PacketType.Play.Server.INITIALIZE_WORLD_BORDER);
+        registry.registerHandler(event -> {
             player.sendTransaction();
             WrapperPlayServerWorldBorderCenter center = new WrapperPlayServerWorldBorderCenter(event);
             setCenter(center.getX(), center.getZ());
-        }
-
-        if (event.getPacketType() == PacketType.Play.Server.WORLD_BORDER_SIZE) {
+        }, PacketType.Play.Server.WORLD_BORDER_CENTER);
+        registry.registerHandler(event -> {
             player.sendTransaction();
             WrapperPlayServerWorldBorderSize size = new WrapperPlayServerWorldBorderSize(event);
             setSize(size.getDiameter());
-        }
-
-        if (event.getPacketType() == PacketType.Play.Server.WORLD_BORDER_LERP_SIZE) {
+        }, PacketType.Play.Server.WORLD_BORDER_SIZE);
+        registry.registerHandler(event -> {
             player.sendTransaction();
             WrapperPlayWorldBorderLerpSize size = new WrapperPlayWorldBorderLerpSize(event);
             setLerp(size.getOldDiameter(), size.getNewDiameter(), size.getSpeed());
-        }
+        }, PacketType.Play.Server.WORLD_BORDER_LERP_SIZE);
     }
 
     private void setCenter(double x, double z) {

--- a/src/main/java/ac/grim/grimac/manager/ActionManager.java
+++ b/src/main/java/ac/grim/grimac/manager/ActionManager.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.manager;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -9,7 +9,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientIn
 import lombok.Getter;
 
 @Getter
-public class ActionManager extends Check implements PacketCheck {
+public class ActionManager extends AbstractPacketCheck {
     private boolean attacking = false;
     private long lastAttack = 0;
 
@@ -18,18 +18,20 @@ public class ActionManager extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
+            if (!isTickPacketIncludingNonMovement(event.getPacketType())) return;
             WrapperPlayClientInteractEntity action = new WrapperPlayClientInteractEntity(event);
             if (action.getAction() == WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
                 player.totalFlyingPacketsSent = 0;
                 attacking = true;
                 lastAttack = System.currentTimeMillis();
             }
-        } else if (isTickPacketIncludingNonMovement(event.getPacketType())) {
+        }, PacketType.Play.Client.INTERACT_ENTITY);
+        registry.registerHandler(event -> {
             player.totalFlyingPacketsSent++;
             attacking = false;
-        }
+        });
     }
 
     public boolean hasAttackedSince(long time) {

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -64,10 +64,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -86,9 +83,9 @@ public class CheckManager {
 
     public ClassToInstanceMap<AbstractCheck> allChecks;
 
-    private final Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> sendHandlers = new HashMap<>();
-    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> receiveHandlers = new HashMap<>();
-    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> preReceiveHandlers = new HashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> sendHandlers = new IdentityHashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> receiveHandlers = new IdentityHashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> preReceiveHandlers = new IdentityHashMap<>();
 
     public CheckManager(GrimPlayer player) {
         // Include post checks in the packet check too

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -243,7 +243,7 @@ public class CheckManager {
                 .putAll(blockBreakChecks)
                 .build();
 
-        registerReceiveHandlers(prePredictionChecks);
+        registerPreReceiveHandlers(prePredictionChecks);
 
         registerReceiveHandlers(packetChecks);
         registerReceiveHandlers(postPredictionCheck);

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -19,7 +19,10 @@ import ac.grim.grimac.checks.impl.groundspoof.NoFall;
 import ac.grim.grimac.checks.impl.misc.ClientBrand;
 import ac.grim.grimac.checks.impl.misc.GhostBlockMitigation;
 import ac.grim.grimac.checks.impl.misc.TransactionOrder;
-import ac.grim.grimac.checks.impl.movement.*;
+import ac.grim.grimac.checks.impl.movement.NoSlow;
+import ac.grim.grimac.checks.impl.movement.PredictionRunner;
+import ac.grim.grimac.checks.impl.movement.SetbackBlocker;
+import ac.grim.grimac.checks.impl.movement.VehiclePredictionRunner;
 import ac.grim.grimac.checks.impl.multiactions.*;
 import ac.grim.grimac.checks.impl.post.Post;
 import ac.grim.grimac.checks.impl.prediction.DebugHandler;
@@ -54,13 +57,19 @@ import ac.grim.grimac.utils.latency.CompensatedInventory;
 import ac.grim.grimac.utils.team.TeamHandler;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 public class CheckManager {
     private static boolean inited;
@@ -76,6 +85,10 @@ public class CheckManager {
     ClassToInstanceMap<PostPredictionCheck> postPredictionCheck;
 
     public ClassToInstanceMap<AbstractCheck> allChecks;
+
+    private final Map<PacketTypeCommon, List<Consumer<PacketSendEvent>>> sendHandlers = new HashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> receiveHandlers = new HashMap<>();
+    private final Map<PacketTypeCommon, List<Consumer<PacketReceiveEvent>>> preReceiveHandlers = new HashMap<>();
 
     public CheckManager(GrimPlayer player) {
         // Include post checks in the packet check too
@@ -230,6 +243,19 @@ public class CheckManager {
                 .putAll(blockBreakChecks)
                 .build();
 
+        registerReceiveHandlers(prePredictionChecks);
+
+        registerReceiveHandlers(packetChecks);
+        registerReceiveHandlers(postPredictionCheck);
+        registerReceiveHandlers(blockPlaceCheck);
+        registerReceiveHandlers(blockBreakChecks);
+
+        registerSendHandlers(prePredictionChecks);
+        registerSendHandlers(packetChecks);
+        registerSendHandlers(postPredictionCheck);
+        registerSendHandlers(blockPlaceCheck);
+        registerSendHandlers(blockBreakChecks);
+
         init();
     }
 
@@ -249,41 +275,29 @@ public class CheckManager {
     }
 
     public void onPrePredictionReceivePacket(final PacketReceiveEvent packet) {
-        for (PacketCheck check : prePredictionChecks.values()) {
-            check.onPacketReceive(packet);
+        List<Consumer<PacketReceiveEvent>> handlers = preReceiveHandlers.get(packet.getPacketType());
+        if (handlers != null) {
+            for (Consumer<PacketReceiveEvent> handler : handlers) {
+                handler.accept(packet);
+            }
         }
     }
 
     public void onPacketReceive(final PacketReceiveEvent packet) {
-        for (PacketCheck check : packetChecks.values()) {
-            check.onPacketReceive(packet);
-        }
-        for (PostPredictionCheck check : postPredictionCheck.values()) {
-            check.onPacketReceive(packet);
-        }
-        for (BlockPlaceCheck check : blockPlaceCheck.values()) {
-            check.onPacketReceive(packet);
-        }
-        for (BlockBreakCheck check : blockBreakChecks.values()) {
-            check.onPacketReceive(packet);
+        List<Consumer<PacketReceiveEvent>> handlers = receiveHandlers.get(packet.getPacketType());
+        if (handlers != null) {
+            for (Consumer<PacketReceiveEvent> handler : handlers) {
+                handler.accept(packet);
+            }
         }
     }
 
     public void onPacketSend(final PacketSendEvent packet) {
-        for (PacketCheck check : prePredictionChecks.values()) {
-            check.onPacketSend(packet);
-        }
-        for (PacketCheck check : packetChecks.values()) {
-            check.onPacketSend(packet);
-        }
-        for (PostPredictionCheck check : postPredictionCheck.values()) {
-            check.onPacketSend(packet);
-        }
-        for (BlockPlaceCheck check : blockPlaceCheck.values()) {
-            check.onPacketSend(packet);
-        }
-        for (BlockBreakCheck check : blockBreakChecks.values()) {
-            check.onPacketSend(packet);
+        List<Consumer<PacketSendEvent>> handlers = sendHandlers.get(packet.getPacketType());
+        if (handlers != null) {
+            for (Consumer<PacketSendEvent> handler : handlers) {
+                handler.accept(packet);
+            }
         }
     }
 
@@ -361,7 +375,8 @@ public class CheckManager {
     private PacketEntityReplication packetEntityReplication = null;
 
     public PacketEntityReplication getEntityReplication() {
-        if (packetEntityReplication == null) packetEntityReplication = getPacketCheck(PacketEntityReplication.class);
+        if (packetEntityReplication == null)
+            packetEntityReplication = getPacketCheck(PacketEntityReplication.class);
         return packetEntityReplication;
     }
 
@@ -403,6 +418,24 @@ public class CheckManager {
     @SuppressWarnings("unchecked")
     public <T extends PostPredictionCheck> T getPostPredictionCheck(Class<T> check) {
         return (T) postPredictionCheck.get(check);
+    }
+
+    private void registerReceiveHandlers(ClassToInstanceMap<? extends PacketCheck> map) {
+        for (PacketCheck check : map.values()) {
+            check.getReceiveHandlers().forEach((type, handlers) -> receiveHandlers.computeIfAbsent(type, __ -> new ArrayList<>()).addAll(handlers));
+        }
+    }
+
+    private void registerPreReceiveHandlers(ClassToInstanceMap<? extends PacketCheck> map) {
+        for (PacketCheck check : map.values()) {
+            check.getReceiveHandlers().forEach((type, handlers) -> preReceiveHandlers.computeIfAbsent(type, __ -> new ArrayList<>()).addAll(handlers));
+        }
+    }
+
+    private void registerSendHandlers(ClassToInstanceMap<? extends PacketCheck> map) {
+        for (PacketCheck check : map.values()) {
+            check.getSendHandlers().forEach((type, handlers) -> sendHandlers.computeIfAbsent(type, __ -> new ArrayList<>()).addAll(handlers));
+        }
     }
 
     private void init() {

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.utils.latency;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.BlockPlace;
 import ac.grim.grimac.utils.inventory.EquipmentType;
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 // Updated to support modern 1.17 protocol
-public class CompensatedInventory extends Check implements PacketCheck {
+public class CompensatedInventory extends AbstractPacketCheck {
     // "Temporarily" public for debugging
     public Inventory inventory;
     // "Temporarily" public for debugging
@@ -177,7 +177,8 @@ public class CompensatedInventory extends Check implements PacketCheck {
     }
 
     public boolean hasItemType(ItemType type) {
-        if (isPacketInventoryActive || player.bukkitPlayer == null) return inventory.hasItemType(type);
+        if (isPacketInventoryActive || player.bukkitPlayer == null)
+            return inventory.hasItemType(type);
 
         // Fall back to bukkit inventories
         for (org.bukkit.inventory.ItemStack item : player.bukkitPlayer.getInventory().getContents()) {
@@ -187,8 +188,9 @@ public class CompensatedInventory extends Check implements PacketCheck {
         return false;
     }
 
-    public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM) {
+    @Override
+    protected void registerReceiveHandlers(PacketHandlerRegistry<PacketReceiveEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayClientUseItem item = new WrapperPlayClientUseItem(event);
 
             ItemStack use = item.getHand() == InteractionHand.MAIN_HAND ? player.getInventory().getHeldItem() : player.getInventory().getOffHand();
@@ -215,7 +217,8 @@ public class CompensatedInventory extends Check implements PacketCheck {
 
                 ItemStack itemstack1 = getByEquipmentType(equipmentType);
                 // Only 1.19.4+ clients support swapping with non-empty items
-                if (player.getClientVersion().isOlderThan(ClientVersion.V_1_19_4) && !itemstack1.isEmpty()) return;
+                if (player.getClientVersion().isOlderThan(ClientVersion.V_1_19_4) && !itemstack1.isEmpty())
+                    return;
 
                 // 1.19.4+ clients support swapping with non-empty items
                 int swapItemSlot = item.getHand() == InteractionHand.MAIN_HAND ? inventory.selected + Inventory.HOTBAR_OFFSET : Inventory.SLOT_OFFHAND;
@@ -227,9 +230,8 @@ public class CompensatedInventory extends Check implements PacketCheck {
                 inventory.getInventoryStorage().handleClientClaimedSlotSet(slot);
                 inventory.getInventoryStorage().setItem(slot, use);
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.PLAYER_DIGGING) {
+        }, PacketType.Play.Client.USE_ITEM);
+        registry.registerHandler(event -> {
             WrapperPlayClientPlayerDigging dig = new WrapperPlayClientPlayerDigging(event);
 
             // 1.8 clients don't predict dropping items
@@ -251,32 +253,30 @@ public class CompensatedInventory extends Check implements PacketCheck {
                 inventory.setHeldItem(null);
                 inventory.getInventoryStorage().handleClientClaimedSlotSet(Inventory.HOTBAR_OFFSET + player.packetStateData.lastSlotSelected);
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.HELD_ITEM_CHANGE) {
+        }, PacketType.Play.Client.PLAYER_DIGGING);
+        registry.registerHandler(event -> {
             final int slot = new WrapperPlayClientHeldItemChange(event).getSlot();
 
             // Stop people from spamming the server with an out-of-bounds exception
             if (slot > 8 || slot < 0) return;
 
             inventory.selected = slot;
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.CREATIVE_INVENTORY_ACTION) {
+        }, PacketType.Play.Client.HELD_ITEM_CHANGE);
+        registry.registerHandler(event -> {
             WrapperPlayClientCreativeInventoryAction action = new WrapperPlayClientCreativeInventoryAction(event);
             if (player.gamemode != GameMode.CREATIVE) return;
 
             boolean valid = action.getSlot() >= 1 &&
                     (PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_8) ?
-                    action.getSlot() <= 45 : action.getSlot() < 45);
+                            action.getSlot() <= 45 : action.getSlot() < 45);
 
             if (valid) {
                 player.getInventory().inventory.getSlot(action.getSlot()).set(action.getItemStack());
                 inventory.getInventoryStorage().handleClientClaimedSlotSet(action.getSlot());
             }
-        }
-
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW && !event.isCancelled()) {
+        }, PacketType.Play.Client.CREATIVE_INVENTORY_ACTION);
+        registry.registerHandler(event -> {
+            if (event.isCancelled()) return;
             WrapperPlayClientClickWindow click = new WrapperPlayClientClickWindow(event);
 
             // How is this possible? Maybe transaction splitting.
@@ -305,36 +305,21 @@ public class CompensatedInventory extends Check implements PacketCheck {
             if (slot == -1 || slot == -999 || slot < menu.getSlots().size()) {
                 menu.doClick(button, slot, clickType);
             }
-        }
 
-        if (event.getPacketType() == PacketType.Play.Client.CLOSE_WINDOW) {
+        }, PacketType.Play.Client.CLICK_WINDOW);
+        registry.registerHandler(event -> {
             menu = inventory;
             openWindowID = 0;
             menu.setCarried(ItemStack.EMPTY); // Reset carried item
-        }
+        }, PacketType.Play.Client.CLOSE_WINDOW);
     }
 
-    public void markSlotAsResyncing(BlockPlace place) {
-        // Update held item tracking
-        if (place.getHand() == InteractionHand.MAIN_HAND) {
-            inventory.getInventoryStorage().handleClientClaimedSlotSet(Inventory.HOTBAR_OFFSET + player.packetStateData.lastSlotSelected);
-        } else {
-            inventory.getInventoryStorage().handleServerCorrectSlot(Inventory.SLOT_OFFHAND);
-        }
-    }
-
-    public void onBlockPlace(BlockPlace place) {
-        if (player.gamemode != GameMode.CREATIVE && place.getItemStack().getType() != ItemTypes.POWDER_SNOW_BUCKET) {
-            markSlotAsResyncing(place);
-            place.getItemStack().setAmount(place.getItemStack().getAmount() - 1);
-        }
-    }
-
-    public void onPacketSend(final PacketSendEvent event) {
+    @Override
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
         // Not 1:1 MCP, based on Wiki.VG to be simpler as we need less logic...
         // For example, we don't need permanent storage, only storing data until the client closes the window
         // We also don't need a lot of server-sided only logic
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
+        registry.registerHandler(event -> {
             WrapperPlayServerOpenWindow open = new WrapperPlayServerOpenWindow(event);
 
             MenuType menuType = MenuType.getMenuType(open.getType());
@@ -356,10 +341,9 @@ public class CompensatedInventory extends Check implements PacketCheck {
                 isPacketInventoryActive = !(newMenu instanceof NotImplementedMenu);
                 needResend = newMenu instanceof NotImplementedMenu;
             });
-        }
-
+        }, PacketType.Play.Server.OPEN_WINDOW);
         // I'm not implementing this lol
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_HORSE_WINDOW) {
+        registry.registerHandler(event -> {
             WrapperPlayServerOpenHorseWindow open = new WrapperPlayServerOpenHorseWindow(event);
 
             packetSendingInventorySize = UNSUPPORTED_INVENTORY_CASE;
@@ -368,10 +352,9 @@ public class CompensatedInventory extends Check implements PacketCheck {
                 needResend = true;
                 openWindowID = open.getWindowId();
             });
-        }
-
+        }, PacketType.Play.Server.OPEN_HORSE_WINDOW);
         // 1:1 MCP
-        if (event.getPacketType() == PacketType.Play.Server.CLOSE_WINDOW) {
+        registry.registerHandler(event -> {
             packetSendingInventorySize = PLAYER_INVENTORY_CASE;
 
             // Disregard provided window ID, client doesn't care...
@@ -381,10 +364,9 @@ public class CompensatedInventory extends Check implements PacketCheck {
                 menu = inventory;
                 menu.setCarried(ItemStack.EMPTY); // Reset carried item
             });
-        }
-
+        }, PacketType.Play.Server.CLOSE_WINDOW);
         // Should be 1:1 MCP
-        if (event.getPacketType() == PacketType.Play.Server.WINDOW_ITEMS) {
+        registry.registerHandler(event -> {
             WrapperPlayServerWindowItems items = new WrapperPlayServerWindowItems(event);
             stateID = items.getStateId();
 
@@ -425,10 +407,9 @@ public class CompensatedInventory extends Check implements PacketCheck {
                     }
                 });
             }
-        }
-
+        }, PacketType.Play.Server.WINDOW_ITEMS);
         // Also 1:1 MCP
-        if (event.getPacketType() == PacketType.Play.Server.SET_SLOT) {
+        registry.registerHandler(event -> {
             // Only edit hotbar (36 to 44) if window ID is 0
             // Set cursor by putting -1 as window ID and as slot
             // Window ID -2 means any slot can be used
@@ -463,6 +444,22 @@ public class CompensatedInventory extends Check implements PacketCheck {
                     menu.getSlot(slot.getSlot()).set(slot.getItem());
                 }
             });
+        }, PacketType.Play.Server.SET_SLOT);
+    }
+
+    public void markSlotAsResyncing(BlockPlace place) {
+        // Update held item tracking
+        if (place.getHand() == InteractionHand.MAIN_HAND) {
+            inventory.getInventoryStorage().handleClientClaimedSlotSet(Inventory.HOTBAR_OFFSET + player.packetStateData.lastSlotSelected);
+        } else {
+            inventory.getInventoryStorage().handleServerCorrectSlot(Inventory.SLOT_OFFHAND);
+        }
+    }
+
+    public void onBlockPlace(BlockPlace place) {
+        if (player.gamemode != GameMode.CREATIVE && place.getItemStack().getType() != ItemTypes.POWDER_SNOW_BUCKET) {
+            markSlotAsResyncing(place);
+            place.getItemStack().setAmount(place.getItemStack().getAmount() - 1);
         }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/team/TeamHandler.java
+++ b/src/main/java/ac/grim/grimac/utils/team/TeamHandler.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.utils.team;
 
-import ac.grim.grimac.checks.Check;
-import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.checks.AbstractPacketCheck;
+import ac.grim.grimac.checks.PacketHandlerRegistry;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 
 // Reminder: Entities use UUIDs, players use name, for setting teams.
-public class TeamHandler extends Check implements PacketCheck {
+public class TeamHandler extends AbstractPacketCheck {
 
     private final Map<String, EntityTeam> entityTeams = new Object2ObjectOpenHashMap<>();
     private final Map<String, EntityTeam> entityToTeam = new Object2ObjectOpenHashMap<>();
@@ -42,8 +42,8 @@ public class TeamHandler extends Check implements PacketCheck {
     }
 
     @Override
-    public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.TEAMS) {
+    protected void registerSendHandlers(PacketHandlerRegistry<PacketSendEvent> registry) {
+        registry.registerHandler(event -> {
             WrapperPlayServerTeams teams = new WrapperPlayServerTeams(event);
             final String teamName = teams.getTeamName();
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> {
@@ -61,6 +61,6 @@ public class TeamHandler extends Check implements PacketCheck {
                     entityTeam.update(teams);
                 }
             });
-        }
+        }, PacketType.Play.Server.TEAMS);
     }
 }


### PR DESCRIPTION
# Optimize packet event handling

## Summary
Added efficient packet type mapping to avoid processing unnecessary checks and optimized packet event handling by only iterating over relevant handlers

I've tested basic scenarios (fly, hitboxes), but I believe this needs a thorough review before merging, as I could have inadvertently disrupted the logic of individual handlers.

## Performance improvement
I observed high CPU usage during the processing of large numbers of clientbound packets, especially during high-traffic scenarios. After implementing these optimizations, CPU consumption was significantly reduced.

The main optimization changes the packet handling mechanism to use a hashmap of packet types to handlers instead of iterating through all registered handlers for every packet. This maintains the same logical behavior while dramatically improving performance.