### PR TITLE
Save via version state after query to avoid re-compute.

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/reflection/ViaVersionUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/reflection/ViaVersionUtil.java
@@ -39,7 +39,8 @@ public class ViaVersionUtil {
 
     public static boolean isAvailable() {
         if (available == ViaState.UNKNOWN) { // Plugins haven't loaded... let's refer to whether we have a class
-            return getViaVersionAccessor();
+            boolean present = getViaVersionAccessor();
+            available = present ? ViaState.ENABLED : ViaState.DISABLED;
         }
         return available == ViaState.ENABLED;
     }


### PR DESCRIPTION
Whether ViaVersion is available is checked every time when `isAvailable()` called, leading to high CPU usage, which should be optimized.
The fact is that my server was impacted because of this, while highest CPU usage points to this method. It's strange that this issue didn't occur at the first 12 hours after installation of GrimAC, but restarting server did not resolve this issue though.