### PR TITLE
Optimize LatencyUtils: concurrent, autoboxing

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/collections/FastIteLinkedQueue.java
+++ b/common/src/main/java/ac/grim/grimac/utils/collections/FastIteLinkedQueue.java
@@ -1,0 +1,254 @@
+package ac.grim.grimac.utils.collections;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Queue;
+
+/**
+ * A queue that supports inserting while iterating.
+ * <p>
+ * Iterators reflect the state on creation, newly added elements are skipped.
+ *
+ */
+public class FastIteLinkedQueue<E> implements Queue<E> {
+
+    int size = 0;
+    Node<E> head;
+    Node<E> tail;
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size != 0;
+    }
+
+    @Override
+    public @NotNull Iterator<E> iterator() {
+        return new FastIterator();
+    }
+
+    @Override
+    public boolean add(E e) {
+        return offer(e);
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        for (E e : this) {
+            if (e.equals(o)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public @NotNull Object[] toArray() {
+        Object[] result = new Object[size];
+        int i = 0;
+        for (E e: this) {
+            result[i++] = e;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        Iterator<E> iterator = iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().equals(o)) {
+                iterator.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addAll(@NotNull Collection<? extends E> c) {
+        for (E e : c) {
+            offer(e);
+        }
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        Node<E> node = head;
+        while (node != null) {
+            Node<E> next = node.next;
+            node.item = null;
+            node.next = null;
+            node.prev = null;
+            node = next;
+        }
+        head = tail = null;
+        size = 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Collection<?> c))
+            return false;
+
+        Iterator<E> i1 = this.iterator();
+        Iterator<?> i2 = c.iterator();
+        while (i1.hasNext() && i2.hasNext()) {
+            Object o1 = i1.next();
+            Object o2 = i2.next();
+            if (!(Objects.equals(o1, o2)))
+                return false;
+        }
+        return !(i1.hasNext() || i2.hasNext());
+    }
+
+    @Override
+    public boolean offer(E e) {
+        Node<E> last = tail;
+        Node<E> newNode = new Node<>(e, last, null);
+        tail = newNode;
+        if (last == null) {
+            head = newNode;
+        } else {
+            last.next = newNode;
+        }
+        size++;
+        return true;
+    }
+
+    @Override
+    public E remove() {
+        if (size == 0) throw new NoSuchElementException();
+        return poll();
+    }
+
+    @Override
+    public E poll() {
+        if (head == null)
+            return null;
+        Node<E> node = head;
+        Node<E> next = head.next;
+        size--;
+        head = next;
+        // Unlink
+        node.next = null;
+        if (next == null)
+            tail = null;
+        else
+            next.prev = null;
+        return node.item;
+    }
+
+    @Override
+    public E element() {
+        if (size == 0) throw new NoSuchElementException();
+        return peek();
+    }
+
+    @Override
+    public E peek() {
+        return head != null ? head.item : null;
+    }
+
+    void onRemove(Node<E> node) {
+        final Node<E> next = node.next;
+        final Node<E> prev = node.prev;
+
+        if (prev == null) {
+            head = next;
+        } else {
+            prev.next = next;
+            node.prev = null;
+        }
+
+        if (next == null) {
+            tail = prev;
+        } else {
+            next.prev = prev;
+            node.next = null;
+        }
+
+        node.item = null;
+        size--;
+    }
+
+    static class Node<E> {
+        E item;
+        Node<E> prev;
+        Node<E> next;
+
+        Node(E element, Node<E> prev, Node<E> next) {
+            this.item = element;
+            this.next = next;
+            this.prev = prev;
+        }
+    }
+
+    class FastIterator implements Iterator<E> {
+
+        int remains = size;
+        Node<E> last = null;
+        Node<E> next = head;
+
+        @Override
+        public boolean hasNext() {
+            return remains != 0;
+        }
+
+        @Override
+        public E next() {
+//            if (remains == 0) throw new NoSuchElementException(); // No bounds check
+            Node<E> node = next;
+            next = node.next;
+            remains--;
+            last = node;
+            return node.item;
+        }
+
+        @Override
+        public void remove() {
+            Node<E> node = this.last;
+            Node<E> prev = node.prev;
+            Node<E> next = this.next;
+            if (prev != null) {
+                prev.next = next;
+            }
+            if (next != null) {
+                next.prev = prev;
+            }
+            onRemove(node);
+        }
+
+    }
+
+    @Override
+    public @NotNull <T> T[] toArray(@NotNull T[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(@NotNull Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(@NotNull Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(@NotNull Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -42,12 +42,9 @@ public class LatencyUtils {
         while (iterator.hasNext()) {
             QueuedTask queuedTask = iterator.next();
 
-            // We are at most a tick ahead when running tasks based on transactions, meaning this is too far
-            if (transaction + 1 < queuedTask.transaction)
-                break;
-
-            // This is at most tick ahead of what we want
-            if (transaction == queuedTask.transaction - 1)
+            // Tick ahead of, but we don't break the loop here, cuz ConcurrentLinkedQueue is
+            // weakly consistent, we need to iterate over all to make sure we don't miss anything.
+            if (transaction < queuedTask.transaction)
                 continue;
 
             try {

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -6,11 +6,14 @@ import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import ac.grim.grimac.utils.common.arguments.CommonGrimArguments;
 
+import java.util.ArrayDeque;
 import java.util.Iterator;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LatencyUtils {
-    private final ConcurrentLinkedQueue<QueuedTask> transactionMap = new ConcurrentLinkedQueue<>();
+    private final Queue<QueuedTask> transactions = new ArrayDeque<>();
+    private final Queue<QueuedTask> transactionsAsync = new ConcurrentLinkedQueue<>();
     private final GrimPlayer player;
 
     public LatencyUtils(GrimPlayer player) {
@@ -34,21 +37,36 @@ public class LatencyUtils {
             }
             return;
         }
-        transactionMap.add(new QueuedTask(transaction, runnable));
+        queueTask(transaction, runnable, async);
+    }
+
+    private void queueTask(int transaction, Runnable runnable, boolean async) {
+        Queue<QueuedTask> queue = async ? transactionsAsync : transactions;
+        queue.add(new QueuedTask(transaction, runnable));
     }
 
     public void handleNettySyncTransaction(int transaction) {
-        Iterator<QueuedTask> iterator = transactionMap.iterator();
-        while (iterator.hasNext()) {
-            QueuedTask queuedTask = iterator.next();
+        handleQueue(transaction, true, transactions);
+        // ConcurrentLinkedQueue is weakly consistent, we need to iterate over all elements
+        // to make sure we don't miss anything.
+        handleQueue(transaction, false, transactionsAsync);
+    }
 
-            // Tick ahead of, but we don't break the loop here, cuz ConcurrentLinkedQueue is
-            // weakly consistent, we need to iterate over all to make sure we don't miss anything.
-            if (transaction < queuedTask.transaction)
-                continue;
+    private void handleQueue(int transaction, boolean breakOnAhead, Queue<QueuedTask> queue) {
+        Iterator<QueuedTask> iterator = queue.iterator();
+        while (iterator.hasNext()) {
+            QueuedTask task = iterator.next();
+
+            // Tick ahead of
+            if (transaction < task.transaction) {
+                if (breakOnAhead && transaction + 1 < task.transaction)
+                    break;
+                else
+                    continue;
+            }
 
             try {
-                queuedTask.runnable.run();
+                task.runnable.run();
             } catch (Exception e) {
                 LogUtil.error("An error has occurred when running transactions for player: " + player.user.getName(), e);
                 // Kick the player SO PEOPLE ACTUALLY REPORT PROBLEMS AND KNOW WHEN THEY HAPPEN

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -38,7 +38,6 @@ public class LatencyUtils {
     }
 
     public void handleNettySyncTransaction(int transaction) {
-        // First pass: collect tasks and mark them for removal
         Iterator<QueuedTask> iterator = transactionMap.iterator();
         while (iterator.hasNext()) {
             QueuedTask queuedTask = iterator.next();

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -4,15 +4,15 @@ import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
+import ac.grim.grimac.utils.collections.FastIteLinkedQueue;
 import ac.grim.grimac.utils.common.arguments.CommonGrimArguments;
 
-import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LatencyUtils {
-    private final Queue<QueuedTask> transactions = new ArrayDeque<>();
+    private final Queue<QueuedTask> transactions = new FastIteLinkedQueue<>();
     private final Queue<QueuedTask> transactionsAsync = new ConcurrentLinkedQueue<>();
     private final GrimPlayer player;
 

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -7,17 +7,12 @@ import ac.grim.grimac.utils.anticheat.MessageUtil;
 import ac.grim.grimac.utils.common.arguments.CommonGrimArguments;
 import ac.grim.grimac.utils.data.Pair;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.ListIterator;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LatencyUtils {
-    private final LinkedList<Pair<Integer, Runnable>> transactionMap = new LinkedList<>();
+    private final ConcurrentLinkedQueue<Pair<Integer, Runnable>> transactionMap = new ConcurrentLinkedQueue<>();
     private final GrimPlayer player;
-
-    // Built from transactionMap and cleared at start of every handleNettySyncTransaction() call
-    // The actual usage scope of this variable's use is limited to within the synchronized block of handleNettySyncTransaction
-    private final ArrayList<Runnable> tasksToRun = new ArrayList<>();
 
     public LatencyUtils(GrimPlayer player) {
         this.player = player;
@@ -40,62 +35,33 @@ public class LatencyUtils {
             }
             return;
         }
-        synchronized (this) {
-            transactionMap.add(new Pair<>(transaction, runnable));
-        }
+        transactionMap.add(new Pair<>(transaction, runnable));
     }
 
     public void handleNettySyncTransaction(int transaction) {
-        /*
-         * This code uses a two-pass approach within the synchronized block to prevent CMEs.
-         * First we collect and remove tasks using the iterator, then execute all collected tasks.
-         *
-         * The issue:
-         *     We cannot execute tasks during iteration because if a runnable modifies transactionMap
-         *     or calls addRealTimeTask, it will cause a ConcurrentModificationException.
-         *     While only seen on Folia servers, this is theoretically possible everywhere.
-         *
-         * Why this solution:
-         *     Rather than documenting "don't modify transactionMap in runnables" and risking subtle
-         *     bugs from future contributions or Check API usage, we prevent the issue entirely
-         *     at a small performance cost.
-         *
-         * Future considerations:
-         *     If this becomes a performance bottleneck, we may revisit using a single-pass approach
-         *     on non-Folia servers. We could also explore concurrent data structures or parallel
-         *     execution, but this would lose the guarantee that transactions are processed in order.
-         */
-        synchronized (this) {
-            tasksToRun.clear();
+        // First pass: collect tasks and mark them for removal
+        Iterator<Pair<Integer, Runnable>> iterator = transactionMap.iterator();
+        while (iterator.hasNext()) {
+            Pair<Integer, Runnable> pair = iterator.next();
 
-            // First pass: collect tasks and mark them for removal
-            ListIterator<Pair<Integer, Runnable>> iterator = transactionMap.listIterator();
-            while (iterator.hasNext()) {
-                Pair<Integer, Runnable> pair = iterator.next();
+            // We are at most a tick ahead when running tasks based on transactions, meaning this is too far
+            if (transaction + 1 < pair.first())
+                break;
 
-                // We are at most a tick ahead when running tasks based on transactions, meaning this is too far
-                if (transaction + 1 < pair.first())
-                    break;
+            // This is at most tick ahead of what we want
+            if (transaction == pair.first() - 1)
+                continue;
 
-                // This is at most tick ahead of what we want
-                if (transaction == pair.first() - 1)
-                    continue;
-
-                tasksToRun.add(pair.second());
-                iterator.remove();
-            }
-
-            for (Runnable runnable : tasksToRun) {
-                try {
-                    runnable.run();
-                } catch (Exception e) {
-                    LogUtil.error("An error has occurred when running transactions for player: " + player.user.getName(), e);
-                    // Kick the player SO PEOPLE ACTUALLY REPORT PROBLEMS AND KNOW WHEN THEY HAPPEN
-                    if (CommonGrimArguments.KICK_ON_TRANSACTION_ERRORS.value()) {
-                        player.disconnect(MessageUtil.miniMessage(MessageUtil.replacePlaceholders(player, GrimAPI.INSTANCE.getConfigManager().getDisconnectPacketError())));
-                    }
+            try {
+                pair.second().run();
+            } catch (Exception e) {
+                LogUtil.error("An error has occurred when running transactions for player: " + player.user.getName(), e);
+                // Kick the player SO PEOPLE ACTUALLY REPORT PROBLEMS AND KNOW WHEN THEY HAPPEN
+                if (CommonGrimArguments.KICK_ON_TRANSACTION_ERRORS.value()) {
+                    player.disconnect(MessageUtil.miniMessage(MessageUtil.replacePlaceholders(player, GrimAPI.INSTANCE.getConfigManager().getDisconnectPacketError())));
                 }
             }
+            iterator.remove();
         }
     }
 }

--- a/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/LatencyUtils.java
@@ -5,13 +5,12 @@ import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import ac.grim.grimac.utils.common.arguments.CommonGrimArguments;
-import ac.grim.grimac.utils.data.Pair;
 
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LatencyUtils {
-    private final ConcurrentLinkedQueue<Pair<Integer, Runnable>> transactionMap = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<QueuedTask> transactionMap = new ConcurrentLinkedQueue<>();
     private final GrimPlayer player;
 
     public LatencyUtils(GrimPlayer player) {
@@ -35,25 +34,25 @@ public class LatencyUtils {
             }
             return;
         }
-        transactionMap.add(new Pair<>(transaction, runnable));
+        transactionMap.add(new QueuedTask(transaction, runnable));
     }
 
     public void handleNettySyncTransaction(int transaction) {
         // First pass: collect tasks and mark them for removal
-        Iterator<Pair<Integer, Runnable>> iterator = transactionMap.iterator();
+        Iterator<QueuedTask> iterator = transactionMap.iterator();
         while (iterator.hasNext()) {
-            Pair<Integer, Runnable> pair = iterator.next();
+            QueuedTask queuedTask = iterator.next();
 
             // We are at most a tick ahead when running tasks based on transactions, meaning this is too far
-            if (transaction + 1 < pair.first())
+            if (transaction + 1 < queuedTask.transaction)
                 break;
 
             // This is at most tick ahead of what we want
-            if (transaction == pair.first() - 1)
+            if (transaction == queuedTask.transaction - 1)
                 continue;
 
             try {
-                pair.second().run();
+                queuedTask.runnable.run();
             } catch (Exception e) {
                 LogUtil.error("An error has occurred when running transactions for player: " + player.user.getName(), e);
                 // Kick the player SO PEOPLE ACTUALLY REPORT PROBLEMS AND KNOW WHEN THEY HAPPEN
@@ -64,4 +63,7 @@ public class LatencyUtils {
             iterator.remove();
         }
     }
+
+    private record QueuedTask(int transaction, Runnable runnable) {}
+
 }


### PR DESCRIPTION
ConcurrentLinkedQueue is particularly suitable for this scenario. Changes to the queue are atomic, so it's thread-safe.

This change has not actually been tested, but should be much faster than the synchronized blocks, especially when add the tasks.

Additionally, Changed Pair to record class. Using Pair will autoboxing the ints, it's an unnecessary cost.