### PR TITLE
Fix vehicle desync when demounting too fast

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -375,7 +375,7 @@ public class PacketEntityReplication extends Check implements PacketCheck {
     }
 
     private void handleMountVehicle(PacketSendEvent event, int vehicleID, int[] passengers) {
-        boolean wasInVehicle = player.getRidingVehicleId() == vehicleID;
+        boolean wasInVehicle = player.compensatedEntities.serverPlayerVehicle == vehicleID;
         boolean inThisVehicle = false;
 
         for (int passenger : passengers) {


### PR DESCRIPTION
When demounting too quickly, a desync can occur and the player cannot move at all.
I believe the issue to be this line:
```
boolean wasInVehicle = player.getRidingVehicleId() == vehicleID;
```
The variable `wasInVehicle`  is used to determine if an entity is being mounted or dismounted. 
`player.getRidingVehicleId() ` is latency compensated. But the way `wasInVehicle ` is used it really shouldn't.

Replacing it to use `serverPlayerVehicle ` fixes the desync. Tested on 1.8.9 Server with 1.8.9 and 1.21.5 clients.
I'm not too sure if this has any other side effects. 

From the discord:
![image](https://github.com/user-attachments/assets/e8796ae9-beb2-4e61-bc03-0e0eca687ac8)
