### PR TITLE
Fix horse hitbox falses

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -22,6 +22,7 @@ import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.data.packetentity.PacketEntityHorse;
 import ac.grim.grimac.utils.data.packetentity.dragon.PacketEntityEnderDragonPart;
 import ac.grim.grimac.utils.math.Vector3dm;
 import ac.grim.grimac.utils.nmsutil.ReachUtils;
@@ -240,6 +241,27 @@ public class Reach extends Check implements PacketCheck {
         // if the entity is not exempt and the entity is alive
         if ((!blacklisted.contains(reachEntity.type) && reachEntity.isLivingEntity) || reachEntity.type == EntityTypes.END_CRYSTAL) {
             if (minDistance == Double.MAX_VALUE) {
+                // Interacting with a horse (not necessarily mounting it) forcefully sets the
+                // rotation of the player to the horse's rotation on the client in versions 1.13
+                // and lower, so in that case the rotation sent in the following flying packet
+                // is not the one used for interacting with the horse, but we used it for the reach
+                // calculation, which leads to hitbox flags. However, the player's position is
+                // still accurate, so this forced rotation will not cause reach falses, and we
+                // can still check reach on horse interactions.
+                //
+                // This even affects attacks from the same tick as the client only ray traces
+                // at the start of the tick, so an attack can occur first and then the interaction
+                // happens which breaks the rotation. We exempt attacks automatically because the
+                // horseInteractCausedForcedRotation is set as soon as an interact is received
+                // and is only set to false on the next flying/transaction. This function here is
+                // run either directly on attack/interact if packets have previously been cancelled
+                // or on that next flying/transaction so we always know if the rotation was forced.
+                // If there wasn't any interaction with a horse in a tick, attacks can still be
+                // checked normally.
+                if (reachEntity instanceof PacketEntityHorse && player.packetStateData.horseInteractCausedForcedRotation) {
+                    return NONE;
+                }
+
                 cancelBuffer = 1;
                 return new CheckResult(ResultType.HITBOX, "");
             } else if (minDistance > maxReach) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -240,28 +240,35 @@ public class Reach extends Check implements PacketCheck {
 
         // if the entity is not exempt and the entity is alive
         if ((!blacklisted.contains(reachEntity.type) && reachEntity.isLivingEntity) || reachEntity.type == EntityTypes.END_CRYSTAL) {
-            if (minDistance == Double.MAX_VALUE) {
-                // Interacting with a horse (not necessarily mounting it) forcefully sets the
-                // rotation of the player to the horse's rotation on the client in versions 1.13
-                // and lower, so in that case the rotation sent in the following flying packet
-                // is not the one used for interacting with the horse, but we used it for the reach
-                // calculation, which leads to hitbox flags. However, the player's position is
-                // still accurate, so this forced rotation will not cause reach falses, and we
-                // can still check reach on horse interactions.
-                //
-                // This even affects attacks from the same tick as the client only ray traces
-                // at the start of the tick, so an attack can occur first and then the interaction
-                // happens which breaks the rotation. We exempt attacks automatically because the
-                // horseInteractCausedForcedRotation is set as soon as an interact is received
-                // and is only set to false on the next flying/transaction. This function here is
-                // run either directly on attack/interact if packets have previously been cancelled
-                // or on that next flying/transaction so we always know if the rotation was forced.
-                // If there wasn't any interaction with a horse in a tick, attacks can still be
-                // checked normally.
-                if (reachEntity instanceof PacketEntityHorse && player.packetStateData.horseInteractCausedForcedRotation) {
+            // Interacting with a horse (not necessarily mounting it) forcefully sets the
+            // rotation of the player to the horse's rotation on the client in versions 1.13
+            // and lower, so in that case the rotation sent in the following flying packet
+            // is not the one used for interacting with the horse, but we used it for the reach
+            // calculation, which leads to hitbox and reach flags.
+            //
+            // This even affects attacks from the same tick as the client only ray traces
+            // at the start of the tick, so an attack can occur first and then the interaction
+            // happens which breaks the rotation. We exempt attacks automatically because the
+            // horseInteractCausedForcedRotation is set as soon as an interact is received
+            // and is only set to false on the next flying/transaction. This function here is
+            // run either directly on attack/interact if packets have previously been cancelled
+            // or on that next flying/transaction so we always know if the rotation was forced.
+            // If there wasn't any interaction with a horse in a tick, attacks can still be
+            // checked normally.
+            //
+            // We use the basic rotationless reach check as a replacement here, otherwise
+            // cheaters could flag reach once to increase their cancelBuffer and effectively
+            // bypass the getMinReachToBox check in isKnownInvalid for a few hits.
+            if (reachEntity instanceof PacketEntityHorse && player.packetStateData.horseInteractCausedForcedRotation) {
+                double optimalRotationMinDistance = ReachUtils.getMinReachToBox(player, targetBox);
+                if (optimalRotationMinDistance > maxReach) {
+                    return new CheckResult(ResultType.REACH, String.format("%.5f", optimalRotationMinDistance) + " blocks");
+                } else {
                     return NONE;
                 }
+            }
 
+            if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return new CheckResult(ResultType.HITBOX, "");
             } else if (minDistance > maxReach) {

--- a/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -38,6 +38,7 @@ import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerBlockPlacement;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUseItem;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAcknowledgeBlockChanges;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
@@ -461,6 +462,16 @@ public class CheckManagerListener extends PacketListenerAbstract {
         // Call the packet checks last as they can modify the contents of the packet
         // Such as the NoFall check setting the player to not be on the ground
         player.checkManager.onPacketReceive(event);
+
+        // Reset exemption for forced horse rotation when we know a new tick is starting
+        // The second case (transaction) will be quite unlikely since we should receive a rotation
+        // packet because of the large forced rotation difference.
+        if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())
+                || event.getPacketType() == PacketType.Play.Client.WINDOW_CONFIRMATION
+                || event.getPacketType() == PacketType.Play.Client.PONG
+        ) {
+            player.packetStateData.horseInteractCausedForcedRotation = false;
+        }
 
         if (player.packetStateData.cancelDuplicatePacket) {
             event.setCancelled(true);

--- a/common/src/main/java/ac/grim/grimac/events/packets/PreViaCheckManagerListener.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PreViaCheckManagerListener.java
@@ -331,8 +331,6 @@ public class PreViaCheckManagerListener extends PacketListenerAbstract {
         if (!player.packetStateData.lastPacketWasTeleport) {
             player.packetStateData.didSendMovementBeforeTickEnd = true;
         }
-
-        player.packetStateData.horseInteractCausedForcedRotation = false;
     }
 
     private void handleDigging(GrimPlayer player, PacketReceiveEvent event) {


### PR DESCRIPTION
Fixes the hitboxes falses when mounting a horse (mentioned in #1794). When interacting with a horse, the player's rotation is forcefully set to the horse's rotation on the client in 1.13 and below so we don't receive the actual rotation used to interact with the horse, meaning we can't check for hitboxes when interacting with horses. We can still check for reach though.

This fix uses the horseInteractCausedForcedRotation field introduced in #2033 (that PR also includes a more detailed explanation of the exact cause) in the reach check to exempt only the hitbox check for horses when the player has interacted with one in the current tick (this also exempts any attacks in the same tick since these false too). For this to work, I had to move the reset of the boolean field near the end of the `onPacketReceive` method in `CheckManagerListener` so we can still access the true value in the reach check.

I have included a detailed comment in the reach check code explaining the exemption, please let me know if I should shorten that and refer here instead.