### PR TITLE
Fix cobweb 0.03 false setback

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -748,7 +748,8 @@ public class CheckManagerListener extends PacketListenerAbstract {
             //
             // This may need to be secured better, but limiting the new setback positions seems good enough for now...
             boolean canFeasiblyPointThree = Collisions.slowCouldPointThreeHitGround(player, player.x, player.y, player.z);
-            if ((!canFeasiblyPointThree && !player.compensatedWorld.isNearHardEntity(player.boundingBox.copy().expand(4))) || player.clientVelocity.getY() > 0.06) {
+            if (!canFeasiblyPointThree && !player.compensatedWorld.isNearHardEntity(player.boundingBox.copy().expand(4))
+                    || player.clientVelocity.getY() > 0.06 && !player.uncertaintyHandler.wasAffectedByStuckSpeed()) {
                 player.getSetbackTeleportUtil().executeForceResync();
             }
         }


### PR DESCRIPTION
Fixes #2094
When horizontally colliding with a block that has a cobweb on top and jumping into that cobweb, players are constantly being setback to a single position without any alerts, making it difficult to leave the cobweb and even impossible to move through it. The teleport is prevented by using `uncertaintyHandler.wasAffectedByStuckSpeed()` to check if the player was touching a cobweb. This fixes the issue on 1.8.
