### PR TITLE
ci: make runner configurable to work around Tenki issues

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
     build:
-        runs-on: tenki-standard-autoscale
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,6 +3,11 @@ name: Reusable Build and Publish
 on:
     workflow_call:
         inputs:
+            runner:
+                description: 'The runner to use for the build job.'
+                required: false
+                type: string
+                default: 'ubuntu-latest'
             is-release-build:
                 description: 'True if this is a release build, which affects versioning and publishing.'
                 required: true
@@ -36,7 +41,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
     build:
-        runs-on: ${{ inputs.runner }
+        runs-on: ${{ inputs.runner }}
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -12,6 +12,11 @@ on:
                 description: 'Upload to Modrinth & API? (Uncheck for a dry run)'
                 type: boolean
                 default: true
+            runner:
+                description: 'The runner to use for the build job.'
+                required: false
+                type: string
+                default: 'ubuntu-latest'
     push:
         branches:
             - 'main'
@@ -31,6 +36,7 @@ jobs:
     call-build-workflow:
         uses: ./.github/workflows/build-and-publish.yml
         with:
+            runner: ${{ github.event.inputs.runner }}
             is-release-build: false
             release-version-type: alpha # Dev builds are always 'alpha'
             run-build-scan: ${{ github.event.inputs.run-build-scan == 'true' }}


### PR DESCRIPTION
Tenki's self-hosted runners started failing on Dec 19, 2025 with
"Invalid URL" errors during artifact upload. This adds a configurable
runner input to all workflows, allowing easy switching between
GitHub-hosted and Tenki runners.

- Add `runner` input to reusable build workflow (default: ubuntu-latest)
- Expose runner option in gradle-publish.yml for manual runs  
- Explicitly set runner in release.yml
- Bump upload-artifact v4 → v6