### PR TITLE
Project Codex - Config / Settings API

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/config/ConfigManagerFileImpl.java
+++ b/common/src/main/java/ac/grim/grimac/manager/config/ConfigManagerFileImpl.java
@@ -3,24 +3,99 @@ package ac.grim.grimac.manager.config;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.common.BasicReloadable;
 import ac.grim.grimac.api.config.ConfigManager;
+import ac.grim.grimac.api.config.source.ConfigLoader;
+import ac.grim.grimac.api.config.source.ConfigSource;
+import ac.grim.grimac.api.config.source.SourceHandler;
+import ac.grim.grimac.api.config.source.impl.FileConfigSource;
+import ac.grim.grimac.api.config.source.impl.MemoryConfigSource;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import github.scarsz.configuralize.DynamicConfig;
 import github.scarsz.configuralize.Language;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable {
+public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable, ConfigLoader {
 
     private final DynamicConfig config;
     private boolean initialized = false;
 
+    // Registry of logic handlers
+    private final Map<Class<?>, SourceHandler<?>> handlers = new HashMap<>();
+
+    // Registry of sources (stored for reloads)
+    private final List<ConfigSource> registeredSources = new ArrayList<>();
+    private final Set<String> loadedIds = new HashSet<>();
+
     public ConfigManagerFileImpl() {
         config = new DynamicConfig();
+
+        this.registerHandler(FileConfigSource.class, (source, loader) -> {
+            loader.loadFile(source.getId(), source.getFile(), source.getResourceOwner());
+        });
+
+        // 2. Register Logic: How to handle Memory/Maps
+        this.registerHandler(MemoryConfigSource.class, (source, loader) -> {
+            loader.loadMap(source.getId(), source.getValues());
+        });
+
+        // 3. Register Standard Configs using the new system
+        // Note: These are now treated exactly the same as external platform configs
+        this.registerSource(ConfigSource.file("config", getConfigFile("config.yml"), GrimAPI.class));
+        this.registerSource(ConfigSource.file("messages", getConfigFile("messages.yml"), GrimAPI.class));
+        this.registerSource(ConfigSource.file("discord", getConfigFile("discord.yml"), GrimAPI.class));
+        this.registerSource(ConfigSource.file("punishments", getConfigFile("punishments.yml"), GrimAPI.class));
+    }
+
+    @Override
+    public void registerSource(@NotNull ConfigSource source) {
+        if (!registeredSources.contains(source)) {
+            registeredSources.add(source);
+        }
+        // Process immediately
+        runHandler(source);
+    }
+
+    @Override
+    public <T extends ConfigSource> void registerHandler(@NotNull Class<T> type, @NotNull SourceHandler<T> handler) {
+        handlers.put(type, handler);
+    }
+
+    @Override
+    public void loadFile(@NotNull String id, @NotNull File file, @NotNull Class<?> resourceOwner) {
+        // SAFETY GUARD: Only add the source definition ONCE.
+        // config.loadAll() will handle refreshing the content during reload.
+        if (loadedIds.contains(id)) return;
+
+        loadedIds.add(id);
+        config.addSource(resourceOwner, id, file);
+    }
+
+    @Override
+    public void loadMap(@NotNull String id, @NotNull Map<String, Object> values) {
+        // Runtime values need to be re-applied every time
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
+            config.setRuntimeValue(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runHandler(ConfigSource source) {
+        SourceHandler handler = handlers.get(source.getClass());
+        if (handler != null) {
+            handler.handle(source, this);
+        } else {
+            LogUtil.warn("No handler registered for config type: " + source.getClass().getName());
+        }
     }
 
     private File getConfigFile(String path) {
@@ -32,10 +107,10 @@ public class ConfigManagerFileImpl implements ConfigManager, BasicReloadable {
         GrimAPI.INSTANCE.getGrimPlugin().getDataFolder().mkdirs();
         if (!initialized) {
             initialized = true;
-            config.addSource(GrimAPI.class, "config", getConfigFile("config.yml"));
-            config.addSource(GrimAPI.class, "messages", getConfigFile("messages.yml"));
-            config.addSource(GrimAPI.class, "discord", getConfigFile("discord.yml"));
-            config.addSource(GrimAPI.class, "punishments", getConfigFile("punishments.yml"));
+        }
+
+        for (ConfigSource source : registeredSources) {
+            runHandler(source);
         }
 
         String languageCode = System.getProperty("user.language").toUpperCase();

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.2.1.0"
+grim-api = "1.2.2.0-da8fb90"
 packetevents = "2.11.2+a28fb76-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.5.0"


### PR DESCRIPTION
I'm starting a new "Project" system to track major features/refactors. The first one is Project Codex.

### The Problem
Right now, Grim's config system is too tightly coupled to the underlying library (configuralize).
- It's hard for the Platform implementations (Bukkit/Fabric) to register their own settings files cleanly.
- Extensions basically can't register their own configs without hacks.
- If we ever want to switch config libraries (e.g. to Carbon) or support non-file sources (Redis/SQL), we'd have to break the API.

### The Plan
I want to decouple the Data (the file/values) from the Loader (the logic).

I've drafted a new design using a Handler pattern. The goal is to let plugins register a source, and the manager figures out how to handle it. This keeps the API clean and lets us add support for things like Redis later or have extensions register sources without changing the API.

### Proposed API
Here is what I'm thinking for the usage. Does this look annoying to use?

**1. Registering a File (Standard usage)**
```java
// Extensions or Platforms just do this:
ConfigSource settings = ConfigSource.file("my-settings", new File(...), getClass());
GrimAPI.getConfigManager().registerSource(settings);
```

**2. Custom Sources (Future proofing)**
If someone wants to write a Redis loader later, they can register a handler that converts Redis data into a simple Map, and Grim handles the rest.
```java
// Register logic for handling Redis sources
manager.registerHandler(RedisSource.class, (source, loader) -> {
    Map<String, Object> data = jedis.hgetAll(source.getKey());
    // "loadMap" is a new primitive that injects raw values into Grim
    loader.loadMap(source.getId(), data); 
});
```

Related Grim API Draft: https://github.com/GrimAnticheat/GrimAPI/pull/17

I'm drafting the PR right now, but before I commit to this:
1.  **Is this over-engineered?** Is the separation between `ConfigSource` (Data) and `SourceHandler` (Logic) too much, or do you think it's necessary for long-term support?
2.  **Naming:** I'm calling them `ConfigSource` and `ConfigManager`. Is that clear enough?
3.  **Primitives:** Currently, the API only accepts `File` or `Map<String, Object>` as inputs. Is there any use case where this wouldn't work?

Let me know what you think.