### PR TITLE
Shadow 9.0.0-rc2

### DIFF
--- a/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
@@ -5,17 +5,10 @@ plugins {
     id("com.gradleup.shadow")
 }
 
-// Create a configuration for shading dependencies from common
-val shadowCommon: Configuration by project.configurations.creating {
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(project.configurations.getByName("implementation"))
-}
-
 tasks.named<ShadowJar>("shadowJar") {
     minimize()
-    archiveFileName.set("${rootProject.name}-${project.name}-${rootProject.version}.jar")
-    from(shadowCommon) // Use from() instead of direct assignment
+    archiveFileName = "${rootProject.name}-${project.name}-${rootProject.version}.jar"
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     if (BuildConfig.relocate) {
         if (BuildConfig.shadePE) {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -18,7 +18,7 @@ fabric-loom = "1.11.4"
 
 spotless = "6.25.0"
 lombok = "8.6"
-shadow = "9.0.0-beta8"
+shadow = "9.0.0-rc2"
 
 [libraries]
 adventure-text-minimessage = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure"}


### PR DESCRIPTION
```
OLD: grimac-bukkit-2.3.72-ba4bbef66-before.jar
NEW: grimac-bukkit-2.3.72-ba4bbef66-new.jar

 JAR   │ old      │ new      │ diff
───────┼──────────┼──────────┼──────────
 class │ 20.9 MiB │ 20.9 MiB │      0 B
 other │  1.5 MiB │  1.5 MiB │ -1.2 KiB
───────┼──────────┼──────────┼──────────
 total │ 22.4 MiB │ 22.4 MiB │ -1.2 KiB

 CLASSES │ old   │ new   │ diff
─────────┼───────┼───────┼───────────
 classes │  4603 │  4603 │ 0 (+0 -0)
 methods │ 53656 │ 53656 │ 0 (+0 -0)
  fields │ 22173 │ 22173 │ 0 (+0 -0)

=================
====   JAR   ====
=================

 size  │ diff     │ path
───────┼──────────┼─────────────────────────────────────────────────────────────────
   0 B │      0 B │ + META-INF/versions/9/ac/grim/grimac/shaded/snakeyaml/internal/
   0 B │      0 B │ + META-INF/versions/9/ac/grim/grimac/shaded/snakeyaml/
       │      0 B │ - META-INF/versions/9/org/yaml/snakeyaml/internal/
   0 B │      0 B │ + META-INF/versions/9/ac/grim/grimac/shaded/
       │      0 B │ - META-INF/versions/9/org/yaml/snakeyaml/
   0 B │      0 B │ + META-INF/versions/9/ac/grim/grimac/
       │      0 B │ - META-INF/versions/9/org/yaml/
   0 B │      0 B │ + META-INF/versions/9/ac/grim/
       │      0 B │ - META-INF/versions/9/org/
   0 B │      0 B │ + META-INF/versions/9/ac/
   0 B │      0 B │ + META-INF/services/
 280 B │ -1.2 KiB │ ∆ plugin.yml
───────┼──────────┼─────────────────────────────────────────────────────────────────
 280 B │ -1.2 KiB │ (total)
```