### PR TITLE
fix: useless player fetch

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/velocity/KnockbackHandler.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/velocity/KnockbackHandler.java
@@ -46,9 +46,6 @@ public class KnockbackHandler extends Check implements PostPredictionCheck {
             WrapperPlayServerEntityVelocity velocity = new WrapperPlayServerEntityVelocity(event);
             int entityId = velocity.getEntityId();
 
-            GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
-            if (player == null) return;
-
             // Detect whether this knockback packet affects the player or if it is useless
             // Mojang sends extra useless knockback packets for no apparent reason
             if (player.compensatedEntities.serverPlayerVehicle != null && entityId != player.compensatedEntities.serverPlayerVehicle) {


### PR DESCRIPTION
I think its kind off useless to fetch the player again when we have it defined inside of the check when it might take a tiny bit of performance in a high player count (i know its not that big of a deal but 0.00001ms is always something, no?)