### PR TITLE
Fix NPE when Spigot late-bind option is enabled

### DIFF
--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -13,10 +13,12 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
 import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import sun.misc.Unsafe;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +26,19 @@ import java.util.List;
 // Copied from: https://github.com/ThomasOM/Pledge/blob/master/src/main/java/dev/thomazz/pledge/inject/ServerInjector.java
 @SuppressWarnings(value = {"unchecked", "deprecated"})
 public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener {
+
+    // Yes, we need this method because Spigot doesn't have an API to retrieve the configuration like Paper does
+    public static boolean isLateBindEnabled() {
+        File spigotFile = new File("spigot.yml");
+
+        if (!spigotFile.exists()) { // If you are using cb, or a fork that removes the spigot configuration, ignore this
+            return false;
+        }
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(spigotFile);
+
+        return config.getBoolean("settings.late-bind", true);
+    }
 
     @Override
     public void start() {
@@ -41,6 +56,10 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
         // if it fails to inject, try to use paper's event
         if (!injectWithReflection() && !PaperUtils.registerTickEndEvent(this, this::tickAllPlayers)) {
             LogUtil.error("Failed to inject into the end of tick event!");
+
+            if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4) && isLateBindEnabled()) {
+                LogUtil.error("You have the \"late-bind\" option enabled; this option does not work in conjunction with Reach.enable-post-packet=true. Disable it in spigot.yml.");
+            }
         }
     }
 
@@ -62,6 +81,10 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
     }
 
     private boolean injectWithReflection() {
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4) && isLateBindEnabled()) {
+            return false;
+        }
+
         // Inject so we can add the final transaction pre-flush event
         try {
             Object connection = SpigotReflectionUtil.getMinecraftServerConnectionInstance();

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -38,7 +38,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(spigotFile);
 
-        // If you found the spigot configuration but not the option (custom fork?), return false
+        // If the Spigot configuration is found, but not the option (custom fork?), return false
         return config.getBoolean("settings.late-bind", false);
     }
 

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -56,7 +56,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4)) {
                 Boolean lateBind = getLateBindState();
                 if (lateBind == null) {
-                    LogUtil.error("Failed to determine the late-bind state. Perhaps you are using CraftBukkit or a custom server fork? Check the fork configuration for a late-bind option.");
+                    LogUtil.error("Failed to determine the late-bind state. Perhaps you are using a custom server fork? Check the fork configuration for a late-bind option.");
                 } else if (lateBind) {
                     LogUtil.error("Injection failed because the late-bind option is enabled. Disable it in spigot.yml.");
                 }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -27,17 +27,19 @@ import java.util.List;
 @SuppressWarnings(value = {"unchecked", "deprecated"})
 public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener {
 
-    // Yes, we need this method because Spigot doesn't have an API to retrieve the configuration like Paper does
+    // We need this method because Spigot doesn't have an API to retrieve the configuration
     public static boolean isLateBindEnabled() {
         File spigotFile = new File("spigot.yml");
 
-        if (!spigotFile.exists()) { // If you are using cb, or a fork that removes the spigot configuration, ignore this
+        // If the server is using cb or a fork that removes the Spigot configuration, ignore this
+        if (!spigotFile.exists()) {
             return false;
         }
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(spigotFile);
 
-        return config.getBoolean("settings.late-bind", true);
+        // If you found the spigot configuration but not the option (custom fork?), return false
+        return config.getBoolean("settings.late-bind", false);
     }
 
     @Override

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -27,19 +27,25 @@ import java.util.List;
 @SuppressWarnings(value = {"unchecked", "deprecated"})
 public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener {
 
-    // We need this method because Spigot doesn't have an API to retrieve the configuration
-    public static boolean isLateBindEnabled() {
-        File spigotFile = new File("spigot.yml");
-
-        // If the server is using cb or a fork that removes the Spigot configuration, ignore this
-        if (!spigotFile.exists()) {
-            return false;
+    private Boolean getLateBindFromAPI() {
+        try {
+            Class<?> spigotConfig = Class.forName("org.spigotmc.SpigotConfig");
+            Field field = spigotConfig.getDeclaredField("lateBind");
+            field.setAccessible(true);
+            return field.getBoolean(null);
+        } catch (Throwable ignored) {
+            return null;
         }
+    }
 
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(spigotFile);
+    private Boolean getLateBindFromConfig() {
+        File file = new File("spigot.yml");
+        if (!file.exists()) return null;
 
-        // If the Spigot configuration is found, but not the option (custom fork?), return false
-        return config.getBoolean("settings.late-bind", false);
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        if (!config.contains("settings.late-bind")) return null;
+
+        return config.getBoolean("settings.late-bind");
     }
 
     @Override
@@ -59,8 +65,27 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
         if (!PaperUtils.registerTickEndEvent(this, this::tickAllPlayers) && !injectWithReflection()) {
             LogUtil.error("Failed to inject into the end of tick event!");
 
-            if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4) && isLateBindEnabled()) {
-                LogUtil.error("You have the \"late-bind\" option enabled; this option does not work in conjunction with Reach.enable-post-packet=true. Disable it in spigot.yml.");
+            if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4)) {
+                Boolean lateBindFromAPI = getLateBindFromAPI();
+                Boolean lateBindFromConfig = getLateBindFromConfig();
+
+                if (lateBindFromAPI == null && lateBindFromConfig == null) {
+                    LogUtil.warn("Injection failed, but late-bind state could not be determined from API or configuration. Perhaps you are using CraftBukkit or a custom fork?");
+                } else if (lateBindFromAPI != null && lateBindFromConfig != null) {
+                    if (!lateBindFromAPI.equals(lateBindFromConfig)) {
+                        LogUtil.warn("Injection failed and late-bind values do not match. Detected API=" + lateBindFromAPI + ", spigot.yml=" + lateBindFromConfig + ".");
+                        return;
+                    }
+
+                    if (lateBindFromAPI) {
+                        LogUtil.warn("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
+                    }
+                } else {
+                    Boolean detectedLateBind = lateBindFromAPI != null ? lateBindFromAPI : lateBindFromConfig;
+                    if (detectedLateBind) {
+                        LogUtil.warn("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
+                    }
+                }
             }
         }
     }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -13,12 +13,10 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
 import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import sun.misc.Unsafe;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +25,7 @@ import java.util.List;
 @SuppressWarnings(value = {"unchecked", "deprecated"})
 public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener {
 
-    private Boolean getLateBindFromAPI() {
+    private Boolean getLateBindState() {
         try {
             Class<?> spigotConfig = Class.forName("org.spigotmc.SpigotConfig");
             Field field = spigotConfig.getDeclaredField("lateBind");
@@ -36,16 +34,6 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
         } catch (Throwable ignored) {
             return null;
         }
-    }
-
-    private Boolean getLateBindFromConfig() {
-        File file = new File("spigot.yml");
-        if (!file.exists()) return null;
-
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
-        if (!config.contains("settings.late-bind")) return null;
-
-        return config.getBoolean("settings.late-bind");
     }
 
     @Override
@@ -66,25 +54,14 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             LogUtil.error("Failed to inject into the end of tick event!");
 
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4)) {
-                Boolean lateBindFromAPI = getLateBindFromAPI();
-                Boolean lateBindFromConfig = getLateBindFromConfig();
+                Boolean lateBind = getLateBindState();
+                if (lateBind == null) {
+                    LogUtil.error("Failed to determine the late-bind state. Perhaps you are using CraftBukkit or a custom server fork? Check the fork configuration for a late-bind option.");
+                    return;
+                }
 
-                if (lateBindFromAPI == null && lateBindFromConfig == null) {
-                    LogUtil.error("Injection failed, but late-bind state could not be determined from API or configuration. Perhaps you are using CraftBukkit or a custom fork?");
-                } else if (lateBindFromAPI != null && lateBindFromConfig != null) {
-                    if (!lateBindFromAPI.equals(lateBindFromConfig)) {
-                        LogUtil.error("Injection failed and late-bind values do not match. Detected API=" + lateBindFromAPI + ", spigot.yml=" + lateBindFromConfig + ".");
-                        return;
-                    }
-
-                    if (lateBindFromAPI) {
-                        LogUtil.error("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
-                    }
-                } else {
-                    Boolean detectedLateBind = lateBindFromAPI != null ? lateBindFromAPI : lateBindFromConfig;
-                    if (detectedLateBind) {
-                        LogUtil.error("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
-                    }
+                if (lateBind) {
+                    LogUtil.error("Injection failed because the late-bind option is enabled. Disable it in spigot.yml.");
                 }
             }
         }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -57,10 +57,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
                 Boolean lateBind = getLateBindState();
                 if (lateBind == null) {
                     LogUtil.error("Failed to determine the late-bind state. Perhaps you are using CraftBukkit or a custom server fork? Check the fork configuration for a late-bind option.");
-                    return;
-                }
-
-                if (lateBind) {
+                } else if (lateBind) {
                     LogUtil.error("Injection failed because the late-bind option is enabled. Disable it in spigot.yml.");
                 }
             }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -60,7 +60,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4)) {
                 Boolean lateBind = getLateBindState();
                 if (lateBind == null) {
-                    LogUtil.error("Failed to determine the late-bind state. Perhaps you are using a custom server fork? Check the fork configuration for a late-bind option.");
+                    LogUtil.error("Failed to determine the late-bind state. Perhaps you are using a custom server fork? Check the fork configuration for a late-bind option and disable it.");
                 } else if (lateBind) {
                     LogUtil.error("Injection failed because the late-bind option is enabled. Disable it in spigot.yml.");
                 }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -55,8 +55,8 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             PaperUtils.registerTickEndEvent(this, this::tickAllFoliaPlayers);
             return;
         }
-        // if it fails to inject, try to use paper's event
-        if (!injectWithReflection() && !PaperUtils.registerTickEndEvent(this, this::tickAllPlayers)) {
+        // if it fails to register Paper event, try to inject via reflection
+        if (!PaperUtils.registerTickEndEvent(this, this::tickAllPlayers) && !injectWithReflection()) {
             LogUtil.error("Failed to inject into the end of tick event!");
 
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4) && isLateBindEnabled()) {
@@ -83,13 +83,10 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
     }
 
     private boolean injectWithReflection() {
-        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4) && isLateBindEnabled()) {
-            return false;
-        }
-
         // Inject so we can add the final transaction pre-flush event
         try {
             Object connection = SpigotReflectionUtil.getMinecraftServerConnectionInstance();
+            if (connection == null) return false;
 
             Field connectionsList = Reflection.getField(connection.getClass(), List.class, 1);
             List<Object> endOfTickObject = (List<Object>) connectionsList.get(connection);

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -70,20 +70,20 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
                 Boolean lateBindFromConfig = getLateBindFromConfig();
 
                 if (lateBindFromAPI == null && lateBindFromConfig == null) {
-                    LogUtil.warn("Injection failed, but late-bind state could not be determined from API or configuration. Perhaps you are using CraftBukkit or a custom fork?");
+                    LogUtil.error("Injection failed, but late-bind state could not be determined from API or configuration. Perhaps you are using CraftBukkit or a custom fork?");
                 } else if (lateBindFromAPI != null && lateBindFromConfig != null) {
                     if (!lateBindFromAPI.equals(lateBindFromConfig)) {
-                        LogUtil.warn("Injection failed and late-bind values do not match. Detected API=" + lateBindFromAPI + ", spigot.yml=" + lateBindFromConfig + ".");
+                        LogUtil.error("Injection failed and late-bind values do not match. Detected API=" + lateBindFromAPI + ", spigot.yml=" + lateBindFromConfig + ".");
                         return;
                     }
 
                     if (lateBindFromAPI) {
-                        LogUtil.warn("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
+                        LogUtil.error("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
                     }
                 } else {
                     Boolean detectedLateBind = lateBindFromAPI != null ? lateBindFromAPI : lateBindFromConfig;
                     if (detectedLateBind) {
-                        LogUtil.warn("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
+                        LogUtil.error("Injection failed because late-bind is enabled. Disable settings.late-bind in spigot.yml.");
                     }
                 }
             }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -8,6 +8,7 @@ import ac.grim.grimac.platform.bukkit.utils.reflection.PaperUtils;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.lists.HookedListWrapper;
+import ac.grim.grimac.utils.reflection.ReflectionUtils;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
@@ -26,12 +27,15 @@ import java.util.List;
 public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener {
 
     private Boolean getLateBindState() {
+        Class<?> spigotConfig = ReflectionUtils.getClass("org.spigotmc.SpigotConfig");
+        // ReflectionUtils.getField(class, name) handles the loop and setAccessible
+        Field field = ReflectionUtils.getField(spigotConfig, "lateBind");
+
+        if (field == null) return null;
+
         try {
-            Class<?> spigotConfig = Class.forName("org.spigotmc.SpigotConfig");
-            Field field = spigotConfig.getDeclaredField("lateBind");
-            field.setAccessible(true);
-            return field.getBoolean(null);
-        } catch (Throwable ignored) {
+            return (boolean) field.get(null);
+        } catch (Exception ignored) {
             return null;
         }
     }

--- a/common/src/main/java/ac/grim/grimac/manager/init/start/CommandLoader.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/start/CommandLoader.java
@@ -1,0 +1,40 @@
+package ac.grim.grimac.manager.init.start;
+
+import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.command.commands.GrimVersion;
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import org.incendo.cloud.CommandManager;
+
+import java.util.function.Supplier;
+
+public record CommandLoader(Supplier<CommandManager<Sender>> commandManagerSupplier) implements StartableInitable {
+
+    // Static helper for platforms calling this manually (Fabric EntryPoint)
+    public static void load(CommandManager<Sender> manager) {
+        try {
+            // This method call triggers the JVM to verify CommandRegister.
+            // If Cloud is missing, the NoClassDefFoundError happens HERE.
+            CommandRegister.registerCommands(manager);
+        } catch (NoClassDefFoundError e) {
+            LogUtil.error("Cloud Command Framework is missing! Grim commands are disabled.", e);
+        } catch (Throwable t) {
+            LogUtil.error("Failed to register commands.", t);
+        }
+    }
+
+    @Override
+    public void start() {
+        CommandManager<Sender> commandManager = commandManagerSupplier.get();
+
+        // If the manager failed to create (Bukkit), don't try to register
+        if (commandManager == null) return;
+
+        load(commandManager);
+
+        // Move the update check here so it runs safely
+        if (GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("check-for-updates", true)) {
+            GrimVersion.checkForUpdatesAsync(GrimAPI.INSTANCE.getPlatformServer().getConsoleSender());
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
+++ b/common/src/main/java/ac/grim/grimac/utils/reflection/ReflectionUtils.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 @UtilityClass
@@ -39,5 +40,21 @@ public class ReflectionUtils {
         } catch (ClassNotFoundException e) {
             return null;
         }
+    }
+
+    /**
+     * Finds a field by name, searching up the superclass hierarchy.
+     */
+    public static Field getField(Class<?> clazz, String fieldName) {
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
In servers prior to version 1.14.4, there's an option called `late-bind` that delays the creation of the server connection instance until after the plugins are loaded, causing a NPE if the Grim option "Reach.enable-post-packet" is active.

```java
[18:42:38] [Server thread/ERROR]: [GrimAC] Failed to start BukkitTickEndEvent: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "connection" is null
	at ac.grim.grimac.platform.bukkit.initables.BukkitTickEndEvent.injectWithReflection(BukkitTickEndEvent.java:85)
	at ac.grim.grimac.platform.bukkit.initables.BukkitTickEndEvent.start(BukkitTickEndEvent.java:43)
	at ac.grim.grimac.manager.InitManager.start(InitManager.java:86)
	at ac.grim.grimac.GrimAPI.start(GrimAPI.java:88)
	at ac.grim.grimac.platform.bukkit.GrimACBukkitLoaderPlugin.onEnable(GrimACBukkitLoaderPlugin.java:100)
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:321)
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:332)
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:454)
	at org.bukkit.craftbukkit.v1_8_R3.CraftServer.loadPlugin(CraftServer.java:393)
	at org.bukkit.craftbukkit.v1_8_R3.CraftServer.enablePlugins(CraftServer.java:352)
	at net.minecraft.server.v1_8_R3.MinecraftServer.s(MinecraftServer.java:410)
	at net.minecraft.server.v1_8_R3.MinecraftServer.k(MinecraftServer.java:374)
	at net.minecraft.server.v1_8_R3.MinecraftServer.a(MinecraftServer.java:329)
	at net.minecraft.server.v1_8_R3.DedicatedServer.init(DedicatedServer.java:301)
	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:580)
	at java.base/java.lang.Thread.run(Thread.java:840)
```