### PR TITLE
Fixed: NullPointerException in BadPacketsH

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -175,7 +175,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
 
                 player.checkManager.getPacketCheck(BadPacketsE.class).handleRespawn(); // Reminder ticks reset
                 player.checkManager.getPacketCheck(BadPacketsG.class).handleRespawn();
-                player.checkManager.getPacketCheck(BadPacketsH.class).onWorldChange();
+                player.checkManager.getBlockPlaceCheck(BadPacketsH.class).onWorldChange();
 
                 // compensate for immediate respawn gamerule
                 if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)) {

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -319,6 +319,11 @@ public class CheckManager {
         return (T) rotationCheck.get(check);
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends BlockPlaceCheck> T getBlockPlaceCheck(Class<T> check) {
+        return (T) blockPlaceCheck.get(check);
+    }
+
     public void onPrePredictionReceivePacket(final PacketReceiveEvent packet) {
         for (PacketCheck check : prePredictionChecks.values()) {
             check.onPacketReceive(packet);


### PR DESCRIPTION
Fixes a NullPointerException being thrown in BadPacketsH upon the server sending a respawn packet, because `BadPacketsH` isn't part of the PacketCheck ImmutableClassToInstanceMap.

Fixes: #2105
Fixes: #2107 