### PR TITLE
fix(fabric): guard replaceNativePlayer cache miss

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/SpectateManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/SpectateManager.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SpectateManager implements StartableInitable, ReloadableInitable {
-
     private final Map<UUID, PreviousState> spectatingPlayers = new ConcurrentHashMap<>();
     private final Set<UUID> hiddenPlayers = ConcurrentHashMap.newKeySet();
     private final Set<String> allowedWorlds = ConcurrentHashMap.newKeySet();

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/FabricPlatformPlayerFactory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/FabricPlatformPlayerFactory.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.platform.fabric.player;
 import ac.grim.grimac.platform.api.entity.GrimEntity;
 import ac.grim.grimac.platform.api.player.AbstractPlatformPlayerFactory;
 import ac.grim.grimac.platform.api.player.OfflinePlatformPlayer;
+import ac.grim.grimac.platform.api.player.PlatformPlayer;
 import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import com.mojang.authlib.GameProfile;
 import lombok.RequiredArgsConstructor;
@@ -117,7 +118,10 @@ public class FabricPlatformPlayerFactory extends AbstractPlatformPlayerFactory<S
 
     @Override
     public void replaceNativePlayer(@NotNull UUID uuid, @NotNull ServerPlayer serverPlayerEntity) {
-        super.cache.getPlayer(uuid).replaceNativePlayer(serverPlayerEntity);
+        PlatformPlayer cachedPlayer = super.cache.getPlayer(uuid);
+        if (cachedPlayer != null) {
+            cachedPlayer.replaceNativePlayer(serverPlayerEntity);
+        }
     }
 
     public AbstractFabricPlatformInventory getPlatformInventory(AbstractFabricPlatformPlayer serverPlayerEntity) {


### PR DESCRIPTION
## Summary
Add a null guard in Fabric `replaceNativePlayer` to prevent a hard NPE when the platform player cache entry is missing during `ServerPlayer.restoreFrom`.

## Problem
On Fabric, Grim currently assumes a cached `PlatformPlayer` always exists when `ServerPlayerMixin` fires at `restoreFrom` tail.

When that assumption is violated, this call chain crashes:
- `ServerPlayerMixin#onRestoreFrom` -> `FabricPlatformPlayerFactory#replaceNativePlayer`
- `cache.getPlayer(uuid)` returns `null`
- direct dereference throws NPE

This manifests as `Ticking player` packet handling failures and `Internal server error` disconnects.

## Root Cause
`FabricPlatformPlayerFactory.replaceNativePlayer` dereferences `cache.getPlayer(uuid)` without checking for null, but lifecycle timing can produce legitimate cache misses (for example around disconnect/invalidation vs reconstruction timing).

## Changes
- File: `fabric/src/main/java/ac/grim/grimac/platform/fabric/player/FabricPlatformPlayerFactory.java`
- Method: `replaceNativePlayer(@NotNull UUID uuid, @NotNull ServerPlayer serverPlayerEntity)`
- Change: guard `cache.getPlayer(uuid)` and only call `replaceNativePlayer(...)` when a cached entry exists.

## Validation
- Deployed test build in a Fabric 1.21.11 environment where this stack had been observed.
- Server startup was healthy; no `PlatformPlayerCache.getPlayer(...)` / `replaceNativePlayer` NPEs seen after deployment.


## Related
- Closes #2508
