### PR TITLE
Check if the block was actually placed

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/scaffolding/RotationPlace.java
@@ -33,6 +33,7 @@ public class RotationPlace extends BlockPlaceCheck {
     @Override
     public void onBlockPlace(final BlockPlace place) {
         if (place.material == StateTypes.SCAFFOLDING) return;
+        if (place.material == StateTypes.FIRE) return;
         if (!player.cameraEntity.isSelf())
             return; // you don't send flying packets when spectating entities
         if (player.inVehicle()) return;
@@ -49,6 +50,7 @@ public class RotationPlace extends BlockPlaceCheck {
     @Override
     public void onPostFlyingBlockPlace(BlockPlace place) {
         if (place.material == StateTypes.SCAFFOLDING) return;
+        if (place.material == StateTypes.FIRE) return;
         if (!player.cameraEntity.isSelf())
             return; // you don't send flying packets when spectating entities
         if (player.inVehicle()) return;


### PR DESCRIPTION
This fixes a lot of false positives where you could just click on blocks without placing the block at all.