### PR TITLE
add PacketOrderQ

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderQ.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderQ.java
@@ -1,0 +1,45 @@
+package ac.grim.grimac.checks.impl.packetorder;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+
+@CheckData(name = "PacketOrderQ", description = "Has position changed without transactions packet", experimental = true)
+public class PacketOrderQ extends Check implements PacketCheck {
+    private int positions = 0;
+    private long lastTransTime = 0L;
+
+    public PacketOrderQ(final GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        PacketTypeCommon type = event.getPacketType();
+        long now = event.getTimestamp();
+
+        // If a valid transaction has arrived, we reset the counter.
+        if (isTransaction(type) && player.packetStateData.lastTransactionPacketWasValid) {
+            positions = 0;
+            lastTransTime = now;
+            return;
+        }
+
+        // Count the pos packets
+        if (type == PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION || type == PacketType.Play.Client.PLAYER_POSITION) {
+            positions++;
+
+            // If 40 position packets have already arrived (~2 seconds), but there are zero transactions
+            if (positions > 40 && now - player.joinTime > 5000L) {
+                flagAndAlert("positions=" + positions + ", last=" + (now - lastTransTime) + "ms");
+                player.getSetbackTeleportUtil().executeViolationSetback();
+
+                positions = 0;
+            }
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -139,6 +139,7 @@ public class CheckManager {
                 .put(PacketOrderD.class, new PacketOrderD(player))
                 .put(PacketOrderO.class, new PacketOrderO(player))
 //                .put(PacketOrderP.class, new PacketOrderP(player))
+                .put(PacketOrderQ.class, new PacketOrderQ(player))
                 .put(SprintA.class, new SprintA(player))
                 .put(VehicleA.class, new VehicleA(player))
                 .put(VehicleB.class, new VehicleB(player))


### PR DESCRIPTION
We shouldn't allow players to cancel transaction packets while they're moving. This check is a complete inversion of BadPafcketsR. You can still be detected by TransactionOrder for canceling transactions, but I decided to add a check to completely fix some bypass.
