### PR TITLE
fix box npe

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/type/BlockPlaceCheck.java
+++ b/common/src/main/java/ac/grim/grimac/checks/type/BlockPlaceCheck.java
@@ -74,7 +74,7 @@ public class BlockPlaceCheck extends Check implements RotationCheck, BlockBreakC
             return new SimpleCollisionBox(clicked.getX() + 1, clicked.getY() + 1, clicked.getZ() + 1, clicked.getX(), clicked.getY(), clicked.getZ());
         }
 
-        HitboxData.getBlockHitbox(
+        int size = HitboxData.getBlockHitbox(
                 player,
                 place.material,
                 player.getClientVersion(),
@@ -86,7 +86,8 @@ public class BlockPlaceCheck extends Check implements RotationCheck, BlockBreakC
         ).downCast(boxes);
 
         SimpleCollisionBox combined = new SimpleCollisionBox(clicked.getX(), clicked.getY(), clicked.getZ());
-        for (SimpleCollisionBox box : boxes) {
+        for (int i = 0; i < size; i++) {
+            SimpleCollisionBox box = boxes[i];
             combined = new SimpleCollisionBox(
                     Math.max(box.minX, combined.minX),
                     Math.max(box.minY, combined.minY),


### PR DESCRIPTION
```text
[ac.grim.grimac.shaded.com.github.retrooper.packetevents.PacketEventsAPI] PacketEvents caught an unhandled exception while calling your listener.
java.lang.NullPointerException: Cannot read field "minX" because "box" is null
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.checks.type.BlockPlaceCheck.getCombinedBox(BlockPlaceCheck.java:90) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.checks.impl.scaffolding.PositionPlace.onBlockPlace(PositionPlace.java:21) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.manager.CheckManager.onBlockPlace(CheckManager.java:393) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.events.packets.CheckManagerListener.onPacketReceive(CheckManagerListener.java:420) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.event.PacketReceiveEvent.call(PacketReceiveEvent.java:44) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.event.EventManager.callEvent(EventManager.java:85) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.com.github.retrooper.packetevents.util.PacketEventsImplHelper.handleServerBoundPacket(PacketEventsImplHelper.java:101) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.read(PacketEventsDecoder.java:68) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.decode(PacketEventsDecoder.java:85) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
	at grimac-bukkit-2.3.72-d8b719daf.jar/ac.grim.grimac.shaded.io.github.retrooper.packetevents.injector.handlers.PacketEventsDecoder.decode(PacketEventsDecoder.java:43) ~[grimac-bukkit-2.3.72-d8b719daf.jar:?]
```