### PR TITLE
Check server version before complaining about ViaVersion placement rotation

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/init/start/ViaVersion.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/start/ViaVersion.java
@@ -12,13 +12,16 @@ public class ViaVersion implements StartableInitable {
     @Override
     public void start() {
         if (!ViaVersionUtil.isAvailable()) return;
-        if (Via.getConfig().getValues().containsKey("fix-1_21-placement-rotation") && Via.getConfig().fix1_21PlacementRotation()) {
+
+        ServerVersion serverVersion = PacketEvents.getAPI().getServerManager().getVersion();
+
+        if (Via.getConfig().getValues().containsKey("fix-1_21-placement-rotation") && Via.getConfig().fix1_21PlacementRotation() && serverVersion.isOlderThan(ServerVersion.V_1_21)) {
             LogUtil.error("GrimAC has detected that you are using ViaVersion with the `fix-1_21-placement-rotation` option enabled.");
             LogUtil.error("This option is known to cause issues with GrimAC and may result in false positives and bypasses.");
             LogUtil.error("Please disable this option in your ViaVersion configuration to prevent these issues.");
         }
 
-        if (GrimAPI.INSTANCE.getPluginManager().getPlugin("ViaBackwards") != null && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21_2)) {
+        if (GrimAPI.INSTANCE.getPluginManager().getPlugin("ViaBackwards") != null && serverVersion.isNewerThanOrEquals(ServerVersion.V_1_21_2)) {
             LogUtil.warn("GrimAC has detected that you have installed ViaBackwards on a 1.21.2+ server.");
             LogUtil.warn("This setup is currently unsupported and you will experience issues with older clients using vehicles.");
         }


### PR DESCRIPTION
ViaVersion's `fix-1_21-placement-rotation` option only applies to 1.21+ clients on servers older than 1.21. Ref:
- https://github.com/ViaVersion/ViaVersion/blob/e597d8faaa69f1e0246999b14c1e021129031e97/api/src/main/java/com/viaversion/viaversion/api/configuration/ViaVersionConfig.java#L483
- https://github.com/ViaVersion/ViaVersion/blob/e597d8faaa69f1e0246999b14c1e021129031e97/common/src/main/java/com/viaversion/viaversion/protocols/v1_20_5to1_21/rewriter/EntityPacketRewriter1_21.java#L114

I got annoyed by the error message because it doesn't apply to my server version, and it could be misleading for other server owners, so let's check the server version before complaining.