### PR TITLE
Fix excluded checks can still be enabled

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -72,11 +72,13 @@ public class PunishmentManager implements ConfigReloadable {
                                 excluded.add(check);
                             } else {
                                 checksList.add(check);
-                                check.setEnabled(true);
                             }
                         }
                     }
                     for (AbstractCheck check : excluded) checksList.remove(check);
+                }
+                for (AbstractCheck check : checksList) {
+                    check.setEnabled(true);
                 }
 
                 for (String command : commands) {


### PR DESCRIPTION
This makes it possible:
```yaml
    checks:
      - "Elytra"
      - '!ElytraA'
```