### PR TITLE
Fix GrimPlayer#getKeepAlivePing() method throwing a CCE.

### DIFF
--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -656,7 +656,7 @@ public class GrimPlayer implements GrimUser {
     @Override
     public int getKeepAlivePing() {
         if (platformPlayer == null) return -1;
-        return PacketEvents.getAPI().getPlayerManager().getPing(platformPlayer);
+        return PacketEvents.getAPI().getPlayerManager().getPing(platformPlayer.getNative());
     }
 
     public SetbackTeleportUtil getSetbackTeleportUtil() {


### PR DESCRIPTION
I've just seen that GrimPlayer#getKeepAlivePing() throws a ClassCastException. This should fix the issue as PacketEvents is casting the object with the appropriate player (depending on the platform). But i'm not sure that my way of fixing this is correct/robust.

```
at ac.grim.grimac.shaded.io.github.retrooper.packetevents.manager.player
.PlayerManagerImpl.getPing(PlayerManagerImpl.java:43)
        at ac.grim.grimac.player.GrimPlayer.getKeepAlivePing(GrimPlayer.java:665)
```