### PR TITLE
fix: prevent crash when accessing invalid slot index (Fixes #2295)

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/inventory/inventory/AbstractContainerMenu.java
+++ b/common/src/main/java/ac/grim/grimac/utils/inventory/inventory/AbstractContainerMenu.java
@@ -421,13 +421,27 @@ public abstract class AbstractContainerMenu {
         return this.slots.get(slotID).getItem();
     }
 
+    /**
+     * Safely gets a slot from the container.
+     * Prevents IndexOutOfBounds crashes by logging and returning null instead of throwing.
+     */
     public Slot getSlot(int slotID) {
-        try {
-            return this.slots.get(slotID);
-        } catch (IndexOutOfBoundsException e) {
-            LogUtil.error("Tried to get slot " + slotID + " in a container with only " + this.slots.size() + " slots, container type: " + this.getClass().getName(), e);
-            throw e;
+        if (slotID < 0 || slotID >= this.slots.size()) {
+            boolean verbose = GrimAPI.INSTANCE.getConfigManager().getBoolean("verbose.print-to-console");
+
+            if (verbose) {
+                LogUtil.warn("Attempted to access invalid slot ID " + slotID +
+                        " in " + this.getClass().getSimpleName() +
+                        " (size=" + this.slots.size() + ")");
+                Thread.dumpStack(); // optional for debug visibility
+            } else {
+                LogUtil.debug("Suppressed invalid slot access in " + this.getClass().getSimpleName());
+            }
+
+            return null;
         }
+
+        return this.slots.get(slotID);
     }
 
     public boolean canDragTo(Slot slot) {

--- a/common/src/main/java/ac/grim/grimac/utils/inventory/inventory/AbstractContainerMenu.java
+++ b/common/src/main/java/ac/grim/grimac/utils/inventory/inventory/AbstractContainerMenu.java
@@ -36,6 +36,34 @@ public abstract class AbstractContainerMenu {
     @NotNull
     private ItemStack carriedItem = ItemStack.EMPTY;
 
+    // Dummy slot placeholder for safe fallback
+    private static final Slot DUMMY_SLOT = new Slot(null, -1) {
+        @Override
+        public boolean hasItem() {
+            return false;
+        }
+
+        @Override
+        public ItemStack getItem() {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public void set(ItemStack stack) {
+            // No-op
+        }
+
+        @Override
+        public boolean mayPickup() {
+            return false;
+        }
+
+        @Override
+        public boolean mayPlace(ItemStack stack) {
+            return false;
+        }
+    };
+
     public AbstractContainerMenu(GrimPlayer player, Inventory playerInventory) {
         this.player = player;
         this.playerInventory = playerInventory;
@@ -423,7 +451,7 @@ public abstract class AbstractContainerMenu {
 
     /**
      * Safely gets a slot from the container.
-     * Prevents IndexOutOfBounds crashes by logging and returning null instead of throwing.
+     * Prevents IndexOutOfBounds crashes by logging and returning a dummy slot instead of throwing.
      */
     public Slot getSlot(int slotID) {
         if (slotID < 0 || slotID >= this.slots.size()) {
@@ -438,7 +466,8 @@ public abstract class AbstractContainerMenu {
                 LogUtil.debug("Suppressed invalid slot access in " + this.getClass().getSimpleName());
             }
 
-            return null;
+            // Return dummy slot to prevent null-related crashes
+            return DUMMY_SLOT;
         }
 
         return this.slots.get(slotID);


### PR DESCRIPTION
This change adds bounds checking to AbstractContainerMenu#getSlot to prevent IndexOutOfBoundsException crashes when the slot index exceeds the container size. If an invalid index is requested, an error is logged (useful for debugging) instead of causing a fatal crash.

Made to fix issue 2295, caused with the typewriter plugin, 