### PR TITLE
Added a new experimental checks `ConnectionA-B` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
- <h1>GrimAC (fork)</h1>
+ <h1>GrimAC</h1>
 
  <div>
   <a href="https://github.com/GrimAnticheat/Grim/actions/workflows/gradle-publish.yml">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
- <h1>GrimAC</h1>
+ <h1>GrimAC (fork)</h1>
 
  <div>
   <a href="https://github.com/GrimAnticheat/Grim/actions/workflows/gradle-publish.yml">

--- a/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
@@ -16,7 +16,7 @@ public class ConnectionA extends Check implements PacketCheck {
 
     private static final int SAMPLE_SIZE = 35;
     private static final long JOIN_GRACE_PERIOD = 5000L;
-    private static final double MAX_AVG_PING = 150.0;
+    private static final double MAX_AVG_PING = 300.0;
     private static final double BUFFER_THRESHOLD = 4.0;
     private static final double BUFFER_DECAY = 0.5;
 

--- a/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
@@ -10,14 +10,13 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 
 @CheckData(
         name = "ConnectionA",
-        description = "Detects suspicious ping changes",
-        experimental = true
+        description = "Detects suspicious ping changes"
 )
 public class ConnectionA extends Check implements PacketCheck {
 
     private static final int SAMPLE_SIZE = 35;
     private static final long JOIN_GRACE_PERIOD = 5000L;
-    private static final double MAX_AVG_PING = 300.0;
+    private static final double MAX_AVG_PING = 150.0;
     private static final double BUFFER_THRESHOLD = 4.0;
     private static final double BUFFER_DECAY = 0.5;
 

--- a/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionA.java
@@ -1,0 +1,84 @@
+package ac.grim.grimac.checks.impl.misc.connection;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.lists.EvictingQueue;
+import ac.grim.grimac.utils.math.GrimMath;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+
+@CheckData(
+        name = "ConnectionA",
+        description = "Detects suspicious ping changes",
+        experimental = true
+)
+public class ConnectionA extends Check implements PacketCheck {
+
+    private static final int SAMPLE_SIZE = 35;
+    private static final long JOIN_GRACE_PERIOD = 5000L;
+    private static final double MAX_AVG_PING = 300.0;
+    private static final double BUFFER_THRESHOLD = 4.0;
+    private static final double BUFFER_DECAY = 0.5;
+
+    private final EvictingQueue<Double> delays = new EvictingQueue<>(SAMPLE_SIZE);
+
+    private double buffer;
+
+    public ConnectionA(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (!isTickPacket(event.getPacketType())) return;
+        if (shouldIgnore()) return;
+
+        double delay = player.getTransactionPing();
+        delays.add(delay);
+
+        if (!delays.isCollected()) return;
+
+        handleCollectedSamples(delay);
+    }
+
+    private boolean shouldIgnore() {
+        return player.packetStateData.lastPacketWasTeleport
+                || System.currentTimeMillis() - player.joinTime < JOIN_GRACE_PERIOD
+                || player.inVehicle();
+    }
+
+    private void handleCollectedSamples(double latestDelay) {
+        double averageDelay = GrimMath.getAverage(delays);
+        delays.clear();
+
+        if (averageDelay > MAX_AVG_PING) {
+            increaseBuffer(averageDelay, latestDelay);
+        } else {
+            decayBuffer();
+        }
+    }
+
+    private void increaseBuffer(double avgDelay, double latestDelay) {
+        buffer++;
+
+        if (buffer > BUFFER_THRESHOLD) {
+            flagAndAlert(String.format(
+                    "avg=%.1f, delay=%.1f, buffer=%.1f",
+                    avgDelay,
+                    latestDelay,
+                    buffer
+            ));
+
+            if (shouldSetback()) {
+                player.getSetbackTeleportUtil().executeViolationSetback();
+            }
+        }
+    }
+
+    private void decayBuffer() {
+        if (buffer > 0) {
+            buffer = Math.max(0, buffer - BUFFER_DECAY);
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionB.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/misc/connection/ConnectionB.java
@@ -1,0 +1,137 @@
+package ac.grim.grimac.checks.impl.misc.connection;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+
+import java.util.*;
+
+@CheckData(
+        name = "ConnectionB",
+        description = "Soft ping spoof detection, avoids overflagging"
+)
+public class ConnectionB extends Check implements PacketCheck {
+
+    private final Deque<Long> pingQueue = new ArrayDeque<>();
+    private final Deque<Long> recentDelays = new ArrayDeque<>();
+
+    private long lastPongTime;
+    private long lastFlagTime;
+    private double buffer;
+
+    // Constants
+    private static final long NANOS_PER_TICK = 50_000_000L;
+    private static final long MAX_ACCEPTABLE_DELAY = NANOS_PER_TICK * 8;
+    private static final int MAX_RECENT_PINGS = 20;
+    private static final long FLAG_COOLDOWN = 2_000_000_000L;
+    private static final double BUFFER_THRESHOLD = 3.0;
+
+    public ConnectionB(GrimPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        if (event.getPacketType() != PacketType.Play.Server.PING) return;
+
+        addSample(pingQueue, System.nanoTime());
+    }
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() != PacketType.Play.Client.PONG) return;
+        if (pingQueue.isEmpty()) return;
+
+        long now = System.nanoTime();
+        long sentTime = pingQueue.poll();
+
+        long delay = Math.abs(now - sentTime);
+        lastPongTime = now;
+
+        addSample(recentDelays, delay);
+
+        long medianDelay = calculateMedian(recentDelays);
+
+        updateBuffer(delay, medianDelay);
+
+        if (shouldFlag(now)) {
+            handleFlag(now, delay, medianDelay);
+        } else {
+            reward();
+        }
+    }
+
+    public void onPredictionComplete(PredictionComplete predictionComplete) {
+        long now = System.nanoTime();
+        long timeSinceLastPong = now - lastPongTime;
+
+        if (timeSinceLastPong <= NANOS_PER_TICK * 60) return;
+        if (now - lastFlagTime <= FLAG_COOLDOWN * 2) return;
+
+        buffer++;
+
+        if (buffer >= BUFFER_THRESHOLD) {
+            if (flagAndAlertWithSetback(String.format(
+                    "Soft ping spoof | no pong in %.2fms",
+                    timeSinceLastPong / 1e6
+            ))) {
+                lastFlagTime = now;
+            }
+
+            buffer = 0;
+        }
+    }
+
+    private void updateBuffer(long delay, long medianDelay) {
+        if (delay > MAX_ACCEPTABLE_DELAY && delay > medianDelay * 2) {
+            buffer += 1.0;
+        } else {
+            buffer = Math.max(0, buffer - 0.5);
+        }
+    }
+
+    private boolean shouldFlag(long now) {
+        return buffer >= BUFFER_THRESHOLD && now - lastFlagTime > FLAG_COOLDOWN;
+    }
+
+    private void handleFlag(long now, long delay, long medianDelay) {
+        if (flagAndAlert(String.format(
+                "Soft ping spoof suspected | delay=%.2fms median=%.2fms buffer=%.1f",
+                delay / 1e6,
+                medianDelay / 1e6,
+                buffer
+        ))) {
+            lastFlagTime = now;
+        }
+
+        buffer = 0;
+    }
+
+    private void addSample(Deque<Long> queue, long value) {
+        queue.add(value);
+
+        if (queue.size() > MAX_RECENT_PINGS) {
+            queue.poll();
+        }
+    }
+
+    private long calculateMedian(Collection<Long> values) {
+        if (values.isEmpty()) return 0L;
+
+        List<Long> sorted = new ArrayList<>(values);
+        Collections.sort(sorted);
+
+        int mid = sorted.size() / 2;
+
+        if (sorted.size() % 2 == 0) {
+            return (sorted.get(mid - 1) + sorted.get(mid)) / 2;
+        }
+
+        return sorted.get(mid);
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -24,6 +24,7 @@ import ac.grim.grimac.checks.impl.misc.ClientBrand;
 import ac.grim.grimac.checks.impl.misc.GhostBlockMitigation;
 import ac.grim.grimac.checks.impl.misc.Post;
 import ac.grim.grimac.checks.impl.misc.TransactionOrder;
+import ac.grim.grimac.checks.impl.misc.connection.ConnectionA;
 import ac.grim.grimac.checks.impl.movement.NoSlow;
 import ac.grim.grimac.checks.impl.movement.PredictionRunner;
 import ac.grim.grimac.checks.impl.movement.SetbackBlocker;
@@ -139,6 +140,7 @@ public class CheckManager {
                 .put(PacketOrderD.class, new PacketOrderD(player))
                 .put(PacketOrderO.class, new PacketOrderO(player))
 //                .put(PacketOrderP.class, new PacketOrderP(player))
+                .put(ConnectionA.class, new ConnectionA(player))
                 .put(SprintA.class, new SprintA(player))
                 .put(VehicleA.class, new VehicleA(player))
                 .put(VehicleB.class, new VehicleB(player))

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -25,6 +25,7 @@ import ac.grim.grimac.checks.impl.misc.GhostBlockMitigation;
 import ac.grim.grimac.checks.impl.misc.Post;
 import ac.grim.grimac.checks.impl.misc.TransactionOrder;
 import ac.grim.grimac.checks.impl.misc.connection.ConnectionA;
+import ac.grim.grimac.checks.impl.misc.connection.ConnectionB;
 import ac.grim.grimac.checks.impl.movement.NoSlow;
 import ac.grim.grimac.checks.impl.movement.PredictionRunner;
 import ac.grim.grimac.checks.impl.movement.SetbackBlocker;
@@ -141,6 +142,7 @@ public class CheckManager {
                 .put(PacketOrderO.class, new PacketOrderO(player))
 //                .put(PacketOrderP.class, new PacketOrderP(player))
                 .put(ConnectionA.class, new ConnectionA(player))
+                .put(ConnectionB.class, new ConnectionB(player))
                 .put(SprintA.class, new SprintA(player))
                 .put(VehicleA.class, new VehicleA(player))
                 .put(VehicleB.class, new VehicleB(player))

--- a/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -324,7 +324,6 @@ public class MovementCheckRunner extends Check implements PositionCheck {
 
         // This isn't the final velocity of the player in the tick, only the one applied to the player
         player.actualMovement = new Vector3dm(player.x - player.lastX, player.y - player.lastY, player.z - player.lastZ);
-
         if (player.isSprinting != player.lastSprinting) {
             player.compensatedEntities.hasSprintingAttributeEnabled = player.isSprinting;
         }

--- a/common/src/main/java/ac/grim/grimac/utils/lists/EvictingQueue.java
+++ b/common/src/main/java/ac/grim/grimac/utils/lists/EvictingQueue.java
@@ -5,25 +5,25 @@ import java.util.ArrayList;
 // https://stackoverflow.com/a/21047889
 // License: Originally CC By-SA 4.0 licensed as GPL
 public class EvictingQueue<K> extends ArrayList<K> {
+
     private final int maxSize;
 
     public EvictingQueue(int size) {
         this.maxSize = size;
     }
 
+    @Override
     public boolean add(K k) {
         boolean r = super.add(k);
+
         if (size() > maxSize) {
             removeRange(0, size() - maxSize);
         }
+
         return r;
     }
 
-    public K getYoungest() {
-        return get(size() - 1);
-    }
-
-    public K getOldest() {
-        return get(0);
+    public boolean isCollected() {
+        return size() >= maxSize;
     }
 }

--- a/common/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
+++ b/common/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
@@ -3,9 +3,7 @@ package ac.grim.grimac.utils.math;
 import com.github.retrooper.packetevents.util.Vector3i;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
+import java.util.Collection;
 
 @UtilityClass
 public class GrimMath {
@@ -31,23 +29,34 @@ public class GrimMath {
 
         return a;
     }
+    public static double getAverage(final Collection<? extends Number> data) {
+        if (data == null || data.isEmpty()) {
+            return 0.0;
+        }
 
-    @Contract(pure = true)
-    public static double calculateSD(@NotNull List<@NotNull Double> numbers) {
         double sum = 0.0;
-        double standardDeviation = 0.0;
 
-        for (double rotation : numbers) {
-            sum += rotation;
+        for (Number number : data) {
+            sum += number.doubleValue();
         }
 
-        double mean = sum / numbers.size();
+        return sum / data.size();
+    }
 
-        for (double num : numbers) {
-            standardDeviation += Math.pow(num - mean, 2);
+    public static double getVariance(final Collection<? extends Number> data) {
+        if (data == null || data.isEmpty()) {
+            return 0.0;
         }
 
-        return Math.sqrt(standardDeviation / numbers.size());
+        double mean = getAverage(data);
+        double variance = 0.0;
+
+        for (Number number : data) {
+            double diff = number.doubleValue() - mean;
+            variance += diff * diff;
+        }
+
+        return variance / data.size();
     }
 
     @Contract(pure = true)

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -70,7 +70,7 @@ Simulation:
     # Measured in blocks from the possible movement
     # We account for Optifine by switching trig tables but dropping this to 0.001 will reduce FastMath
     # flagging the anticheat if this compensation doesn't work...
-    threshold: 0.001
+    threshold: 0.1
     # How large of a violation in a tick before the player gets immediately setback?
     # -1 to disable
     immediate-setback-threshold: 0.1
@@ -148,11 +148,11 @@ TimerLimit:
     # Ping at which the check will start to limit timer balance, to prevent abuse.
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
-    ping-abuse-limit-threshold: 2000
+    ping-abuse-limit-threshold: -1
 
 NegativeTimer:
     # Number of milliseconds lost while moving before we should start flagging
-    drift: 1200
+    drift: 2000
 
 # Same check method as TimerA, but for vehicles
 VehicleTimer:

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -148,7 +148,7 @@ TimerLimit:
     # Ping at which the check will start to limit timer balance, to prevent abuse.
     # Can cause some setbacks for legitimate players but only if they are over this ping threshold.
     # -1 to disable
-    ping-abuse-limit-threshold: 1000
+    ping-abuse-limit-threshold: 2000
 
 NegativeTimer:
     # Number of milliseconds lost while moving before we should start flagging

--- a/common/src/main/resources/punishments/en.yml
+++ b/common/src/main/resources/punishments/en.yml
@@ -63,6 +63,14 @@ Punishments:
       - "20:20 [log]"
       - "40:40 [webhook]"
       - "40:40 [proxy]"
+  Connection:
+      remove-violations-after: 300
+      checks:
+          - "Connection"
+      commands:
+          - "5:5 [alert]"
+          - "5:5 [log]"
+          - "10:0 kick %player% Suspicious connection detected (unstable ping)"
   Reach:
     remove-violations-after: 300
     checks:

--- a/common/src/main/resources/punishments/en.yml
+++ b/common/src/main/resources/punishments/en.yml
@@ -33,6 +33,7 @@ Punishments:
       - "100:40 [log]"
       - "100:100 [webhook]"
       - "100:100 [proxy]"
+      - "100:0 kick %player% incorrect movement!"
   Knockback:
     remove-violations-after: 300
     checks:


### PR DESCRIPTION
The check samples transaction ping values using an EvictingQueue and analyzes
their average over a fixed window. If the average ping exceeds the configured
threshold, a buffer is increased and the player may be flagged after repeated
violations.

Key features:
- Uses EvictingQueue to collect ping samples
- Calculates average delay via GrimMath
- Buffer-based violation system to reduce false positives
- Ignores players during teleport, join grace period, or while in vehicles
- Optional setback execution on violation

This check is currently marked as experimental and may be tuned further
based on live testing.

No AI was used. 
<img width="677" height="312" alt="{561524CE-E46C-400E-9B66-44E4D203C74D}" src="https://github.com/user-attachments/assets/497bc63d-e784-4273-b9cf-14c45e73fc63" />
