### PR TITLE
Fix Discord Webhook PAPI Placeholders + Update default Discord config and translations.

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/DiscordManager.java
@@ -109,13 +109,13 @@ public class DiscordManager implements StartableInitable, ReloadableInitable {
     @Contract(value = " -> new", pure = true)
     private @NotNull @Unmodifiable List<@NotNull String> getDefaultContents() {
         return List.of(
-                "**Player**: %player%",
-                "**Check**: %check%",
-                "**Violations**: %violations%",
-                "**Client Version**: %version%",
-                "**Brand**: %brand%",
-                "**Ping**: %ping%",
-                "**TPS**: %tps%"
+                "**Player**: `%player%`", // User input (Unsafe chars) -> Code Block
+                "**Brand**: `%brand%`", // Client input (Unsafe chars) -> Code Block
+                "**Check**: %check%", // Internal String -> Plain text
+                "**Violations**: %violations%", // Integer -> Plain text
+                "**Client Version**: %version%", // Standard String (1.8) -> Plain text
+                "**Ping**: %ping%", // Integer -> Plain text
+                "**TPS**: %tps%" // Double -> Plain text
         );
     }
 

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
@@ -54,33 +54,69 @@ public class MessageUtil {
         return replacePlaceholders(player == null ? null : GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(player.getUniqueId()), player, string, false);
     }
 
+    // NOTE: This pattern intentionally matches standard placeholders (Alphanumeric + Underscore).
+    // Complex PAPI placeholders containing symbols like '<' or '>' (e.g., %img_<id>%) will NOT match.
+    // This is acceptable: complex placeholders are skipped by this loop and handled raw by PAPI later.
     private static final Pattern UNIFIED_PLACEHOLDER_PATTERN = Pattern.compile("%([a-zA-Z0-9_]+)%");
 
+    /**
+     * Replaces placeholders using a hybrid performance strategy: Grim-internal lookups first, then PAPI.
+     * <p>
+     * <b>Strategy:</b>
+     * <ol>
+     *     <li><b>Fast Path:</b> Immediate return if no {@code %} is present.</li>
+     *     <li><b>Grim Lookup:</b> Checks internal maps (O(1)). If found, the value is calculated and (optionally) filtered.</li>
+     *     <li><b>PAPI Fallback:</b> If the placeholder is unknown to Grim, it is left <b>raw</b> (e.g., {@code %player_name%}).
+     *     This allows the external PAPI hook to process it after this method returns.</li>
+     * </ol>
+     *
+     * <b>Discord Formatting (when removeFormatting is true):</b>
+     * <ul>
+     *     <li><b>Standard:</b> Values are fully escaped (e.g., {@code _User_} -> {@code \_User\_}) to prevent accidental formatting.</li>
+     *     <li><b>Code Blocks:</b> If the placeholder is wrapped in backticks (e.g., {@code `%player%`}),
+     *     only backticks/backslashes are escaped. This preserves the raw data look.</li>
+     *     <li><b>Caveat:</b> PAPI results are <b>NOT</b> filtered. If a PAPI placeholder returns an underscore, it may cause formatting issues.</li>
+     * </ul>
+     *
+     * @param grimPlayer       The Grim user instance (nullable).
+     * @param platformPlayer   The Platform player instance (nullable).
+     * @param string           The raw message string.
+     * @param removeFormatting Whether to escape Markdown characters (used for Discord).
+     * @return The processed string with Grim placeholders filled and PAPI placeholders pending.
+     */
     @Contract("_, _, null, _ -> null; _, _, !null, _ -> !null")
     private @Nullable String replacePlaceholders(@Nullable GrimPlayer grimPlayer, @Nullable PlatformPlayer platformPlayer, @Nullable String string, boolean removeFormatting) {
         if (string == null) return null;
 
-        // OPTIMIZATION 1: THE FAST PATH
+        // --- PHASE 1: FAST PATH ---
+        // JVM Intrinsic: Scanning for a char is significantly faster than initializing a Regex Matcher.
+        // If there is no '%', we can skip all allocation.
         if (string.indexOf('%') == -1) {
             return string;
         }
 
         final Matcher matcher = UNIFIED_PLACEHOLDER_PATTERN.matcher(string);
 
+        // If '%' exists but doesn't form a valid simple placeholder, skip to the PAPI/Legacy handler.
+        // This avoids allocating the StringBuilder below.
         if (!matcher.find()) {
             return GrimAPI.INSTANCE.getMessagePlaceHolderManager().replacePlaceholders(platformPlayer, string);
         }
 
         final Map<String, String> staticReplacements = GrimAPI.INSTANCE.getExternalAPI().getStaticReplacements();
         final Map<String, Function<GrimUser, String>> variableReplacements = GrimAPI.INSTANCE.getExternalAPI().getVariableReplacements();
+
+        // 32 is a heuristic buffer. It roughly covers the expansion cost of one UUID (36 chars) vs one placeholder (6 chars).
         final StringBuilder sb = new StringBuilder(string.length() + 32);
 
-        // OPTIMIZATION 2: UNIFIED SINGLE-PASS LOOP
+        // --- PHASE 2: THE REPLACEMENT LOOP ---
+        // Used do-while because the first `matcher.find()` was already called above.
         do {
             final String keyWithPercent = matcher.group(0);
             String value = staticReplacements.get(keyWithPercent);
 
-            // OPTIMIZATION 3: UNIFIED LOOKUP
+            // Lazy Evaluation: Only check dynamic placeholders if static failed.
+            // Only run the function (e.g. TPS calc) if the placeholder is actually present.
             if (value == null && grimPlayer != null) {
                 final Function<GrimUser, String> func = variableReplacements.get(keyWithPercent);
                 if (func != null) {
@@ -88,15 +124,35 @@ public class MessageUtil {
                 }
             }
 
-            // OPTIMIZATION 4: CONDITIONAL FORMATTING
+            // --- PHASE 3: HANDLING & FORMATTING ---
             if (value != null) {
-                // If we found a Grim replacement, we apply formatting filters (if requested)
+                // CASE A: Grim Placeholder Found
                 if (removeFormatting) {
-                    value = filterDiscordText(value);
+                    // Check if the user wrapped this placeholder in code blocks (e.g. ` %player% `)
+                    boolean insideCodeBlock = false;
+                    if (matcher.start() > 0 && matcher.end() < string.length()) {
+                        char charBefore = string.charAt(matcher.start() - 1);
+                        char charAfter = string.charAt(matcher.end());
+                        if (charBefore == '`' && charAfter == '`') {
+                            insideCodeBlock = true;
+                        }
+                    }
+
+                    if (insideCodeBlock) {
+                        // Context: Inside Code Block (`...`).
+                        // Action: Escape backticks/backslashes to prevent breaking out. Leave underscores/markdown raw.
+                        value = value.replace("\\", "\\\\").replace("`", "\\`");
+                    } else {
+                        // Context: Standard Text.
+                        // Action: Aggressively escape all Markdown characters.
+                        value = filterDiscordText(value);
+                    }
                 }
             } else {
-                // If no replacement found, keep the original placeholder so PAPI can handle it later.
-                // Do NOT filter this, or we might escape characters (like '_') that break PAPI syntax.
+                // CASE B: Unknown Placeholder (Likely PAPI)
+                // Action: Restore the original key (e.g. "%player_name%") so PAPI can process it later.
+                // CRITICAL: Do NOT run filterDiscordText() here. It would escape the '%' or '_' in the key,
+                // breaking PAPI syntax (e.g., "%player\_name%" is invalid PAPI).
                 value = keyWithPercent;
             }
 
@@ -108,6 +164,7 @@ public class MessageUtil {
 
         String grimReplaced = sb.toString();
 
+        // Final Pass: Hand off to platform-specific handler (PAPI)
         return GrimAPI.INSTANCE.getMessagePlaceHolderManager().replacePlaceholders(platformPlayer, grimReplaced).replace(PLACEHOLDER_ESCAPE_CHAR, '%');
     }
 

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/MessageUtil.java
@@ -60,76 +60,52 @@ public class MessageUtil {
     private @Nullable String replacePlaceholders(@Nullable GrimPlayer grimPlayer, @Nullable PlatformPlayer platformPlayer, @Nullable String string, boolean removeFormatting) {
         if (string == null) return null;
 
-        // --- OPTIMIZATION 1: THE FAST PATH ---
-        // If the string contains no '%' characters, it's impossible for it to have placeholders.
-        // indexOf() is a JVM intrinsic and is magnitudes faster than even creating a Matcher.
+        // OPTIMIZATION 1: THE FAST PATH
         if (string.indexOf('%') == -1) {
-            // Since there are no % signs we can skip calling papi or our own replacement code
             return string;
         }
 
         final Matcher matcher = UNIFIED_PLACEHOLDER_PATTERN.matcher(string);
 
-        // If matcher.find() is false, it means '%' existed but not in a valid %...% pattern.
-        // This avoids allocating a StringBuilder unless absolutely necessary.
         if (!matcher.find()) {
             return GrimAPI.INSTANCE.getMessagePlaceHolderManager().replacePlaceholders(platformPlayer, string);
         }
 
-        // Get references to the maps once, outside the loop.
         final Map<String, String> staticReplacements = GrimAPI.INSTANCE.getExternalAPI().getStaticReplacements();
         final Map<String, Function<GrimUser, String>> variableReplacements = GrimAPI.INSTANCE.getExternalAPI().getVariableReplacements();
-        final StringBuilder sb = new StringBuilder(string.length() + 32); // Pre-size with a little extra room
+        final StringBuilder sb = new StringBuilder(string.length() + 32);
 
-        // --- OPTIMIZATION 2: THE UNIFIED SINGLE-PASS LOOP ---
-        // We use a do-while loop because we already performed the first matcher.find().
+        // OPTIMIZATION 2: UNIFIED SINGLE-PASS LOOP
         do {
-            // The full placeholder, e.g., "%tps%" or "%prefix%"
             final String keyWithPercent = matcher.group(0);
-            String value = null;
+            String value = staticReplacements.get(keyWithPercent);
 
-            // --- OPTIMIZATION 3: UNIFIED LOOKUP ---
-            // We check the static map first. This is a single, O(1) hash map lookup.
-            String staticValue = staticReplacements.get(keyWithPercent);
-
-            if (staticValue != null) {
-                value = staticValue;
-            } else if (grimPlayer != null) {
-                // If it's not a static placeholder, check if it's a dynamic one.
-                // This is a second, O(1) hash map lookup.
+            // OPTIMIZATION 3: UNIFIED LOOKUP
+            if (value == null && grimPlayer != null) {
                 final Function<GrimUser, String> func = variableReplacements.get(keyWithPercent);
                 if (func != null) {
-                    // LAZY EVALUATION: We only call the expensive function (like getTPS)
-                    // if we actually found its placeholder in the string.
                     value = func.apply(grimPlayer);
                 }
             }
 
-            // If we found no replacement, `value` will be null.
-            // In that case, we treat the placeholder as literal text by appending the original key.
-            if (value == null) {
+            // OPTIMIZATION 4: CONDITIONAL FORMATTING
+            if (value != null) {
+                // If we found a Grim replacement, we apply formatting filters (if requested)
+                if (removeFormatting) {
+                    value = filterDiscordText(value);
+                }
+            } else {
+                // If no replacement found, keep the original placeholder so PAPI can handle it later.
+                // Do NOT filter this, or we might escape characters (like '_') that break PAPI syntax.
                 value = keyWithPercent;
             }
 
-            // --- OPTIMIZATION 4: CONDITIONAL FORMATTING ---
-            // The check for `removeFormatting` is inside the loop, but it's a simple boolean
-            // check and the cost is negligible compared to the string operations.
-            if (removeFormatting) {
-                // Note: This assumes `filterDiscordText` is reasonably fast.
-                // If it's slow, there are further micro-optimizations, but this is the right place for it.
-                value = filterDiscordText(value);
-            }
-
-            // `appendReplacement` efficiently appends the text between matches and our replacement value.
-            // `Matcher.quoteReplacement` should handle any '$' or '\' in the replacement value.
             matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
 
         } while (matcher.find());
 
-        // Append the final part of the string after the last found placeholder.
         matcher.appendTail(sb);
 
-        // Create the final string from our builder.
         String grimReplaced = sb.toString();
 
         return GrimAPI.INSTANCE.getMessagePlaceHolderManager().replacePlaceholders(platformPlayer, grimReplaced).replace(PLACEHOLDER_ESCAPE_CHAR, '%');

--- a/common/src/main/resources/discord/de.yml
+++ b/common/src/main/resources/discord/de.yml
@@ -1,13 +1,15 @@
+# Hilfe zu Webhooks: https://support.discord.com/hc/de/articles/228383668
 enabled: false
 webhook: ""
 embed-title: "**Grim Warnung**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% und %brand% sind in Backticks (`) eingeschlossen, um Formatierungsprobleme durch Sonderzeichen zu verhindern.
 violation-content:
-    - "**Spieler**: %player%"
+    - "**Spieler**: `%player%`"
+    - "**Marke**: `%brand%`"
     - "**Überprüfung**: %check%"
     - "**Verstöße**: %violations%"
     - "**Client-Version**: %version%"
-    - "**Marke**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/en.yml
+++ b/common/src/main/resources/discord/en.yml
@@ -1,13 +1,15 @@
+# For help with webhooks: https://support.discord.com/hc/en-us/articles/228383668
 enabled: false
 webhook: ""
 embed-title: "**Grim Alert**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% and %brand% are wrapped in backticks (`) to prevent special characters from breaking formatting.
 violation-content:
-    - "**Player**: %player%"
+    - "**Player**: `%player%`"
+    - "**Brand**: `%brand%`"
     - "**Check**: %check%"
     - "**Violations**: %violations%"
     - "**Client Version**: %version%"
-    - "**Brand**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/es.yml
+++ b/common/src/main/resources/discord/es.yml
@@ -1,25 +1,15 @@
-# Configuraciones del webhook de Discord
-# Si tienes dudas en como usarlos, puedes consultar el artículo de soporte de Discord: https://support.discord.com/hc/es/articles/228383668
-
-# ¿Deberíamos usar webhooks?
+# Ayuda con webhooks: https://support.discord.com/hc/es/articles/228383668
 enabled: false
-
-# La URL del webhook.
 webhook: ""
-
-embed-title: "**Grim Alert**"
-
-# El color del embed que se mandara por este webhook.
+embed-title: "**Grim Alerta**"
 embed-color: "#00FFFF"
-
 include-timestamp: true
-
-# El contenido del embed que se mandara por este webhook.
+# %player% y %brand% están envueltos en acentos graves (`) para evitar que caracteres especiales rompan el formato.
 violation-content:
-    - "**Jugador**: %player%"
+    - "**Jugador**: `%player%`"
+    - "**Marca del cliente**: `%brand%`"
     - "**Comprobación**: %check%"
     - "**Violaciones**: %violations%"
-    - "**Version del cliente**: %version%"
-    - "**Marca del cliente**: %brand%"
+    - "**Versión del cliente**: %version%"
     - "**Latencia**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/fr.yml
+++ b/common/src/main/resources/discord/fr.yml
@@ -1,13 +1,15 @@
+# Aide sur les webhooks : https://support.discord.com/hc/fr/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Alerte**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% et %brand% sont entourés d'accents graves (`) pour éviter que les caractères spéciaux ne cassent le formatage.
 violation-content:
-    - "**Joueur**: %player%"
+    - "**Joueur**: `%player%`"
+    - "**Marque du client**: `%brand%`"
     - "**Vérification**: %check%"
     - "**Violations**: %violations%"
     - "**Version du client**: %version%"
-    - "**Nature du client**: %brand%"
     - "**Latence**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/it.yml
+++ b/common/src/main/resources/discord/it.yml
@@ -1,13 +1,15 @@
+# Guida sui webhook: https://support.discord.com/hc/it/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Avviso**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% e %brand% sono racchiusi tra accenti gravi (`) per evitare che caratteri speciali rompano la formattazione.
 violation-content:
-    - "**Giocatore**: %player%"
-    - "**Cheats Rilevati**: %check%"
+    - "**Giocatore**: `%player%`"
+    - "**Marca del client**: `%brand%`"
+    - "**Controllo**: %check%"
     - "**Violazioni**: %violations%"
-    - "**Versione Client**: %version%"
-    - "**Client**: %brand%"
+    - "**Versione del client**: %version%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/ja.yml
+++ b/common/src/main/resources/discord/ja.yml
@@ -1,16 +1,15 @@
-# このファイルは、アラートをDiscordに送信するための設定ファイルです。
-# webhookの取得方法は、以下を参照してください
-# https://support.discord.com/hc/ja/articles/228383668-Webhooks-%E3%81%AE%E4%BD%BF%E3%81%84%E6%96%B9
+# Webhookの使い方: https://support.discord.com/hc/ja/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim アラート**"
+embed-title: "**Grim 警告**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player%と%brand%はバッククォート(`)で囲まれており、特殊文字によるフォーマット崩れを防ぎます。
 violation-content:
-    - "**プレイヤー**: %player%"
+    - "**プレイヤー**: `%player%`"
+    - "**ブランド**: `%brand%`"
     - "**違反項目**: %check%"
     - "**違反回数**: %violations%"
     - "**クライアントバージョン**: %version%"
-    - "**ブランド**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/nl.yml
+++ b/common/src/main/resources/discord/nl.yml
@@ -1,13 +1,15 @@
+# Hulp bij webhooks: https://support.discord.com/hc/nl/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Waarschuwing**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% en %brand% zijn omgeven door backticks (`) om te voorkomen dat speciale tekens de opmaak verstoren.
 violation-content:
-    - "**Speler**: %player%"
-    - "**Controleer**: %check%"
+    - "**Speler**: `%player%`"
+    - "**Client-merk**: `%brand%`"
+    - "**Controle**: %check%"
     - "**Overtredingen**: %violations%"
     - "**Client-versie**: %version%"
-    - "**Client-merk**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/pt.yml
+++ b/common/src/main/resources/discord/pt.yml
@@ -1,13 +1,15 @@
+# Ajuda com webhooks: https://support.discord.com/hc/pt-br/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Alerta**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% e %brand% estão entre crases (`) para evitar que caracteres especiais quebrem a formatação.
 violation-content:
-    - "**Jogador**: %player%"
+    - "**Jogador**: `%player%`"
+    - "**Marca do Cliente**: `%brand%`"
     - "**Verificação**: %check%"
     - "**Violações**: %violations%"
     - "**Versão do Cliente**: %version%"
-    - "**Nome do Cliente**: %brand%"
     - "**Ping**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/ru.yml
+++ b/common/src/main/resources/discord/ru.yml
@@ -1,14 +1,15 @@
-# Включать ли веб-крючок discord
+# Справка по вебхукам: https://support.discord.com/hc/ru/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Оповещение**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% и %brand% обёрнуты в обратные кавычки (`), чтобы спецсимволы не нарушали форматирование.
 violation-content:
-    - "**Игрок**: %player%"
+    - "**Игрок**: `%player%`"
+    - "**Бренд**: `%brand%`"
     - "**Проверка**: %check%"
     - "**Нарушения**: %violations%"
     - "**Версия Клиента**: %version%"
-    - "**Бренд**: %brand%"
     - "**Пинг**: %ping%"
     - "**ТПС**: %tps%"

--- a/common/src/main/resources/discord/tr.yml
+++ b/common/src/main/resources/discord/tr.yml
@@ -1,13 +1,15 @@
+# Webhook yardımı: https://support.discord.com/hc/tr/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim Uyarı**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player% ve %brand% özel karakterlerin biçimlendirmeyi bozmasını önlemek için ters tırnak (`) içine alınmıştır.
 violation-content:
-    - "**Oyuncu**: %player%"
+    - "**Oyuncu**: `%player%`"
+    - "**Client Markası**: `%brand%`"
     - "**Kontrol**: %check%"
     - "**İhlaller**: %violations%"
     - "**Client Versiyonu**: %version%"
-    - "**Kullanılan Client**: %brand%"
     - "**Gecikme**: %ping%"
     - "**TPS**: %tps%"

--- a/common/src/main/resources/discord/zh.yml
+++ b/common/src/main/resources/discord/zh.yml
@@ -1,14 +1,15 @@
-# 是否启用discord webhook
+# Webhook帮助: https://support.discord.com/hc/zh-cn/articles/228383668
 enabled: false
 webhook: ""
-embed-title: "**Grim Alert**"
+embed-title: "**Grim 警报**"
 embed-color: "#00FFFF"
 include-timestamp: true
+# %player%和%brand%用反引号(`)包裹，防止特殊字符破坏格式。
 violation-content:
-    - "**玩家名**: %player%"
+    - "**玩家名**: `%player%`"
+    - "**客户端品牌**: `%brand%`"
     - "**检查**: %check%"
-    - "**违规率**: %violations%"
+    - "**违规次数**: %violations%"
     - "**游戏版本**: %version%"
-    - "**客户端品牌**: %brand%"
     - "**延迟**: %ping%"
-    - "**服务器卡顿程度**: %tps%"
+    - "**TPS**: %tps%"


### PR DESCRIPTION
### Summary
This PR fixes issues with PAPI placeholders not being parsed in Discord webhooks. It also overhauls the Discord webhook system to improve formatting and standardize localization across all supported languages.

*   **Formatting**:
    *   Implemented context-aware Markdown escaping in `MessageUtil`.
    *   If a placeholder is wrapped in backticks (e.g., `` `%player%` ``), only backticks and backslashes are escaped to preserve the raw look.
    *   If a placeholder is in plain text, it is aggressively filtered to prevent users from breaking embed formatting (e.g., using underscores or asterisks).
*   **Configuration & Localization**:
    *   Updated **all** language files to wrap user-controlled variables (`%player%`, `%brand%`) in backticks by default.
    *   Reordering the default order of information in embeds across all languages (Player -> Brand -> Check -> Data).
    *   Fixed translation errors:
        *   **Chinese:** Changed "Server lag degree" to "TPS" and "Violation Rate" to "Count".
        *   **Italian:** Changed "Cheats Detected" to "Check" (Controllo).
        *   **French/Dutch/Turkish:** Improved terminology for "Brand".