### PR TITLE
Fix FastBreak falses while riding entity

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -99,6 +99,10 @@ public class CompensatedEntities {
         return getEntityInControl().getPotionEffectLevel(type);
     }
 
+    public OptionalInt getPotionLevelForSelfPlayer(PotionType type) {
+        return self.getPotionEffectLevel(type);
+    }
+
     public boolean hasPotionEffect(PotionType type) {
         return getEntityInControl().hasPotionEffect(type);
     }

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -220,15 +220,15 @@ public class BlockBreakSpeed {
             }
         }
 
-        OptionalInt digSpeed = player.compensatedEntities.getPotionLevelForPlayer(PotionTypes.HASTE);
-        OptionalInt conduit = player.compensatedEntities.getPotionLevelForPlayer(PotionTypes.CONDUIT_POWER);
+        OptionalInt digSpeed = player.compensatedEntities.getPotionLevelForSelfPlayer(PotionTypes.HASTE);
+        OptionalInt conduit = player.compensatedEntities.getPotionLevelForSelfPlayer(PotionTypes.CONDUIT_POWER);
 
         if (digSpeed.isPresent() || conduit.isPresent()) {
             int hasteLevel = Math.max(digSpeed.isEmpty() ? 0 : digSpeed.getAsInt(), conduit.isEmpty() ? 0 : conduit.getAsInt());
             speedMultiplier *= (float) (1 + (0.2 * (hasteLevel + 1)));
         }
 
-        OptionalInt miningFatigue = player.compensatedEntities.getPotionLevelForPlayer(PotionTypes.MINING_FATIGUE);
+        OptionalInt miningFatigue = player.compensatedEntities.getPotionLevelForSelfPlayer(PotionTypes.MINING_FATIGUE);
 
         if (miningFatigue.isPresent()) {
             switch (miningFatigue.getAsInt()) {


### PR DESCRIPTION
Fix FastBreak falses while riding entity. Why hasn't anyone done this before?