### PR TITLE
fix: honor per-check nomodifypacket

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/common/src/main/java/ac/grim/grimac/checks/Check.java
@@ -60,7 +60,11 @@ public class Check extends GrimProcessor implements AbstractCheck {
     }
 
     public boolean shouldModifyPackets() {
-        return isEnabled && !player.disableGrim && !player.noModifyPacketPermission && !exemptPermission;
+        return isEnabled
+                && !player.disableGrim
+                && !player.noModifyPacketPermission
+                && !noModifyPacketPermission
+                && !exemptPermission;
     }
 
     public final void updatePermissions() {


### PR DESCRIPTION
fix for #2476

This should fix `grim.nomodifypackets.checkname` not being applied to checks. Note this fix targets the nomodifypackets permissions only. 