### PR TITLE
fix: fabric world level method not found

### DIFF
--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/entity/AbstractFabricGrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/entity/AbstractFabricGrimEntity.java
@@ -38,7 +38,7 @@ public abstract class AbstractFabricGrimEntity implements GrimEntity {
 
     @Override
     public PlatformWorld getWorld() {
-        return (PlatformWorld) entity.level;
+        return this.entity.level;
     }
 
     @Override

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mixins/LevelMixin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mixins/LevelMixin.java
@@ -4,20 +4,22 @@ import ac.grim.grimac.platform.api.world.PlatformChunk;
 import ac.grim.grimac.platform.api.world.PlatformWorld;
 import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
 
 import java.util.UUID;
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.storage.ServerLevelData;
 
-@Mixin(ServerLevel.class)
+@Mixin(Level.class)
 @Implements(@Interface(iface = PlatformWorld.class, prefix = "grimac$"))
-abstract class ServerLevelMixin implements LevelAccessor {
-    @Shadow public @Final ServerLevelData serverLevelData;
+abstract class LevelMixin implements LevelAccessor {
+
+    @Shadow
+    public abstract ResourceKey<Level> dimension();
 
     public boolean grimac$isChunkLoaded(int chunkX, int chunkZ) {
         return hasChunk(chunkX, chunkZ);
@@ -30,7 +32,7 @@ abstract class ServerLevelMixin implements LevelAccessor {
     }
 
     public String grimac$getName() {
-        return serverLevelData.getLevelName();
+        return this.dimension().location().toString();
     }
 
     public @Nullable UUID grimac$getUID() {
@@ -42,6 +44,6 @@ abstract class ServerLevelMixin implements LevelAccessor {
     }
 
     public boolean grimac$isLoaded() {
-        return GrimACFabricLoaderPlugin.FABRIC_SERVER.getLevel(getLevel().dimension()) != null;
+        return GrimACFabricLoaderPlugin.FABRIC_SERVER.getLevel(this.dimension()) != null;
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -20,6 +20,13 @@
   "mixins": [
     "grimac.mixins.json"
   ],
+  "custom": {
+    "loom:injected_interfaces": {
+      "net/minecraft/world/level/Level": [
+        "ac/grim/grimac/platform/api/world/PlatformWorld"
+      ]
+    }
+  },
   "accessWidener": "grimac.accesswidener",
   "depends": {
     "fabricloader": "\u003e\u003d0.16",

--- a/fabric/src/main/resources/grimac.mixins.json
+++ b/fabric/src/main/resources/grimac.mixins.json
@@ -5,7 +5,7 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [
         "LevelChunkMixin",
-        "ServerLevelMixin",
+        "LevelMixin",
         "ServerPlayerMixin"
     ],
     "injectors": {


### PR DESCRIPTION
In the current implementation, getLevel() in ServerLevel throws a MethodNotFoundException. I made some improvements and fixed the issue.
Also fixed that the world name is always "world".

Tested on the latest fabric version.