### PR TITLE
Fix spectate command resetting gamemode when spectating someone in another dimension

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -210,7 +210,9 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 }
                 player.pose = Pose.STANDING;
                 player.clientVelocity = new Vector3dm();
-                player.gamemode = respawn.getGameMode();
+                if (!isWorldChange(player, respawn)) {
+                    player.gamemode = respawn.getGameMode();
+                }    
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_17)) {
                     player.compensatedWorld.setDimension(respawn.getDimensionType(), event.getUser());
                 }

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -210,9 +210,9 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 }
                 player.pose = Pose.STANDING;
                 player.clientVelocity = new Vector3dm();
-                if (!isWorldChange(player, respawn)) {
+                if (!GrimAPI.INSTANCE.getSpectateManager().isSpectating(player.uuid)) {
                     player.gamemode = respawn.getGameMode();
-                }    
+                }  
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_17)) {
                     player.compensatedWorld.setDimension(respawn.getDimensionType(), event.getUser());
                 }


### PR DESCRIPTION
This issue happened when using the spectate command on a player in another dimension. the spectator was set to survival mode. Now checks that the player is not spectating before changing gamemode.