### PR TITLE
Fix ghost block mitigation on floating block placement

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/misc/GhostBlockMitigation.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/misc/GhostBlockMitigation.java
@@ -41,10 +41,6 @@ public class GhostBlockMitigation extends BlockPlaceCheck {
                             continue;
                         }
 
-                        if (i == xAgainst && j == yAgainst && k == zAgainst) {
-                            continue;
-                        }
-
                         if (!world.isChunkLoaded(i >> 4, k >> 4)) {
                             continue;
                         }


### PR DESCRIPTION
Fix GhostBlockMitigation falsely resyncing valid placements against isolated floating blocks by handling the clicked
  support block inside the ghost-block scan loop.