### PR TITLE
Add Hitboxes to punishments config

### DIFF
--- a/src/main/resources/punishments/de.yml
+++ b/src/main/resources/punishments/de.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/en.yml
+++ b/src/main/resources/punishments/en.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/es.yml
+++ b/src/main/resources/punishments/es.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/fr.yml
+++ b/src/main/resources/punishments/fr.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/it.yml
+++ b/src/main/resources/punishments/it.yml
@@ -48,6 +48,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/ja.yml
+++ b/src/main/resources/punishments/ja.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/nl.yml
+++ b/src/main/resources/punishments/nl.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/pt.yml
+++ b/src/main/resources/punishments/pt.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/ru.yml
+++ b/src/main/resources/punishments/ru.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/tr.yml
+++ b/src/main/resources/punishments/tr.yml
@@ -59,6 +59,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"

--- a/src/main/resources/punishments/zh.yml
+++ b/src/main/resources/punishments/zh.yml
@@ -61,6 +61,7 @@ Punishments:
     remove-violations-after: 300
     checks:
       - "Reach"
+      - "Hitboxes"
     commands:
       - "5:5 [alert]"
       - "5:5 [webhook]"


### PR DESCRIPTION
Not sure whether this was just an oversight or if it was intentional after the Reach check was split, but Hitboxes does not alert by default after installing Grim.