### PR TITLE
account for 1.21.2+ clients ignoring teleport packets while in vehicle

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketServerTeleport.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketServerTeleport.java
@@ -113,6 +113,11 @@ public class PacketServerTeleport extends PacketListenerAbstract {
                 }
             }
 
+            // 1.21.2+ client ignore teleports if player is inside vehicle, ABSOLUTE CINEMA MOJANG
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21_2) && player.compensatedEntities.serverPlayerVehicle != null) {
+                pos = player.getSetbackTeleportUtil().lastKnownGoodPosition.getPos();
+            }
+
             player.sendTransaction();
             final int lastTransactionSent = player.lastTransactionSent.get();
             event.getTasksAfterSend().add(player::sendTransaction);


### PR DESCRIPTION
fix: https://github.com/GrimAnticheat/Grim/issues/2463

<img width="1269" height="331" alt="image" src="https://github.com/user-attachments/assets/a606fb9a-022b-4748-9edc-bd257b994a9b" />
