### PR TITLE
Enhance /grim sendalert with Hybrid MiniMessage & Legacy Formatting

### DIFF
--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimSendAlert.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimSendAlert.java
@@ -5,27 +5,82 @@ import ac.grim.grimac.command.BuildableCommand;
 import ac.grim.grimac.platform.api.sender.Sender;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.description.Description;
 import org.incendo.cloud.parser.standard.StringParser;
 
-public class GrimSendAlert implements BuildableCommand {
+import java.util.regex.Pattern;
+
+public final class GrimSendAlert implements BuildableCommand {
+
+    private static final MiniMessage MM = MiniMessage.miniMessage(); // Strict MiniMessage parser
+    // Pattern to find & followed by a valid color/formatting code char
+    private static final Pattern LEGACY_COLOR_CODE_PATTERN = Pattern.compile("&([0-9a-fk-orA-FK-OR])");
+
     @Override
-    public void register(CommandManager<Sender> commandManager) {
-        commandManager.command(
-                commandManager.commandBuilder("grim", "grimac")
-                        .literal("sendalert")
-                        .permission("grim.sendalert")
-                        .required("message", StringParser.greedyStringParser())
-                        .handler(this::handleSendAlert)
+    public void register(@NonNull CommandManager<Sender> manager) {
+        manager.command(
+            manager.commandBuilder("grim", "grimac")
+                   .literal(
+                       "sendalert",
+                       Description.of("Broadcast an alert (MiniMessage or legacy) to all staff"))
+                   .permission("grim.sendalert")
+                   .required("message", StringParser.greedyStringParser())
+                   .handler(this::handleSendAlert)
         );
     }
 
-    private void handleSendAlert(@NonNull CommandContext<Sender> context) {
-        String string = context.get("message");
-        string = MessageUtil.replacePlaceholders((Sender) null, string);
-        Component message = MessageUtil.miniMessage(string);
-        GrimAPI.INSTANCE.getAlertManager().sendAlert(message, null);
+    /**
+     * Translates legacy '&' color codes to '§' color codes.
+     */
+    private String translateLegacyColors(String text) {
+        if (text == null) {
+            return null;
+        }
+        return LEGACY_COLOR_CODE_PATTERN.matcher(text).replaceAll("\u00A7$1");
+    }
+
+    private void handleSendAlert(@NonNull CommandContext<Sender> ctx) {
+        String raw = ((String) ctx.get("message")).trim();
+
+        // Strip optional wrapping quotes
+        if (raw.length() > 1 &&
+           ((raw.startsWith("\"") && raw.endsWith("\"")) ||
+            (raw.startsWith("'")  && raw.endsWith("'")))) {
+            raw = raw.substring(1, raw.length() - 1);
+        }
+
+        String replacedPlaceholders = MessageUtil.replacePlaceholders((Sender) null, raw);
+
+        // Translate & to § for compatibility with MiniMessage's interpretation of legacy codes in attributes
+        String translatedForMiniMessage = translateLegacyColors(replacedPlaceholders);
+
+        Component finalComponent;
+
+        try {
+            // Attempt to parse with the STRICT MiniMessage parser
+            Component miniMessageAttempt = MM.deserialize(translatedForMiniMessage);
+
+            // If MM.deserialize didn't apply MiniMessage formatting (e.g., input was "§4Hello"),
+            // it means the input was likely pure legacy or plain text.
+            if (miniMessageAttempt.equals(Component.text(translatedForMiniMessage))) {
+                // Fall back to MessageUtil.miniMessage for pure legacy & code handling,
+                // using the original placeholder-replaced string (before & -> § translation).
+                finalComponent = MessageUtil.miniMessage(replacedPlaceholders);
+            } else {
+                // MiniMessage formatting was successfully applied.
+                finalComponent = miniMessageAttempt;
+            }
+        } catch (Exception e) {
+            // Fallback for cases where strict MM.deserialize fails (e.g., malformed MiniMessage,
+            // or complex mixed content that MessageUtil.miniMessage can handle).
+            // Use the original placeholder-replaced string.
+            finalComponent = MessageUtil.miniMessage(replacedPlaceholders);
+        }
+
+        GrimAPI.INSTANCE.getAlertManager().sendAlert(finalComponent, null);
     }
 }

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
@@ -105,8 +105,6 @@ public class MessageUtil {
 
     public @NotNull Component miniMessage(@NotNull String string) {
         string = string.replace("%prefix%", GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("prefix", "&bGrim &8»"));
-                // Unescape common sequences when received via commands
-                string = string.replace("\\n", "\n").replace("\\\"", "\"");
 
         // hex codes
         Matcher matcher = HEX_PATTERN.matcher(string);

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
@@ -105,6 +105,8 @@ public class MessageUtil {
 
     public @NotNull Component miniMessage(@NotNull String string) {
         string = string.replace("%prefix%", GrimAPI.INSTANCE.getConfigManager().getConfig().getStringElse("prefix", "&bGrim &8»"));
+                // Unescape common sequences when received via commands
+                string = string.replace("\\n", "\n").replace("\\\"", "\"");
 
         // hex codes
         Matcher matcher = HEX_PATTERN.matcher(string);


### PR DESCRIPTION
This PR updates the `/grim sendalert` command to support both **MiniMessage** and traditional **legacy `&` color code** formatting for staff alerts. This allows for richer alert messages using features like hover/click events and gradients, while maintaining compatibility with existing legacy formatted messages.

## Changes

*   **Input Pre-processing:**
    *   Trims whitespace and strips optional wrapping quotes (`"`/`'`) from the input message.
    *   Replaces standard `%placeholders%`.
    *   Translates legacy `&` color codes to `§` section codes. This helps the MiniMessage parser correctly interpret legacy codes embedded within MiniMessage tag attributes (e.g., `hover_text`).

*   **Hybrid Parsing Strategy:**
    1.  **MiniMessage Attempt:** The pre-processed string (with `§` codes) is first parsed using a strict `MiniMessage` instance.
        *   If MiniMessage tags are successfully processed, this result is used.
        *   If no MiniMessage tags were effectively applied (e.g., the input was pure legacy like `&cHello`), the logic proceeds to the fallback.
    2.  **Legacy/Fallback (`MessageUtil.miniMessage`):**
        *   If the MiniMessage attempt indicates the input was pure legacy/plain text, `MessageUtil.miniMessage()` is used with the original (pre-`§` translation) string to ensure correct legacy `&` code handling.
        *   If the strict MiniMessage parser encounters an exception (e.g., malformed MiniMessage or a complex mix it can't handle), `MessageUtil.miniMessage()` is used as a fallback with the original string.

This ensures pure MiniMessage, pure legacy codes, and MiniMessage containing embedded legacy codes are all handled appropriately.

## How to Test

1.  **Legacy:** `/grim sendalert &cLegacy &lAlert`
    *   _Expected:_ Colored and bolded alert.
2.  **MiniMessage:** `/grim sendalert "<red>MiniMessage <click:run_command:/say Test>Click</click>"`
    *   _Expected:_ Red text, clickable "Click".
3.  **MiniMessage with `&` in attributes:** `/grim sendalert "<hover:show_text:'&aTooltip &6Example'>Hover Me</hover>"`
    *   _Expected:_ "Hover Me" displays; hovering shows colored "Tooltip Example".
4.  **Quoted Input:** `/grim sendalert ""'<blue>Quoted MiniMessage</blue>'""`
    *   _Expected:_ Blue "Quoted MiniMessage", quotes are stripped.

This provides a robust and flexible way for staff to create alerts, without impacting any current configurations.