### PR TITLE
Adds check for shreddedpaper usage

### DIFF
--- a/common/src/main/java/ac/grim/grimac/GrimAPI.java
+++ b/common/src/main/java/ac/grim/grimac/GrimAPI.java
@@ -63,7 +63,7 @@ public final class GrimAPI {
 
     // the order matters
     private static Platform detectPlatform() {
-        if (ReflectionUtils.hasMethod("org.bukkit.Bukkit", "getRegionScheduler")) return Platform.FOLIA;
+        if (ReflectionUtils.hasServerBrand("ShreddedPaper")) return Platform.FOLIA;
         if (ReflectionUtils.hasClass("io.papermc.paper.threadedregions.RegionizedServer")) return Platform.FOLIA;
         if (ReflectionUtils.hasClass("org.bukkit.Bukkit")) return Platform.BUKKIT;
         if (ReflectionUtils.hasClass("net.fabricmc.loader.api.FabricLoader")) return Platform.FABRIC;

--- a/common/src/main/java/ac/grim/grimac/GrimAPI.java
+++ b/common/src/main/java/ac/grim/grimac/GrimAPI.java
@@ -63,6 +63,7 @@ public final class GrimAPI {
 
     // the order matters
     private static Platform detectPlatform() {
+        if (ReflectionUtils.hasMethod("org.bukkit.Bukkit", "getRegionScheduler")) return Platform.FOLIA;
         if (ReflectionUtils.hasClass("io.papermc.paper.threadedregions.RegionizedServer")) return Platform.FOLIA;
         if (ReflectionUtils.hasClass("org.bukkit.Bukkit")) return Platform.BUKKIT;
         if (ReflectionUtils.hasClass("net.fabricmc.loader.api.FabricLoader")) return Platform.FABRIC;

--- a/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
@@ -17,13 +17,17 @@ public class ReflectionUtils {
         return getMethod(clazz, methodName, parameterTypes) != null;
     }
 
-    public static boolean hasMethod(@NotNull String className, @NotNull String methodName, Class<?>... parameterTypes) {
-        Class<?> clazz = getClass(className);
-        return clazz != null && hasMethod(clazz, methodName, parameterTypes);
-    }
-
-    public static boolean hasMethod(@NotNull String className, @NotNull String methodName) {
-        return hasMethod(className, methodName, new Class<?>[0]);
+    public static boolean hasServerBrand(@NotNull String expected) {
+        try {
+            Class<?> bukkit = getClass("org.bukkit.Bukkit");
+            if (bukkit == null) return false;
+            Method m = getMethod(bukkit, "getName");
+            if (m == null) return false;
+            Object v = m.invoke(null);
+            return expected.equalsIgnoreCase(String.valueOf(v));
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     public static @Nullable Method getMethod(@NotNull Class<?> clazz, @NotNull String methodName, Class<?>... parameterTypes) {

--- a/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
@@ -17,6 +17,15 @@ public class ReflectionUtils {
         return getMethod(clazz, methodName, parameterTypes) != null;
     }
 
+    public static boolean hasMethod(@NotNull String className, @NotNull String methodName, Class<?>... parameterTypes) {
+        Class<?> clazz = getClass(className);
+        return clazz != null && hasMethod(clazz, methodName, parameterTypes);
+    }
+
+    public static boolean hasMethod(@NotNull String className, @NotNull String methodName) {
+        return hasMethod(className, methodName, new Class<?>[0]);
+    }
+
     public static @Nullable Method getMethod(@NotNull Class<?> clazz, @NotNull String methodName, Class<?>... parameterTypes) {
         try {
             return clazz.getMethod(methodName, parameterTypes);


### PR DESCRIPTION
Add a reflection check for `org.bukkit.Bukkit#getRegionScheduler()` to detect regionized environments (e.g., ShreddedPaper). This follows ShreddedPaper’s recommendation and improves compatibility with Folia-like multi-threaded servers.

[Shreddedpaper](https://github.com/MultiPaper/ShreddedPaper) - supports Folia but defines detection slightly differently.

**From the shreddedpaper page:**

If your plugin already has support for Folia it is highly likely that it will already work with ShreddedPaper without any changes.
If you have a Folia check similar to the following:

```
try {
    Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
    return true;
} catch (ClassNotFoundException e) {
    return false;
}
```
You should remove it and instead check of the existence of Paper's region api:

```
try {
    Bukkit.class.getMethod("getRegionScheduler");
    return true;
} catch (NoSuchMethodException e) {
    return false;
}
```