### PR TITLE
Add method exposing int block type from CompensatedWorld

### DIFF
--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.player;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.PacketWorld;
 import ac.grim.grimac.api.config.ConfigManager;
 import ac.grim.grimac.api.handler.ResyncHandler;
 import ac.grim.grimac.checks.Check;
@@ -672,6 +673,11 @@ public class GrimPlayer implements GrimUser {
                 default -> this.possibleEyeHeights[0]; // [standing height, sneaking height, swimming/gliding/riptide height]
             };
         }
+    }
+
+    @Override
+    public PacketWorld getPacketWorld() {
+        return compensatedWorld;
     }
 
     @Override

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -64,7 +64,7 @@ import java.util.Map;
 import java.util.Set;
 
 // Inspired by https://github.com/GeyserMC/Geyser/blob/master/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
-public class CompensatedWorld implements PacketWorld{
+public class CompensatedWorld implements PacketWorld {
     public static final ClientVersion blockVersion = PacketEvents.getAPI().getServerManager().getVersion().toClientVersion();
     private static final WrappedBlockState airData = WrappedBlockState.getByGlobalId(blockVersion, 0);
     public final GrimPlayer player;

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.utils.latency;
 
 import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.api.PacketWorld;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.change.BlockModification;
 import ac.grim.grimac.utils.chunks.Column;
@@ -63,7 +64,7 @@ import java.util.Map;
 import java.util.Set;
 
 // Inspired by https://github.com/GeyserMC/Geyser/blob/master/connector/src/main/java/org/geysermc/connector/network/session/cache/ChunkCache.java
-public class CompensatedWorld {
+public class CompensatedWorld implements PacketWorld{
     public static final ClientVersion blockVersion = PacketEvents.getAPI().getServerManager().getVersion().toClientVersion();
     private static final WrappedBlockState airData = WrappedBlockState.getByGlobalId(blockVersion, 0);
     public final GrimPlayer player;
@@ -458,6 +459,25 @@ public class CompensatedWorld {
         }
 
         return airData;
+    }
+
+    @Override
+    public int getBlockStateId(int x, int y, int z) { // Logic copied from getBlock
+        if (noNegativeBlocks && y < 0) return -1;
+
+        try {
+            Column column = getChunk(x >> 4, z >> 4);
+
+            y -= minHeight;
+            if (column == null || y < 0 || (y >> 4) >= column.chunks().length) return -2;
+
+            BaseChunk chunk = column.chunks()[y >> 4];
+            if (chunk != null) {
+                return chunk.getBlockId(x & 0xF, y & 0xF, z & 0xF);
+            }
+        } catch (Exception ignored) {
+        }
+        return -3;
     }
 
     // Not direct power into a block

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -618,6 +618,7 @@ public class CompensatedWorld implements PacketWorld{
         return chunks.get(chunkPosition);
     }
 
+    @Override
     public boolean isChunkLoaded(int chunkX, int chunkZ) {
         long chunkPosition = chunkPositionToLong(chunkX, chunkZ);
         return chunks.containsKey(chunkPosition);


### PR DESCRIPTION
Per discussion with Axionize in the discord, I've implemented `CompensatedWorld#getBlockStateId` and made `CompensatedWorld` extend `PacketWorld`, which is used in the GrimAPI to expose `CompensatedWorld#getBlockStateId` via` GrimUser#getPacketWorld`

Please let me know if any changes are required, I'm still not certain if `BaseChunk` was the correct place to access the block id from, and why exposing packetevent's `WrappedBlockState` from `CompensatedWorld#getBlock` is unacceptable.

Requires https://github.com/GrimAnticheat/GrimAPI/pull/18