### PR TITLE
feat(common): discord forum channel support

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class DiscordManager implements StartableInitable, ReloadableInitable {
-    private static final Predicate<String> WEBHOOK_REGEX = Pattern.compile("https://discord.com/api/webhooks/\\d+/[\\w-]+").asMatchPredicate();
+    private static final Predicate<String> WEBHOOK_REGEX = Pattern.compile("https://discord.com/api/webhooks/\\d+/[\\w-]+(\\?thread_id=\\d+)?").asMatchPredicate();
     private static final Duration timeout = Duration.ofSeconds(15);
     private static final HttpClient client = HttpClient.newBuilder().connectTimeout(timeout).build();
     private static final ConcurrentLinkedDeque<HttpRequest> requests = new ConcurrentLinkedDeque<>();


### PR DESCRIPTION
Allow forum channels, so we can have a single discord channel with groups.

Just add your forum thread id to your webhook:
https://discord.com/api/webhooks/****/****?thread_id= ``<THREAD_ID>``

<img width="2026" height="1188" alt="Discord_9mnahAnPts" src="https://github.com/user-attachments/assets/b8a63c28-6a2f-4953-94ac-1231e0914e87" />
