### PR TITLE
Updated version for rotation desync fix

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -99,7 +99,9 @@ public class RotationPlace extends BlockPlaceCheck {
         // End checking if the player is in the block
 
         // 1.9+ players could be a tick behind because we don't get skipped ticks
-        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) {
+        // Fixes the one-tick rotation desync present only in 1.9–1.16, as in 1.17+ Mojang already fixed yaw/pitch synchronization themselves
+        if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)
+                && player.getClientVersion().isOlderThan(ClientVersion.V_1_17)) {
             possibleLookDirs.add(new Vector3f(player.lastYaw, player.lastPitch, 0));
         }
 


### PR DESCRIPTION
Changed it so that the fix does not apply to people from all versions above 1.9, but only from players using versions 1.9 - 1.16, as mojang fixed the problem of yaw/pitch synchronization themselves in version 1.17+