### PR TITLE
Fix gliders not working in offhand slot

### DIFF
--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -768,7 +768,8 @@ public class GrimPlayer implements GrimUser {
         return isGlider(inventory.getHelmet(), EquipmentSlot.CHEST_PLATE)
                 || isGlider(inventory.getChestplate(), EquipmentSlot.LEGGINGS)
                 || isGlider(inventory.getLeggings(), EquipmentSlot.BOOTS)
-                || isGlider(inventory.getBoots(), EquipmentSlot.OFF_HAND);
+                || isGlider(inventory.getBoots(), EquipmentSlot.OFF_HAND)
+                || isGlider(inventory.getOffHand(), EquipmentSlot.HELMET);
     }
 
     private static boolean isGlider(ItemStack stack, EquipmentSlot slot) {


### PR DESCRIPTION
PacketEvents is detecting glider items in the offhand slot as having equipment slot HELMET...
