### PR TITLE
Fix copper door falses

### DIFF
--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -308,7 +308,7 @@ public class CompensatedWorld {
     public void tickOpenable(int blockX, int blockY, int blockZ) {
         final WrappedBlockState data = getBlock(blockX, blockY, blockZ);
         final StateType type = data.getType();
-        if (BlockTags.WOODEN_DOORS.contains(type) || (player.getClientVersion().isOlderThan(ClientVersion.V_1_8) && type == StateTypes.IRON_DOOR)) {
+        if (Materials.isClientSideOpenableDoor(type, player.getClientVersion())) {
             WrappedBlockState otherDoor = getBlock(blockX,
                     blockY + (data.getHalf() == Half.LOWER ? 1 : -1), blockZ);
 
@@ -330,9 +330,7 @@ public class CompensatedWorld {
                     updateBlock(blockX, blockY - 1, blockZ, otherDoor.getGlobalId());
                 }
             }
-        } else if ((player.getClientVersion().isOlderThan(ClientVersion.V_1_8) || type != StateTypes.IRON_TRAPDOOR) // 1.7 can open iron trapdoors.
-                    && BlockTags.TRAPDOORS.contains(type)
-                    || BlockTags.FENCE_GATES.contains(type)) {
+        } else if (Materials.isClientSideOpenableTrapdoor(type, player.getClientVersion()) || BlockTags.FENCE_GATES.contains(type)) {
             // Take 12 most significant bytes -> the material ID.  Combine them with the new block magic data.
             data.setOpen(!data.isOpen());
             updateBlock(blockX, blockY, blockZ, data.getGlobalId());

--- a/src/main/java/ac/grim/grimac/utils/nmsutil/Materials.java
+++ b/src/main/java/ac/grim/grimac/utils/nmsutil/Materials.java
@@ -24,6 +24,9 @@ public class Materials {
     private static final Set<StateType> WATER_SOURCES = new HashSet<>();
     private static final Set<StateType> WATER_SOURCES_LEGACY = new HashSet<>();
 
+    private static final Set<StateType> COPPER_DOORS = new HashSet<>();
+    private static final Set<StateType> COPPER_TRAPDOORS = new HashSet<>();
+
     private static final Set<StateType> CLIENT_SIDE = new HashSet<>();
 
     static {
@@ -53,6 +56,24 @@ public class Materials {
 
         NO_PLACE_LIQUIDS.add(StateTypes.WATER);
         NO_PLACE_LIQUIDS.add(StateTypes.LAVA);
+
+        COPPER_DOORS.add(StateTypes.COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.EXPOSED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.WEATHERED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.OXIDIZED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.WAXED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.WAXED_EXPOSED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.WAXED_WEATHERED_COPPER_DOOR);
+        COPPER_DOORS.add(StateTypes.WAXED_OXIDIZED_COPPER_DOOR);
+
+        COPPER_TRAPDOORS.add(StateTypes.COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.EXPOSED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.WEATHERED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.OXIDIZED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.WAXED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.WAXED_EXPOSED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.WAXED_WEATHERED_COPPER_TRAPDOOR);
+        COPPER_TRAPDOORS.add(StateTypes.WAXED_OXIDIZED_COPPER_TRAPDOOR);
 
         // Important blocks where we need to ignore right-clicking on for placing blocks
         // We can ignore stuff like right-clicking a pumpkin with shears...
@@ -90,7 +111,7 @@ public class Materials {
         CLIENT_SIDE.addAll(BlockTags.SIGNS.getStates());
         CLIENT_SIDE.addAll(BlockTags.FLOWER_POTS.getStates());
         CLIENT_SIDE.addAll(BlockTags.TRAPDOORS.getStates().stream().filter(type -> type != StateTypes.IRON_TRAPDOOR).collect(Collectors.toSet()));
-        CLIENT_SIDE.addAll(BlockTags.WOODEN_DOORS.getStates());
+        CLIENT_SIDE.addAll(BlockTags.MOB_INTERACTABLE_DOORS.getStates());
 
         PANES.addAll(BlockTags.GLASS_PANES.getStates());
         PANES.add(StateTypes.IRON_BARS);
@@ -270,6 +291,41 @@ public class Materials {
 
     public static boolean isClientSideInteractable(StateType material) {
         return CLIENT_SIDE.contains(material);
+    }
+
+    public static boolean isClientSideOpenableDoor(StateType mat, ClientVersion ver) {
+        // Iron doors and all other blocks are not openable
+        if (!BlockTags.MOB_INTERACTABLE_DOORS.contains(mat)) {
+            return false;
+        }
+
+        // Copper doors can only be opened in 1.20.3 and above, in older versions they appear as iron doors
+        if (COPPER_DOORS.contains(mat)) {
+            return ver.isNewerThanOrEquals(ClientVersion.V_1_20_3);
+        }
+
+        // If it's not a copper door players in any version can open it
+        return true;
+    }
+
+    public static boolean isClientSideOpenableTrapdoor(StateType mat, ClientVersion ver) {
+        // Everything except trapdoors
+        if (!BlockTags.TRAPDOORS.contains(mat)) {
+            return false;
+        }
+
+        // In 1.7, only oak trapdoors exist so 1.7 players can open every type of trapdoor
+        if (ver.isOlderThan(ClientVersion.V_1_8)) {
+            return true;
+        }
+
+        // Copper trapdoors can only be opened in 1.20.3 and above, in older versions they appear as iron trapdoors
+        if (COPPER_TRAPDOORS.contains(mat)) {
+            return ver.isNewerThanOrEquals(ClientVersion.V_1_20_3);
+        }
+
+        // If it's not a copper trapdoor players in any version can open it
+        return true;
     }
 
     public static boolean isCompostable(ItemType material) {


### PR DESCRIPTION
Fixes #2037

Opening copper doors is predicted by the client and they are not included in the `WOODEN_DOORS` block tag which we previously used for that. Now, I thought the issue would be fixed by just switching to the new `MOB_INTERACTABLE_DOORS` block tag. That works on all client versions where copper doors already exists, but ViaVersion translates them to Iron Doors on every version before 1.20.3, so they cannot be directly opened there. At that point, implementing all that logic in the if statement in `tickOpenable` in `CompensatedWorld` would have been too messy, so I introduced two new helper methods (`isClientSideOpenableDoor` and `isClientSideOpenableTrapdoor`) in the `Materials` class, structured similarly to the existing methods there.

I also found a condition in the existing code that would allow 1.7 players to predict opening iron doors, I tested it and it's incorrect so I removed it.

The changes were tested on a 1.21.4 server with wooden, copper and iron doors on these client versions: 1.7.10, 1.8.9, 1.20.2, 1.20.3, 1.21.4. No issues were discovered. Please let me know if I should test any other versions.

I also tested these changes on a 1.8.9 server (wooden and iron doors only) with the same client versions and found that wooden doors false when jumping into them and opening them with newer client versions even without my changes. I'll create a new issue for that.