### PR TITLE
Fix PacketWorldReaderEighteen

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/worldreader/PacketWorldReaderEighteen.java
+++ b/src/main/java/ac/grim/grimac/events/packets/worldreader/PacketWorldReaderEighteen.java
@@ -2,14 +2,11 @@ package ac.grim.grimac.events.packets.worldreader;
 
 import ac.grim.grimac.player.GrimPlayer;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.protocol.world.chunk.BaseChunk;
 import com.github.retrooper.packetevents.protocol.world.chunk.impl.v_1_18.Chunk_v1_18;
 import com.github.retrooper.packetevents.protocol.world.chunk.reader.impl.ChunkReader_v1_18;
 import com.github.retrooper.packetevents.protocol.world.dimension.DimensionTypes;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-
-import java.io.ByteArrayInputStream;
 
 public class PacketWorldReaderEighteen extends BasePacketWorldReader {
 
@@ -24,10 +21,11 @@ public class PacketWorldReaderEighteen extends BasePacketWorldReader {
         // Skip past heightmaps
         wrapper.readNBT();
 
+        int dataLength = wrapper.readVarInt();
+
         BaseChunk[] chunks = new ChunkReader_v1_18().read(DimensionTypes.OVERWORLD,null,
                 null, true, false, false,
-                event.getUser().getTotalWorldHeight() >> 4, null,
-                new NetStreamInput(new ByteArrayInputStream(wrapper.readByteArray())));
+                event.getUser().getTotalWorldHeight() >> 4, dataLength, wrapper);
 
         // Remove biomes to save memory
         for (int i = 0; i < chunks.length; i++) {


### PR DESCRIPTION
After the recent update to PacketEvents 2.8.0, chunks are not being read correctly anymore and the following exception is spammed to the console on 1.21.4 servers (versions above and including 1.18 are likely affected as well):

```
[21:28:41 WARN]: [ac.grim.grimac.shaded.com.github.retrooper.packetevents.PacketEventsAPI] PacketEvents caught an unhandled exception while calling your listener.
java.lang.NullPointerException: Cannot read the array length because "array" is null
	at io.netty.buffer.Unpooled.wrappedBuffer(Unpooled.java:157) ~[netty-buffer-4.1.115.Final.jar:4.1.115.Final]
	at grimac-2.3.71.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.netty.buffer.ByteBufAllocationOperatorModernImpl.wrappedBuffer(ByteBufAllocationOperatorModernImpl.java:27) ~[grimac-2.3.71.jar:?]
	at grimac-2.3.71.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.netty.buffer.UnpooledByteBufAllocationHelper.wrappedBuffer(UnpooledByteBufAllocationHelper.java:25) ~[grimac-2.3.71.jar:?]
	at grimac-2.3.71.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.protocol.world.chunk.reader.ChunkReader.read(ChunkReader.java:42) ~[grimac-2.3.71.jar:?]
	at grimac-2.3.71.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.protocol.world.chunk.reader.ChunkReader.read(ChunkReader.java:58) ~[grimac-2.3.71.jar:?]
	at grimac-2.3.71.jar/ac.grim.grimac.events.packets.worldreader.PacketWorldReaderEighteen.handleMapChunk(PacketWorldReaderEighteen.java:27) ~[grimac-2.3.71.jar:?]
...
```

This PR updates the `handleMapChunk` method in the `PacketWorldReaderEighteen` class to use the correct `read` method of `ChunkReader_v1_18`. For this method, an `arrayLength` argument is needed which was not required before, I copied the code to obtain this value from the PacketEvents `WrapperPlayServerChunkData` class which also uses the `read` function. With these changes, chunks seem to be read correctly again.

The `PacketWorldReaderEight` still works, apparently it requires no changes.