### PR TITLE
Optimize away entity collision check in 1.8

### DIFF
--- a/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -47,6 +47,7 @@ public class MovementTicker {
                 // Check that ViaVersion disables all collisions on a 1.8 server for 1.9+ clients
                 || (!serverSupported
                 && (!ViaVersionUtil.isAvailable || Via.getConfig().isPreventCollision())));
+        if (!hasEntityPushing) return;
 
         int possibleCollidingEntities = 0;
         int possibleRiptideEntities = 0;
@@ -67,8 +68,7 @@ public class MovementTicker {
 
                 possibleRiptideEntities++;
 
-                if (!hasEntityPushing || !entity.isPushable())
-                    continue;
+                if (!entity.isPushable()) continue;
 
                 // Filters out entities that can't be pushed/collided because of team collision rules
                 // Also handles 1.9+ player on 1.8- server with ViaVersion prevent-collision disabled.


### PR DESCRIPTION
A decent bit of entity movement processing is spent calculating entity hitboxes, even when for a server that is running 1.8 and with via entiy collisions disabled. The only other thing this code does is possible riptide, but if entity pushing isn't possible (either 1.8 client, or 1.8 server+disabled via collision) neither is riptide.

<img width="1557" height="369" alt="image" src="https://github.com/user-attachments/assets/93c9a0c1-fb44-4dbb-9b8f-aaab040ce3de" />
