### PR TITLE
AimModulo360: fix horse false flag <= 1.13

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/aim/AimModulo360.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/aim/AimModulo360.java
@@ -20,8 +20,10 @@ public class AimModulo360 extends Check implements RotationCheck {
 
     @Override
     public void process(final RotationUpdate rotationUpdate) {
-        // Exempt for teleport or entering a vehicle due to rotation reset
-        if (player.packetStateData.lastPacketWasTeleport || player.vehicleData.wasVehicleSwitch) {
+        // Exempt for teleport, entering a vehicle due to rotation reset or
+        // after forced, client-sided rotation change after interacting with a horse (not necessarily mounting it)
+        if (player.packetStateData.lastPacketWasTeleport || player.vehicleData.wasVehicleSwitch
+                || player.packetStateData.horseInteractCausedForcedRotation) {
             lastDeltaYaw = rotationUpdate.getDeltaXRot();
             return;
         }

--- a/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -813,6 +813,8 @@ public class CheckManagerListener extends PacketListenerAbstract {
         if (!player.packetStateData.lastPacketWasTeleport) {
             player.packetStateData.didSendMovementBeforeTickEnd = true;
         }
+
+        player.packetStateData.horseInteractCausedForcedRotation = false;
     }
 
     private static void placeLilypad(GrimPlayer player, InteractionHand hand) {

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerAttack.java
@@ -4,6 +4,7 @@ import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.checks.impl.badpackets.BadPacketsW;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.nmsutil.BukkitNMS;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerAbstract;
@@ -85,6 +86,13 @@ public class PacketPlayerAttack extends PacketListenerAbstract {
                         // 1.9+ player who might have been slowed, but we can't be sure
                         player.maxAttackSlow++;
                     }
+                }
+            } else if (interact.getAction() == WrapperPlayClientInteractEntity.InteractAction.INTERACT) {
+                // Interacting with a horse in versions 1.13- will cause the client to
+                // set the player's rotation to the horse's rotation
+                if (player.compensatedEntities.getEntity(interact.getEntityId()) instanceof PacketEntityHorse
+                        && player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_13)) {
+                    player.packetStateData.horseInteractCausedForcedRotation = true;
                 }
             }
         }

--- a/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
+++ b/src/main/java/ac/grim/grimac/utils/data/PacketStateData.java
@@ -33,6 +33,9 @@ public class PacketStateData {
     public int lastFood;
     public boolean lastServerTransWasValid = false;
 
+    // If true, the player's rotation was forced to the horse's rotation only on 1.13-
+    public boolean horseInteractCausedForcedRotation = false;
+
     public void setSlowedByUsingItem(boolean slowedByUsingItem) {
         this.slowedByUsingItem = slowedByUsingItem;
         slowedByUsingItemSlot = slowedByUsingItem ? lastSlotSelected : Integer.MIN_VALUE;


### PR DESCRIPTION
When right clicking on a horse (or donkeys, mules) in versions lower than or equal to 1.13, the player's rotation is forcefully set to the horse's rotation on the client (not by the server). This leads to AimModulo360 falses that are completely unrelated to actually mounting the horse but occur even before the server instructs the client to mount the horse.

### Steps to reproduce falses

1. Optional: create a plugin that cancels the VehicleEnterEvent so it's easier to see that these falses are unrelated to mounting the horse
2. Join server using version 1.13 or below
3. Spin around a bunch of times so the player's yaw is above 360
4. Right click a horse
5. Observe AimModulo360 flags even before the player is mounted on the horse

### The cause

MCP 1.8, net/minecraft/entity/passive/EntityHorse.java, mountTo function

```java
    private void mountTo(EntityPlayer player)
    {
        player.rotationYaw = this.rotationYaw;
        player.rotationPitch = this.rotationPitch;
        this.setEatingHaystack(false);
        this.setRearing(false);

        if (!this.worldObj.isRemote)
        ...
```
The player's rotation is set to the horse's rotation even when running on the client.

### The fix

In the PacketPlayerAttack listener, set the `player.packetStateData.horseInteractCausedForcedRotation` boolean to true when a 1.13- player interacts with a horse. This value causes the next rotation to be exempt in AimModulo360. The exempting variable is reset at the end of `handleFlying` in CheckManagerListener like some of the other packet state variables.