### PR TITLE
26.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </div>
 
 GrimAC is an open source Minecraft anticheat designed to support the latest versions of Minecraft.
-It currently supports minecraft versions 1.8–1.21. Geyser players are fully exempt from the anticheat to prevent false positives.
+It currently supports minecraft versions 1.8–26.1. Geyser players are fully exempt from the anticheat to prevent false positives.
 This project is considered feature-complete for the 2.0 (open-source) branch. If you would like a bug fix or enhancement and cannot sponsor the work, pull requests are welcome.
 A premium version is planned, which will offer additional subscription-based paid checks, such as heuristics.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ BuildConfig.init(project)
 val baseVersion = "2.3.74"
 group = "ac.grim.grimac"
 version = VersionUtil.computeVersion(baseVersion)
-description = "Libre simulation anticheat designed for 1.21 with 1.8–1.21 support, powered by PacketEvents 2.0."
+description = "Libre simulation anticheat designed for 26.1 with 1.8–26.1 support, powered by PacketEvents 2.0."
 
 ext["timestamp"] = System.currentTimeMillis().toString()
 ext["git_branch"] = VersionUtil.getGitBranch(true)

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -159,7 +159,12 @@ publishing.publications.create<MavenPublication>("maven") {
 
 tasks {
     runServer {
-        minecraftVersion("1.21.11")
+        val javaToolchains = project.extensions.getByType<JavaToolchainService>()
+        javaLauncher = javaToolchains.launcherFor {
+            vendor = JvmVendorSpec.JETBRAINS
+            languageVersion = JavaLanguageVersion.of(25)
+        }
+        minecraftVersion("26.1.2")
     }
 
     shadowJar {

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -17,6 +17,7 @@ import ac.grim.grimac.manager.player.features.FeatureManagerImpl;
 import ac.grim.grimac.manager.player.handlers.DefaultResyncHandler;
 import ac.grim.grimac.manager.player.handlers.NoOpResyncHandler;
 import ac.grim.grimac.platform.api.player.PlatformPlayer;
+import ac.grim.grimac.predictionengine.EntityFluidInteraction;
 import ac.grim.grimac.predictionengine.MovementCheckRunner;
 import ac.grim.grimac.predictionengine.PointThreeEstimator;
 import ac.grim.grimac.predictionengine.UncertaintyHandler;
@@ -29,8 +30,10 @@ import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.*;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityHappyGhast;
+import ac.grim.grimac.utils.data.packetentity.PacketEntityNautilus;
 import ac.grim.grimac.utils.data.packetentity.PacketEntitySelf;
 import ac.grim.grimac.utils.data.tags.SyncedTags;
+import ac.grim.grimac.utils.enums.BoatEntityStatus;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.enums.Pose;
 import ac.grim.grimac.utils.latency.*;
@@ -190,10 +193,6 @@ public class GrimPlayer implements GrimUser {
     public boolean wasTouchingWater = false;
     public boolean wasWasTouchingWater = false;
     public boolean wasTouchingLava = false;
-    // For slightly reduced vertical lava friction and jumping
-    public boolean slightlyTouchingLava = false;
-    // For jumping
-    public boolean slightlyTouchingWater = false;
     public boolean wasEyeInWater = false;
     public FluidTag fluidOnEyes;
     public boolean softHorizontalCollision;
@@ -278,6 +277,7 @@ public class GrimPlayer implements GrimUser {
     public boolean wasLastPredictionCompleteChecked;
     public boolean isJumping;
     public boolean lastJumping;
+    public EntityFluidInteraction fluidInteraction = new EntityFluidInteraction(FluidTag.WATER, FluidTag.LAVA);
 
     public GrimPlayer(@NotNull User user) {
         this.user = user;
@@ -1037,4 +1037,42 @@ public class GrimPlayer implements GrimUser {
 
         return blockStateId;
     }
+
+    public @Nullable SimpleCollisionBox getFluidInteractionBox() {
+        SimpleCollisionBox aabb = this.boundingBox.copy().expand(-0.001);
+        PacketEntity entity = this.getVehicle();
+        if (entity != null) {
+            aabb = modifyPassengerFluidInteractionBox(entity, aabb);
+        }
+
+        return aabb;
+    }
+
+    protected @Nullable SimpleCollisionBox modifyPassengerFluidInteractionBox(PacketEntity entity, SimpleCollisionBox passengerBox) {
+        if (!entity.isBoat) return passengerBox;
+
+        if (this.vehicleData.status == BoatEntityStatus.UNDER_WATER || this.vehicleData.status == BoatEntityStatus.UNDER_FLOWING_WATER) {
+            return passengerBox;
+        } else {
+            SimpleCollisionBox aabb = this.boundingBox; // boat boundingbox
+            if (aabb.maxY >= passengerBox.maxY) {
+                return null;
+            } else {
+                double y = Math.max(passengerBox.minY, aabb.maxY);
+                return new SimpleCollisionBox(passengerBox.minX, y, passengerBox.minZ, passengerBox.maxX, passengerBox.maxY, passengerBox.maxZ);
+            }
+        }
+    }
+
+    public double getFluidHeight(FluidTag fluidTag) {
+        if (getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_21_11)) return this.fluidHeight.getDouble(fluidTag);
+        return this.fluidInteraction.getFluidHeight(fluidTag);
+    }
+
+    public boolean isPushedByFluid() {
+        if (!this.inVehicle()) return !this.isFlying;
+        PacketEntity vehicle = getVehicle();
+        return !(vehicle instanceof PacketEntityNautilus);
+    }
+
 }

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -1038,32 +1038,6 @@ public class GrimPlayer implements GrimUser {
         return blockStateId;
     }
 
-    public @Nullable SimpleCollisionBox getFluidInteractionBox() {
-        SimpleCollisionBox aabb = this.boundingBox.copy().expand(-0.001);
-        PacketEntity entity = this.getVehicle();
-        if (entity != null) {
-            aabb = modifyPassengerFluidInteractionBox(entity, aabb);
-        }
-
-        return aabb;
-    }
-
-    protected @Nullable SimpleCollisionBox modifyPassengerFluidInteractionBox(PacketEntity entity, SimpleCollisionBox passengerBox) {
-        if (!entity.isBoat) return passengerBox;
-
-        if (this.vehicleData.status == BoatEntityStatus.UNDER_WATER || this.vehicleData.status == BoatEntityStatus.UNDER_FLOWING_WATER) {
-            return passengerBox;
-        } else {
-            SimpleCollisionBox aabb = this.boundingBox; // boat boundingbox
-            if (aabb.maxY >= passengerBox.maxY) {
-                return null;
-            } else {
-                double y = Math.max(passengerBox.minY, aabb.maxY);
-                return new SimpleCollisionBox(passengerBox.minX, y, passengerBox.minZ, passengerBox.maxX, passengerBox.maxY, passengerBox.maxZ);
-            }
-        }
-    }
-
     public double getFluidHeight(FluidTag fluidTag) {
         if (getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_21_11)) return this.fluidHeight.getDouble(fluidTag);
         return this.fluidInteraction.getFluidHeight(fluidTag);

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -33,7 +33,6 @@ import ac.grim.grimac.utils.data.packetentity.PacketEntityHappyGhast;
 import ac.grim.grimac.utils.data.packetentity.PacketEntityNautilus;
 import ac.grim.grimac.utils.data.packetentity.PacketEntitySelf;
 import ac.grim.grimac.utils.data.tags.SyncedTags;
-import ac.grim.grimac.utils.enums.BoatEntityStatus;
 import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.enums.Pose;
 import ac.grim.grimac.utils.latency.*;

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -1043,6 +1043,11 @@ public class GrimPlayer implements GrimUser {
         return this.fluidInteraction.getFluidHeight(fluidTag);
     }
 
+    public boolean isEyeInFluid(FluidTag fluidTag) {
+        if (getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_21_11)) return this.fluidOnEyes == fluidTag;
+        return this.fluidInteraction.isEyeInFluid(fluidTag);
+    }
+
     public boolean isPushedByFluid() {
         if (!this.inVehicle()) return !this.isFlying;
         PacketEntity vehicle = getVehicle();

--- a/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
@@ -1,0 +1,182 @@
+package ac.grim.grimac.predictionengine;
+
+import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.chunks.Column;
+import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
+import ac.grim.grimac.utils.enums.FluidTag;
+import ac.grim.grimac.utils.latency.CompensatedWorld;
+import ac.grim.grimac.utils.math.GrimMath;
+import ac.grim.grimac.utils.math.Vector3dm;
+import ac.grim.grimac.utils.nmsutil.FluidTypeFlowing;
+import ac.grim.grimac.utils.nmsutil.Materials;
+import com.github.retrooper.packetevents.protocol.world.chunk.BaseChunk;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class EntityFluidInteraction {
+    private final Map<FluidTag, EntityFluidInteraction.Tracker> trackerByFluid = new Reference2ObjectArrayMap<>();
+
+    public EntityFluidInteraction(final FluidTag... fluids) {
+        for (FluidTag tagKey : fluids) {
+            this.trackerByFluid.put(tagKey, new EntityFluidInteraction.Tracker());
+        }
+    }
+
+    public void update(final GrimPlayer player, final boolean ignoreCurrent) {
+        this.trackerByFluid.values().forEach(EntityFluidInteraction.Tracker::reset);
+        SimpleCollisionBox aabb = player.getFluidInteractionBox();
+        if (aabb != null) {
+            int minX = GrimMath.floor(aabb.minX);
+            int minY = GrimMath.floor(aabb.minY);
+            int minZ = GrimMath.floor(aabb.minZ);
+            int maxX = GrimMath.ceil(aabb.maxX) - 1;
+            int maxY = GrimMath.ceil(aabb.maxY) - 1;
+            int maxZ = GrimMath.ceil(aabb.maxZ) - 1;
+            if (hasFluidAndLoaded(player.compensatedWorld, minX - 1, minY, minZ - 1, maxX + 1, maxY, maxZ + 1)) {
+                double aabbMinY = player.boundingBox.minY;
+
+                int playerX = GrimMath.floor(player.x); // lastX?
+                double playerEyeY = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
+                int playerZ = GrimMath.floor(player.z); // lastZ?
+
+                FluidTag fluid = null;
+                EntityFluidInteraction.Tracker tracker = null;
+
+                for (int x = minX; x <= maxX; x++) {
+                    for (int y = minY; y <= maxY; y++) {
+                        for (int z = minZ; z <= maxZ; z++) {
+                            double fluidHeight = player.compensatedWorld.getFluidLevelAt(x, y, z);
+                            if (fluidHeight != 0) {
+                                double fluidHeightToWorld = (double) y + fluidHeight;
+                                if (!(fluidHeightToWorld < aabb.minY)) {
+                                    FluidTag newFluid = Materials.isWater(player.getClientVersion(), player.compensatedWorld.getBlock(x, y, z)) ? FluidTag.WATER : FluidTag.LAVA;
+                                    if (newFluid != fluid) {
+                                        fluid = newFluid;
+                                        tracker = this.getTrackerFor(newFluid);
+                                    }
+
+                                    if (tracker != null) {
+                                        if (x == playerX && z == playerZ && playerEyeY >= (double) y && playerEyeY <= fluidHeightToWorld) {
+                                            tracker.eyesInside = true;
+                                        }
+
+                                        tracker.height = Math.max(fluidHeightToWorld - aabbMinY, tracker.height);
+                                        if (!ignoreCurrent) {
+                                            Vector3dm current = FluidTypeFlowing.getFlow(player, x, y, z);
+                                            if (tracker.height < 0.4) {
+                                                current = current.multiply(tracker.height);
+                                            }
+
+                                            tracker.accumulateCurrent(current);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean hasFluidAndLoaded(final CompensatedWorld level, final int x0, final int y0, final int z0, final int x1, final int y1, final int z1) {
+        int minX = x0 >> 4;
+        int minY = y0 >> 4;
+        int minZ = z0 >> 4;
+        int maxX = x1 >> 4;
+        int maxY = y1 >> 4;
+        int maxZ = z1 >> 4;
+        boolean hasFluidAndLoaded = false;
+
+        for (int x = minZ; x <= maxZ; x++) {
+            for (int z = minX; z <= maxX; z++) {
+                Column chunk = level.getChunk(z, x);
+                if (chunk == null) {
+                    return false;
+                }
+
+                BaseChunk[] sections = chunk.chunks();
+
+                for (int y = minY; y <= maxY; y++) {
+                    int sectionY = y - (level.getMinHeight() >> 4);
+                    if (sectionY >= 0 && sectionY < sections.length) {
+                        hasFluidAndLoaded |= sections[sectionY].hasFluid();
+                    }
+                }
+            }
+        }
+
+        return hasFluidAndLoaded;
+    }
+
+    private EntityFluidInteraction.Tracker getTrackerFor(final FluidTag fluid) {
+        for (Entry<FluidTag, EntityFluidInteraction.Tracker> entry : this.trackerByFluid.entrySet()) {
+            FluidTag tagKey = entry.getKey();
+            if (fluid == tagKey) {
+                return entry.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    public void applyCurrentTo(final FluidTag fluid, final GrimPlayer entity, final double scale) {
+        EntityFluidInteraction.Tracker tracker = this.trackerByFluid.get(fluid);
+        if (tracker != null) {
+            tracker.applyCurrentTo(entity, scale);
+        }
+    }
+
+    public double getFluidHeight(final FluidTag fluid) {
+        EntityFluidInteraction.Tracker tracker = this.trackerByFluid.get(fluid);
+        return tracker != null ? tracker.height : 0.0;
+    }
+
+    public boolean isInFluid(final FluidTag fluid) {
+        return this.getFluidHeight(fluid) > 0.0;
+    }
+
+    public boolean isEyeInFluid(final FluidTag fluid) {
+        EntityFluidInteraction.Tracker tracker = this.trackerByFluid.get(fluid);
+        return tracker != null && tracker.eyesInside;
+    }
+
+    private static class Tracker {
+        private double height;
+        private boolean eyesInside;
+        private Vector3dm accumulatedCurrent = new Vector3dm();
+        private int currentCount;
+
+        public void reset() {
+            this.height = 0.0;
+            this.eyesInside = false;
+            this.accumulatedCurrent = new Vector3dm();
+            this.currentCount = 0;
+        }
+
+        public void accumulateCurrent(final Vector3dm flow) {
+            this.accumulatedCurrent = this.accumulatedCurrent.add(flow);
+            this.currentCount++;
+        }
+
+        public void applyCurrentTo(final GrimPlayer player, final double scale) {
+            if (this.currentCount != 0 && !(this.accumulatedCurrent.lengthSquared() < 1.0E-5F)) {
+                Vector3dm current;
+                if (player.inVehicle()) {
+                    current = this.accumulatedCurrent.normalize();
+                } else {
+                    current = this.accumulatedCurrent.multiply(1.0 / this.currentCount);
+                }
+
+                current = current.multiply(scale);
+                if (Math.abs(player.clientVelocity.getX()) < 0.003 && Math.abs(player.clientVelocity.getZ()) < 0.003 && current.length() < 0.0045000000000000005) {
+                    current = current.normalize().multiply(0.0045000000000000005);
+                }
+
+                player.baseTickAddVector(current);
+            }
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
@@ -10,13 +10,12 @@ import ac.grim.grimac.utils.math.Vector3dm;
 import ac.grim.grimac.utils.nmsutil.FluidTypeFlowing;
 import ac.grim.grimac.utils.nmsutil.Materials;
 import com.github.retrooper.packetevents.protocol.world.chunk.BaseChunk;
-import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
 
-import java.util.Map;
+import java.util.EnumMap;
 import java.util.Map.Entry;
 
 public class EntityFluidInteraction {
-    private final Map<FluidTag, EntityFluidInteraction.Tracker> trackerByFluid = new Reference2ObjectArrayMap<>();
+    private final EnumMap<FluidTag, EntityFluidInteraction.Tracker> trackerByFluid = new EnumMap<>(FluidTag.class);
 
     public EntityFluidInteraction(final FluidTag... fluids) {
         for (FluidTag tagKey : fluids) {
@@ -26,54 +25,61 @@ public class EntityFluidInteraction {
 
     public void update(final GrimPlayer player, final boolean ignoreCurrent) {
         this.trackerByFluid.values().forEach(EntityFluidInteraction.Tracker::reset);
+
         SimpleCollisionBox aabb = player.boundingBox.copy().expand(-0.001);
-        if (aabb != null) {
-            int minX = GrimMath.floor(aabb.minX);
-            int minY = GrimMath.floor(aabb.minY);
-            int minZ = GrimMath.floor(aabb.minZ);
-            int maxX = GrimMath.ceil(aabb.maxX) - 1;
-            int maxY = GrimMath.ceil(aabb.maxY) - 1;
-            int maxZ = GrimMath.ceil(aabb.maxZ) - 1;
-            if (hasFluidAndLoaded(player.compensatedWorld, minX - 1, minY, minZ - 1, maxX + 1, maxY, maxZ + 1)) {
-                double aabbMinY = player.boundingBox.minY;
 
-                int playerX = GrimMath.floor(player.lastX);
-                double playerEyeY = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
-                int playerZ = GrimMath.floor(player.lastZ);
+        int minX = GrimMath.floor(aabb.minX);
+        int minY = GrimMath.floor(aabb.minY);
+        int minZ = GrimMath.floor(aabb.minZ);
+        int maxX = GrimMath.ceil(aabb.maxX) - 1;
+        int maxY = GrimMath.ceil(aabb.maxY) - 1;
+        int maxZ = GrimMath.ceil(aabb.maxZ) - 1;
 
-                FluidTag fluid = null;
-                EntityFluidInteraction.Tracker tracker = null;
+        if (!hasFluidAndLoaded(player.compensatedWorld, minX - 1, minY, minZ - 1, maxX + 1, maxY, maxZ + 1)) {
+            return;
+        }
 
-                for (int x = minX; x <= maxX; x++) {
-                    for (int y = minY; y <= maxY; y++) {
-                        for (int z = minZ; z <= maxZ; z++) {
-                            double fluidHeight = player.compensatedWorld.getFluidLevelAt(x, y, z);
-                            if (fluidHeight != 0) {
-                                double fluidHeightToWorld = (double) y + fluidHeight;
-                                if (!(fluidHeightToWorld < aabb.minY)) {
-                                    FluidTag newFluid = Materials.isWater(player.getClientVersion(), player.compensatedWorld.getBlock(x, y, z)) ? FluidTag.WATER : FluidTag.LAVA;
-                                    if (newFluid != fluid) {
-                                        fluid = newFluid;
-                                        tracker = this.getTrackerFor(newFluid);
-                                    }
+        double aabbMinY = player.boundingBox.minY;
 
-                                    if (tracker != null) {
-                                        if (x == playerX && z == playerZ && playerEyeY >= (double) y && playerEyeY <= fluidHeightToWorld) {
-                                            tracker.eyesInside = true;
-                                        }
+        int playerX = GrimMath.floor(player.lastX);
+        double playerEyeY = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
+        int playerZ = GrimMath.floor(player.lastZ);
 
-                                        tracker.height = Math.max(fluidHeightToWorld - aabbMinY, tracker.height);
-                                        if (!ignoreCurrent) {
-                                            Vector3dm current = FluidTypeFlowing.getFlow(player, x, y, z);
-                                            if (tracker.height < 0.4) {
-                                                current = current.multiply(tracker.height);
-                                            }
+        FluidTag fluid = null;
+        EntityFluidInteraction.Tracker tracker = null;
 
-                                            tracker.accumulateCurrent(current);
-                                        }
-                                    }
-                                }
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    double fluidHeight = player.compensatedWorld.getFluidLevelAt(x, y, z);
+                    if (fluidHeight == 0) {
+                        continue;
+                    }
+
+                    double fluidHeightToWorld = (double) y + fluidHeight;
+                    if (fluidHeightToWorld < aabb.minY) {
+                        continue;
+                    }
+
+                    FluidTag newFluid = Materials.isWater(player.getClientVersion(), player.compensatedWorld.getBlock(x, y, z)) ? FluidTag.WATER : FluidTag.LAVA;
+                    if (newFluid != fluid) {
+                        fluid = newFluid;
+                        tracker = this.getTrackerFor(newFluid);
+                    }
+
+                    if (tracker != null) {
+                        if (x == playerX && z == playerZ && playerEyeY >= (double) y && playerEyeY <= fluidHeightToWorld) {
+                            tracker.eyesInside = true;
+                        }
+
+                        tracker.height = Math.max(fluidHeightToWorld - aabbMinY, tracker.height);
+                        if (!ignoreCurrent) {
+                            Vector3dm current = FluidTypeFlowing.getFlow(player, x, y, z);
+                            if (tracker.height < 0.4) {
+                                current = current.multiply(tracker.height);
                             }
+
+                            tracker.accumulateCurrent(current);
                         }
                     }
                 }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
@@ -119,14 +119,7 @@ public class EntityFluidInteraction {
     }
 
     private EntityFluidInteraction.Tracker getTrackerFor(final FluidTag fluid) {
-        for (Entry<FluidTag, EntityFluidInteraction.Tracker> entry : this.trackerByFluid.entrySet()) {
-            FluidTag tagKey = entry.getKey();
-            if (fluid == tagKey) {
-                return entry.getValue();
-            }
-        }
-
-        return null;
+        return this.trackerByFluid.get(fluid);
     }
 
     public void applyCurrentTo(final FluidTag fluid, final GrimPlayer entity, final double scale) {

--- a/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
@@ -26,7 +26,7 @@ public class EntityFluidInteraction {
 
     public void update(final GrimPlayer player, final boolean ignoreCurrent) {
         this.trackerByFluid.values().forEach(EntityFluidInteraction.Tracker::reset);
-        SimpleCollisionBox aabb = player.getFluidInteractionBox();
+        SimpleCollisionBox aabb = player.boundingBox.copy().expand(-0.001);
         if (aabb != null) {
             int minX = GrimMath.floor(aabb.minX);
             int minY = GrimMath.floor(aabb.minY);
@@ -37,9 +37,9 @@ public class EntityFluidInteraction {
             if (hasFluidAndLoaded(player.compensatedWorld, minX - 1, minY, minZ - 1, maxX + 1, maxY, maxZ + 1)) {
                 double aabbMinY = player.boundingBox.minY;
 
-                int playerX = GrimMath.floor(player.x); // lastX?
+                int playerX = GrimMath.floor(player.lastX);
                 double playerEyeY = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
-                int playerZ = GrimMath.floor(player.z); // lastZ?
+                int playerZ = GrimMath.floor(player.lastZ);
 
                 FluidTag fluid = null;
                 EntityFluidInteraction.Tracker tracker = null;
@@ -102,7 +102,8 @@ public class EntityFluidInteraction {
                 for (int y = minY; y <= maxY; y++) {
                     int sectionY = y - (level.getMinHeight() >> 4);
                     if (sectionY >= 0 && sectionY < sections.length) {
-                        hasFluidAndLoaded |= sections[sectionY].hasFluid();
+//                        hasFluidAndLoaded |= sections[sectionY].hasFluid(); // TODO fluid count tracker
+                        hasFluidAndLoaded |= true;
                     }
                 }
             }
@@ -171,6 +172,9 @@ public class EntityFluidInteraction {
                 }
 
                 current = current.multiply(scale);
+                // Store the vector before handling 0.003, so knockback can use it
+                // However, do this after the multiplier, so that we don't have to recompute it
+                player.baseTickAddWaterPushing(current);
                 if (Math.abs(player.clientVelocity.getX()) < 0.003 && Math.abs(player.clientVelocity.getZ()) < 0.003 && current.length() < 0.0045000000000000005) {
                     current = current.normalize().multiply(0.0045000000000000005);
                 }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -482,6 +482,7 @@ public final class PlayerBaseTick {
         }
         double d2 = 0.0;
         boolean hasTouched = false;
+        boolean pushedByFluid = player.isPushedByFluid();
         Vector3dm vec3 = new Vector3dm();
         int n7 = 0;
 
@@ -506,7 +507,7 @@ public final class PlayerBaseTick {
                     hasTouched = true;
                     d2 = Math.max(fluidHeightToWorld - aABB.minY, d2);
 
-                    if (!player.isFlying && !(player.getVehicle() instanceof PacketEntityNautilus)) {
+                    if (pushedByFluid) {
                         Vector3dm vec32 = FluidTypeFlowing.getFlow(player, x, y, z);
                         if (d2 < 0.4) {
                             vec32 = vec32.multiply(d2);

--- a/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -54,8 +54,13 @@ public final class PlayerBaseTick {
             player.trackBaseTickAddition(flyingShift);
         }
 
-        updateInWaterStateAndDoFluidPushing(player);
-        updateFluidOnEyes(player);
+        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_21_11)) {
+            updateInWaterStateAndDoFluidPushing(player);
+            updateFluidOnEyes(player);
+        } else {
+            player.wasEyeInWater = player.fluidInteraction.isEyeInFluid(FluidTag.WATER);
+            updateFluidInteraction(player);
+        }
         updateSwimming(player);
 
         // If in lava, fall distance is multiplied by 0.5
@@ -537,16 +542,28 @@ public final class PlayerBaseTick {
             }
         }
 
-        if (tag == FluidTag.LAVA) {
-            player.slightlyTouchingLava = hasTouched && d2 <= 0.4D;
-        }
-
-        if (tag == FluidTag.WATER) {
-            player.slightlyTouchingWater = hasTouched && d2 <= 0.4D;
-        }
-
         player.fluidHeight.put(tag, d2);
         return hasTouched;
+    }
+
+    private static boolean updateFluidInteraction(GrimPlayer player) {
+        player.fluidInteraction.update(player, !player.isPushedByFluid());
+        boolean inWater = player.fluidInteraction.isInFluid(FluidTag.WATER);
+        boolean inLava = player.fluidInteraction.isInFluid(FluidTag.LAVA);
+
+        player.wasTouchingWater = inWater;
+        if (player.isPushedByFluid()) {
+            if (inWater) {
+                player.fluidInteraction.applyCurrentTo(FluidTag.WATER, player, 0.014);
+            }
+
+            if (inLava) {
+                double scale = player.dimensionType.getAttributes().getOrDefault(EnvironmentAttributes.GAMEPLAY_FAST_LAVA) ? 0.007 : 0.0023333333333333335;
+                player.fluidInteraction.applyCurrentTo(FluidTag.LAVA, player, scale);
+            }
+        }
+
+        return inWater || inLava;
     }
 
     private static boolean suffocatesAt(GrimPlayer player, int x, int z) {

--- a/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -546,19 +546,25 @@ public final class PlayerBaseTick {
         return hasTouched;
     }
 
-    private static boolean updateFluidInteraction(GrimPlayer player) {
+    public static boolean updateFluidInteraction(GrimPlayer player) {
         player.fluidInteraction.update(player, !player.isPushedByFluid());
         boolean inWater = player.fluidInteraction.isInFluid(FluidTag.WATER);
         boolean inLava = player.fluidInteraction.isInFluid(FluidTag.LAVA);
 
+        player.wasWasTouchingWater = player.wasTouchingWater;
         player.wasTouchingWater = inWater;
+        player.wasTouchingLava = inLava;
         if (player.isPushedByFluid()) {
             if (inWater) {
                 player.fluidInteraction.applyCurrentTo(FluidTag.WATER, player, 0.014);
             }
 
             if (inLava) {
-                double scale = player.dimensionType.getAttributes().getOrDefault(EnvironmentAttributes.GAMEPLAY_FAST_LAVA) ? 0.007 : 0.0023333333333333335;
+                final boolean fastLava = SERVER_SUPPORT_ENVIRONMENT_ATTRIBUTES
+                        ? player.dimensionType.getAttributes().getOrDefault(EnvironmentAttributes.GAMEPLAY_FAST_LAVA)
+                        : player.dimensionType.isUltraWarm();
+
+                final double scale = fastLava ? 0.007 : 0.0023333333333333335;
                 player.fluidInteraction.applyCurrentTo(FluidTag.LAVA, player, scale);
             }
         }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -448,7 +448,7 @@ public class MovementTicker {
                 doLavaMove();
 
                 // Lava movement changed in 1.16
-                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16) && player.slightlyTouchingLava) {
+                if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16) && player.getFluidHeight(FluidTag.LAVA) <= 0.4D) {
                     player.clientVelocity = player.clientVelocity.multiply(0.5D, 0.800000011920929D, 0.5D);
                     player.clientVelocity = FluidFallingAdjustedMovement.getFluidFallingAdjustedMovement(player, playerGravity, isFalling, player.clientVelocity);
                 } else {
@@ -492,7 +492,7 @@ public class MovementTicker {
 
         PacketEntity vehicle = player.getVehicle();
         boolean canFloatWhileRidden = EntityTypeTags.CAN_FLOAT_WHILE_RIDDEN.anyOf(vehicle.type);
-        double fluidHeight = player.fluidHeight.getDouble(FluidTag.WATER);
+        double fluidHeight = player.getFluidHeight(FluidTag.WATER);
         if (canFloatWhileRidden && player.inVehicle() && fluidHeight > 0.4) {
             player.clientVelocity.add(0.0, 0.04F, 0.0);
         }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -174,7 +174,11 @@ public class MovementTicker {
         final PacketEntity riding = player.compensatedEntities.self.getRiding();
         // this needs to be looked at for 1.21.2+ (especially when riding entities, as Mojang has changed this logic a few times).
         if (player.getClientVersion() != ClientVersion.V_1_21_4 && (!player.wasTouchingWater && (riding == null || (!riding.isBoat && !riding.isHappyGhast)))) {
-            PlayerBaseTick.updateInWaterStateAndDoWaterCurrentPushing(player);
+            if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_21_11)) {
+                PlayerBaseTick.updateInWaterStateAndDoWaterCurrentPushing(player);
+            } else {
+                PlayerBaseTick.updateFluidInteraction(player);
+            }
         }
 
         if (player.onGround) {

--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineLava.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineLava.java
@@ -2,6 +2,7 @@ package ac.grim.grimac.predictionengine.predictions;
 
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.VectorData;
+import ac.grim.grimac.utils.enums.FluidTag;
 import ac.grim.grimac.utils.math.GrimMath;
 import ac.grim.grimac.utils.math.Vector3dm;
 
@@ -19,7 +20,7 @@ public class PredictionEngineLava extends PredictionEngine {
                 existingVelocities.add(new VectorData(vector.vector.clone().add(0, 0.04f, 0), vector, VectorData.VectorType.Jump));
             }
 
-            if (player.slightlyTouchingLava && player.lastOnGround && !player.onGround) {
+            if (player.getFluidHeight(FluidTag.LAVA) <= 0.4D && player.lastOnGround && !player.onGround) {
                 Vector3dm withJump = vector.vector.clone();
                 super.doJump(player, withJump);
                 existingVelocities.add(new VectorData(withJump, vector, VectorData.VectorType.Jump));

--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
@@ -79,7 +79,7 @@ public class PredictionEngineWater extends PredictionEngine {
                 existingVelocities.add(new VectorData(vector.vector.clone().add(0, 0.04f, 0), vector, VectorData.VectorType.Jump));
             }
 
-            if (player.slightlyTouchingWater && player.lastOnGround && !player.onGround) {
+            if (player.getFluidHeight(FluidTag.WATER) <= 0.4D && player.lastOnGround && !player.onGround) {
                 Vector3dm withJump = vector.vector.clone();
                 super.doJump(player, withJump);
                 existingVelocities.add(new VectorData(withJump, vector, VectorData.VectorType.Jump));

--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngineWater.java
@@ -39,7 +39,7 @@ public class PredictionEngineWater extends PredictionEngine {
         // This stops players from abusing this mechanic while on top of water, which could theoretically allow
         // some form of a new Jesus hack.
         // Anyways, Jesus doesn't make too much sense on 1.13+ clients when swimming is faster
-        if ((player.wasEyeInWater || player.fluidOnEyes == FluidTag.WATER || player.isSwimming || player.wasSwimming) && !player.inVehicle()) {
+        if ((player.wasEyeInWater || player.isEyeInFluid(FluidTag.WATER) || player.isSwimming || player.wasSwimming) && !player.inVehicle()) {
             for (VectorData vector : base) {
                 double lookYAmount = ReachUtils.getLook(player, player.yaw, player.pitch).getY();
                 double scalar = lookYAmount < -0.2 ? 0.085 : 0.06;

--- a/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
@@ -13,7 +13,7 @@ public abstract class TypedPacketEntity {
         this.isMinecart = EntityTypes.isTypeInstanceOf(type, EntityTypes.MINECART_ABSTRACT);
         this.isHorse = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_HORSE);
         // isAgeable really means "is there a baby version of this mob" and is no longer the term used in modern Minecraft
-        this.isAgeable = // armor stands are not included here because it has a separate tag called isSmall, though it does the same thing
+        this.isAgeable = // armor stands are not included here because it has a separate tag called isSmall, though it does the same thing // TODO: check if this is ok?
                 (EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_AGEABLE) && !(EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PARROT) || type == EntityTypes.FROG))
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ZOMBIE)
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN)

--- a/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
@@ -18,9 +18,6 @@ public abstract class TypedPacketEntity {
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ZOMBIE)
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN)
                         || type == EntityTypes.ZOGLIN
-                        || type == EntityTypes.ZOMBIFIED_PIGLIN
-                        || type == EntityTypes.PIGLIN_BRUTE
-                        || type == EntityTypes.PIGLIN
                         || type == EntityTypes.SQUID
                         || type == EntityTypes.GLOW_SQUID;
         this.isAnimal = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_ANIMAL);

--- a/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
@@ -17,7 +17,12 @@ public abstract class TypedPacketEntity {
                 (EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_AGEABLE) && !(EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PARROT) || type == EntityTypes.FROG))
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ZOMBIE)
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN)
-                        || type == EntityTypes.ZOGLIN;
+                        || type == EntityTypes.ZOGLIN
+                        || type == EntityTypes.ZOMBIFIED_PIGLIN
+                        || type == EntityTypes.PIGLIN_BRUTE
+                        || type == EntityTypes.PIGLIN
+                        || type == EntityTypes.SQUID
+                        || type == EntityTypes.GLOW_SQUID;
         this.isAnimal = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_ANIMAL);
         this.isBoat = EntityTypes.isTypeInstanceOf(type, EntityTypes.BOAT);
         this.isHappyGhast = EntityTypes.HAPPY_GHAST.equals(type);

--- a/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/data/packetentity/TypedPacketEntity.java
@@ -13,7 +13,7 @@ public abstract class TypedPacketEntity {
         this.isMinecart = EntityTypes.isTypeInstanceOf(type, EntityTypes.MINECART_ABSTRACT);
         this.isHorse = EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_HORSE);
         // isAgeable really means "is there a baby version of this mob" and is no longer the term used in modern Minecraft
-        this.isAgeable = // armor stands are not included here because it has a separate tag called isSmall, though it does the same thing // TODO: check if this is ok?
+        this.isAgeable = // armor stands are not included here because it has a separate tag called isSmall, though it does the same thing
                 (EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_AGEABLE) && !(EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PARROT) || type == EntityTypes.FROG))
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ZOMBIE)
                         || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN)

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedDashableEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedDashableEntities.java
@@ -11,7 +11,13 @@ public class CompensatedDashableEntities {
     public void tick() {
         if (dashableMap.isEmpty()) return;
         for (DashableEntity dashable : dashableMap.values()) {
+            // TODO: this is wrong, but camels desync af so at least "fix" this mob if cooldown is gone
+            int dashCooldown = dashable.getDashCooldown();
+            boolean wasDashable = dashCooldown > 0;
             dashable.setDashCooldown(Math.max(0, dashable.getDashCooldown() - 1));
+            if (wasDashable && dashable.getDashCooldown() == 0) {
+                dashable.setDashing(false);
+            }
         }
     }
 

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedDashableEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedDashableEntities.java
@@ -12,10 +12,9 @@ public class CompensatedDashableEntities {
         if (dashableMap.isEmpty()) return;
         for (DashableEntity dashable : dashableMap.values()) {
             // TODO: this is wrong, but camels desync af so at least "fix" this mob if cooldown is gone
-            int dashCooldown = dashable.getDashCooldown();
-            boolean wasDashable = dashCooldown > 0;
+            boolean hasCooldown = dashable.getDashCooldown() > 0;
             dashable.setDashCooldown(Math.max(0, dashable.getDashCooldown() - 1));
-            if (wasDashable && dashable.getDashCooldown() == 0) {
+            if (hasCooldown && dashable.getDashCooldown() == 0) {
                 dashable.setDashing(false);
             }
         }

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -255,8 +255,7 @@ public class CompensatedEntities {
             } else if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_16_5)) {
                 id = 15;
             } else {
-                boolean isPiglin = EntityTypes.isTypeInstanceOf(entity.type, EntityTypes.ABSTRACT_PIGLIN) || entity.type == EntityTypes.PIGLIN || entity.type == EntityTypes.ZOMBIFIED_PIGLIN || entity.type == EntityTypes.PIGLIN_BRUTE;
-                id = 16 + (isPiglin ? 1 : 0);
+                id = 16 + (EntityTypes.isTypeInstanceOf(entity.type, EntityTypes.ABSTRACT_PIGLIN) ? 1 : 0);
             }
 
             // 1.14 good

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -356,6 +356,8 @@ public class CompensatedEntities {
             if (entity.type == EntityTypes.PIG) {
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21_5))
                     offset = 1;
+                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1))
+                    offset--;
 
                 EntityData<?> pigSaddle = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (pigSaddle != null) {
@@ -368,6 +370,9 @@ public class CompensatedEntities {
                     rideable.currentBoostTime = 0;
                 }
             } else if (entity instanceof PacketEntityStrider) {
+                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1))
+                    offset--;
+
                 EntityData<?> striderBoost = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (striderBoost != null) {
                     rideable.boostTimeMax = (int) striderBoost.getValue();
@@ -399,6 +404,9 @@ public class CompensatedEntities {
                 } else if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_16_5)) {
                     offset = 1;
                 }
+                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1)) {
+                    offset--;
+                }
 
                 EntityData<?> horseByte = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (horseByte != null) {
@@ -412,7 +420,7 @@ public class CompensatedEntities {
                 // track camel dashing
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20)) {
                     if (entity instanceof PacketEntityCamel camel) {
-                        EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 18);
+                        EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 18 - offset);
                         if (entityData != null) {
                             camel.setDashing((boolean) entityData.getValue());
 
@@ -437,7 +445,12 @@ public class CompensatedEntities {
         }
 
         if (entity instanceof PacketEntityNautilus nautilus) {
-            EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 19);
+            int index = 19;
+            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1)) {
+                index = 20;
+            }
+
+            EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, index);
             if (entityData != null) {
                 nautilus.setDashing((boolean) entityData.getValue());
 

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -356,8 +356,6 @@ public class CompensatedEntities {
             if (entity.type == EntityTypes.PIG) {
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21_5))
                     offset = 1;
-                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1))
-                    offset--;
 
                 EntityData<?> pigSaddle = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (pigSaddle != null) {
@@ -370,9 +368,6 @@ public class CompensatedEntities {
                     rideable.currentBoostTime = 0;
                 }
             } else if (entity instanceof PacketEntityStrider) {
-                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1))
-                    offset--;
-
                 EntityData<?> striderBoost = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (striderBoost != null) {
                     rideable.boostTimeMax = (int) striderBoost.getValue();
@@ -404,9 +399,6 @@ public class CompensatedEntities {
                 } else if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_16_5)) {
                     offset = 1;
                 }
-                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1)) {
-                    offset--;
-                }
 
                 EntityData<?> horseByte = WatchableIndexUtil.getIndex(watchableObjects, 17 - offset);
                 if (horseByte != null) {
@@ -420,7 +412,7 @@ public class CompensatedEntities {
                 // track camel dashing
                 if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20)) {
                     if (entity instanceof PacketEntityCamel camel) {
-                        EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 18 - offset);
+                        EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 18);
                         if (entityData != null) {
                             camel.setDashing((boolean) entityData.getValue());
 
@@ -445,12 +437,7 @@ public class CompensatedEntities {
         }
 
         if (entity instanceof PacketEntityNautilus nautilus) {
-            int index = 19;
-            if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_26_1)) {
-                index = 20;
-            }
-
-            EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, index);
+            EntityData<?> entityData = WatchableIndexUtil.getIndex(watchableObjects, 19);
             if (entityData != null) {
                 nautilus.setDashing((boolean) entityData.getValue());
 

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -255,7 +255,8 @@ public class CompensatedEntities {
             } else if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThanOrEquals(ServerVersion.V_1_16_5)) {
                 id = 15;
             } else {
-                id = 16;
+                boolean isPiglin = EntityTypes.isTypeInstanceOf(entity.type, EntityTypes.ABSTRACT_PIGLIN) || entity.type == EntityTypes.PIGLIN || entity.type == EntityTypes.ZOMBIFIED_PIGLIN || entity.type == EntityTypes.PIGLIN_BRUTE;
+                id = 16 + (isPiglin ? 1 : 0);
             }
 
             // 1.14 good

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockBreakSpeed.java
@@ -153,7 +153,7 @@ public class BlockBreakSpeed {
 
         speedMultiplier *= (float) player.compensatedEntities.self.getAttributeValue(Attributes.BLOCK_BREAK_SPEED);
 
-        if (player.fluidOnEyes == FluidTag.WATER) {
+        if (player.isEyeInFluid(FluidTag.WATER)) {
             if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21) && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
                 speedMultiplier *= (float) player.compensatedEntities.self.getAttributeValue(Attributes.SUBMERGED_MINING_SPEED);
             } else {

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -22,7 +22,7 @@ public final class BoundingBoxSize {
 
     public static float getWidth(GrimPlayer player, PacketEntity packetEntity) {
         float width = getWidthMinusBaby(player, packetEntity);
-        return width * (packetEntity.isBaby ? getBabyScaleFactor(packetEntity) : 1f);
+        return width * (packetEntity.isBaby ? getBabyScaleFactor(player, packetEntity) : 1f);
     }
 
     private static float getWidthMinusBaby(GrimPlayer player, PacketEntity packetEntity) {
@@ -52,7 +52,7 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.CHICKEN || type == EntityTypes.ENDERMITE || type == EntityTypes.SILVERFISH || type == EntityTypes.VEX || type == EntityTypes.TADPOLE) {
             return 0.4f;
         } else if (type == EntityTypes.RABBIT) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.4f : 0.6f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.49F : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.4f : 0.6f;
         } else if (type == EntityTypes.CREAKING || type == EntityTypes.STRIDER || type == EntityTypes.COW || type == EntityTypes.SHEEP || type == EntityTypes.MOOSHROOM || type == EntityTypes.PIG || type == EntityTypes.LLAMA || type == EntityTypes.DOLPHIN || type == EntityTypes.WITHER || type == EntityTypes.TRADER_LLAMA || type == EntityTypes.WARDEN || type == EntityTypes.GOAT) {
             return 0.9f;
         } else if (type == EntityTypes.PHANTOM) {
@@ -188,7 +188,7 @@ public final class BoundingBoxSize {
 
     public static float getHeight(GrimPlayer player, PacketEntity packetEntity) {
         float height = getHeightMinusBaby(player, packetEntity);
-        return height * (packetEntity.isBaby ? getBabyScaleFactor(packetEntity) : 1f);
+        return height * (packetEntity.isBaby ? getBabyScaleFactor(player, packetEntity) : 1f);
     }
 
     public static double getMyRidingOffset(PacketEntity packetEntity) {
@@ -348,7 +348,7 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.PUFFERFISH) {
             return 0.7f;
         } else if (type == EntityTypes.RABBIT) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.5f : 0.7f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.5f : 0.7f;
         } else if (type == EntityTypes.RAVAGER) {
             return 2.2f;
         } else if (type == EntityTypes.SALMON) {
@@ -417,13 +417,15 @@ public final class BoundingBoxSize {
         return 1.95f;
     }
 
-    private static float getBabyScaleFactor(PacketEntity packetEntity) {
+    private static float getBabyScaleFactor(GrimPlayer player, PacketEntity packetEntity) {
         final EntityType type = packetEntity.type;
         if (type == EntityTypes.TURTLE) return 0.3f;
         if (type == EntityTypes.HAPPY_GHAST) return 0.2375f;
         if (type == EntityTypes.DOLPHIN) return 0.65f;
         if (type == EntityTypes.ARMADILLO) return 0.6f;
-        if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CAMEL)) return 0.45f;
+        if (type == EntityTypes.GOAT && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 0.55f;
+        if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CAMEL))
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : 0.45f;
         return 0.5f;
     }
 }

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -28,7 +28,7 @@ public final class BoundingBoxSize {
     private static float getWidthMinusBaby(GrimPlayer player, PacketEntity packetEntity) {
         final EntityType type = packetEntity.type;
         if (type == EntityTypes.AXOLOTL) {
-            return 0.75f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.5f : 0.75f;
         } else if (type == EntityTypes.PANDA) {
             return 1.3f;
         } else if (type == EntityTypes.BAT || type == EntityTypes.PARROT || type == EntityTypes.COD || type == EntityTypes.EVOKER_FANGS || type == EntityTypes.TROPICAL_FISH || type == EntityTypes.FROG || type == EntityTypes.COPPER_GOLEM) {
@@ -111,7 +111,7 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.SPIDER) {
             return 1.4f;
         } else if (type == EntityTypes.SQUID || type == EntityTypes.GLOW_SQUID) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.8f : 0.95f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.5f : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.8f : 0.95f;
         } else if (type == EntityTypes.TURTLE) {
             return 1.2f;
         } else if (type == EntityTypes.ALLAY) {
@@ -128,6 +128,9 @@ public final class BoundingBoxSize {
             return 0.98F;
         } else if (type == EntityTypes.FIREWORK_ROCKET) {
             return 0.25F;
+        } else if ((type == EntityTypes.ZOMBIE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.VILLAGER || type == EntityTypes.ZOMBIE_VILLAGER) &&
+                        player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
+            return 0.49f;
         }
         return 0.6f;
     }
@@ -246,13 +249,13 @@ public final class BoundingBoxSize {
         if (type == EntityTypes.ARMADILLO) {
             return 0.65f;
         } else if (type == EntityTypes.AXOLOTL) {
-            return 0.42f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.25f : 0.42f;
         } else if (type == EntityTypes.BEE || type == EntityTypes.DOLPHIN || type == EntityTypes.ALLAY) {
             return 0.6f;
         } else if (type == EntityTypes.EVOKER_FANGS || type == EntityTypes.VEX) {
             return 0.8f;
         } else if (type == EntityTypes.SQUID || type == EntityTypes.GLOW_SQUID) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.8f : 0.95f;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.63f : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.8f : 0.95f;
         } else if (type == EntityTypes.PARROT || type == EntityTypes.BAT || type == EntityTypes.PIG || type == EntityTypes.SPIDER) {
             return 0.9f;
         } else if (type == EntityTypes.WITHER_SKULL || type == EntityTypes.SHULKER_BULLET) {
@@ -408,11 +411,13 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.FALLING_BLOCK) {
             return 0.98F;
         } else if (type == EntityTypes.VILLAGER && player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) {
-            return 1.8F;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.99f : 1.8F;
         } else if (type == EntityTypes.FIREWORK_ROCKET) {
             return 0.25F;
         } else if (type == EntityTypes.COPPER_GOLEM) {
             return 1.0F;
+        } else if ((EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.ZOMBIE_VILLAGER) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
+            return 0.99f;
         }
         return 1.95f;
     }
@@ -420,13 +425,23 @@ public final class BoundingBoxSize {
     private static float getBabyScaleFactor(GrimPlayer player, PacketEntity packetEntity) {
         final EntityType type = packetEntity.type;
         if (type == EntityTypes.TURTLE) return 0.3f;
-        if (type == EntityTypes.HAPPY_GHAST) return 0.2375f;
-        if (type == EntityTypes.DOLPHIN) return 0.65f;
-        if (type == EntityTypes.ARMADILLO) return 0.6f;
-        if (type == EntityTypes.GOAT && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 0.55f;
-        if (type == EntityTypes.CHICKEN && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 1f; // in 26.1 baby chickens have their own independent size, so we return 1f to make this method do nothing
-        if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CAMEL))
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : 0.45f;
+        else if (type == EntityTypes.HAPPY_GHAST) return 0.2375f;
+        else if (type == EntityTypes.DOLPHIN) return 0.65f;
+        else if (type == EntityTypes.ARMADILLO) return 0.6f;
+        else if (type == EntityTypes.GOAT && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 0.55f;
+        else if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CAMEL)) return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : 0.45f;
+        else if (EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_HORSE) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 0.7f;
+
+        // in 26.1 mojang refactored baby variants, so they have their own independent size, so we return 1f to make this method do nothing
+        else if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && (
+                type == EntityTypes.CHICKEN ||
+                        type == EntityTypes.SQUID ||
+                        type == EntityTypes.GLOW_SQUID ||
+                        type == EntityTypes.AXOLOTL ||
+                        type == EntityTypes.VILLAGER ||
+                        type == EntityTypes.ZOMBIE_VILLAGER
+        )) return 1f;
+
         return 0.5f;
     }
 }

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -50,7 +50,7 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.HAPPY_GHAST) {
             return 4.0f;
         } else if (type == EntityTypes.CHICKEN || type == EntityTypes.ENDERMITE || type == EntityTypes.SILVERFISH || type == EntityTypes.VEX || type == EntityTypes.TADPOLE) {
-            return 0.4f;
+            return type == EntityTypes.CHICKEN && packetEntity.isBaby && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.3f : 0.4f;
         } else if (type == EntityTypes.RABBIT) {
             return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.49F : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.4f : 0.6f;
         } else if (type == EntityTypes.CREAKING || type == EntityTypes.STRIDER || type == EntityTypes.COW || type == EntityTypes.SHEEP || type == EntityTypes.MOOSHROOM || type == EntityTypes.PIG || type == EntityTypes.LLAMA || type == EntityTypes.DOLPHIN || type == EntityTypes.WITHER || type == EntityTypes.TRADER_LLAMA || type == EntityTypes.WARDEN || type == EntityTypes.GOAT) {
@@ -274,7 +274,7 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.FROG) {
             return 0.55f;
         } else if (type == EntityTypes.CHICKEN) {
-            return 0.7f;
+            return packetEntity.isBaby && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.4f : 0.7f;
         } else if (type == EntityTypes.HOGLIN || type == EntityTypes.ZOGLIN) {
             return 1.4f;
         } else if (type == EntityTypes.COW) {
@@ -424,6 +424,7 @@ public final class BoundingBoxSize {
         if (type == EntityTypes.DOLPHIN) return 0.65f;
         if (type == EntityTypes.ARMADILLO) return 0.6f;
         if (type == EntityTypes.GOAT && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 0.55f;
+        if (type == EntityTypes.CHICKEN && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return 1f; // in 26.1 baby chickens have their own independent size, so we return 1f to make this method do nothing
         if (EntityTypes.isTypeInstanceOf(type, EntityTypes.CAMEL))
             return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : 0.45f;
         return 0.5f;

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -129,7 +129,7 @@ public final class BoundingBoxSize {
             return 0.98F;
         } else if (type == EntityTypes.FIREWORK_ROCKET) {
             return 0.25F;
-        } else if ((type == EntityTypes.PIGLIN || type == EntityTypes.ZOMBIFIED_PIGLIN || type == EntityTypes.PIGLIN_BRUTE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.VILLAGER || type == EntityTypes.ZOMBIE_VILLAGER) &&
+        } else if ((EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.VILLAGER || type == EntityTypes.ZOMBIE_VILLAGER) &&
                         player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
             return 0.49f;
         }
@@ -418,7 +418,7 @@ public final class BoundingBoxSize {
             return 0.25F;
         } else if (type == EntityTypes.COPPER_GOLEM) {
             return 1.0F;
-        } else if ((type == EntityTypes.PIGLIN || type == EntityTypes.ZOMBIFIED_PIGLIN || type == EntityTypes.PIGLIN_BRUTE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.ZOMBIE_VILLAGER || type == EntityTypes.VILLAGER) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
+        } else if ((EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.ZOMBIE_VILLAGER || type == EntityTypes.VILLAGER) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
             return 0.99f;
         }
         return 1.95f;
@@ -444,10 +444,7 @@ public final class BoundingBoxSize {
                         type == EntityTypes.ZOMBIE ||
                         type == EntityTypes.VILLAGER ||
                         type == EntityTypes.ZOMBIE_VILLAGER ||
-                        EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) ||
-                        type == EntityTypes.PIGLIN ||
-                        type == EntityTypes.ZOMBIFIED_PIGLIN ||
-                        type == EntityTypes.PIGLIN_BRUTE
+                        EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN)
         )) return 1f;
 
         return 0.5f;

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BoundingBoxSize.java
@@ -52,7 +52,8 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.CHICKEN || type == EntityTypes.ENDERMITE || type == EntityTypes.SILVERFISH || type == EntityTypes.VEX || type == EntityTypes.TADPOLE) {
             return type == EntityTypes.CHICKEN && packetEntity.isBaby && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.3f : 0.4f;
         } else if (type == EntityTypes.RABBIT) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.49F : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.4f : 0.6f;
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return packetEntity.isBaby ? 0.24f : 0.49F;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.4f : 0.6f;
         } else if (type == EntityTypes.CREAKING || type == EntityTypes.STRIDER || type == EntityTypes.COW || type == EntityTypes.SHEEP || type == EntityTypes.MOOSHROOM || type == EntityTypes.PIG || type == EntityTypes.LLAMA || type == EntityTypes.DOLPHIN || type == EntityTypes.WITHER || type == EntityTypes.TRADER_LLAMA || type == EntityTypes.WARDEN || type == EntityTypes.GOAT) {
             return 0.9f;
         } else if (type == EntityTypes.PHANTOM) {
@@ -128,7 +129,7 @@ public final class BoundingBoxSize {
             return 0.98F;
         } else if (type == EntityTypes.FIREWORK_ROCKET) {
             return 0.25F;
-        } else if ((type == EntityTypes.ZOMBIE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.VILLAGER || type == EntityTypes.ZOMBIE_VILLAGER) &&
+        } else if ((type == EntityTypes.PIGLIN || type == EntityTypes.ZOMBIFIED_PIGLIN || type == EntityTypes.PIGLIN_BRUTE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.VILLAGER || type == EntityTypes.ZOMBIE_VILLAGER) &&
                         player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
             return 0.49f;
         }
@@ -351,7 +352,8 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.PUFFERFISH) {
             return 0.7f;
         } else if (type == EntityTypes.RABBIT) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) ? 0.6f : player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.5f : 0.7f;
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1)) return packetEntity.isBaby ? 0.4f : 0.6F;
+            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9) ? 0.5f : 0.7f;
         } else if (type == EntityTypes.RAVAGER) {
             return 2.2f;
         } else if (type == EntityTypes.SALMON) {
@@ -411,12 +413,12 @@ public final class BoundingBoxSize {
         } else if (type == EntityTypes.FALLING_BLOCK) {
             return 0.98F;
         } else if (type == EntityTypes.VILLAGER && player.getClientVersion().isOlderThan(ClientVersion.V_1_9)) {
-            return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby ? 0.99f : 1.8F;
+            return 1.8F;
         } else if (type == EntityTypes.FIREWORK_ROCKET) {
             return 0.25F;
         } else if (type == EntityTypes.COPPER_GOLEM) {
             return 1.0F;
-        } else if ((EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.ZOMBIE_VILLAGER) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
+        } else if ((type == EntityTypes.PIGLIN || type == EntityTypes.ZOMBIFIED_PIGLIN || type == EntityTypes.PIGLIN_BRUTE || EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) || type == EntityTypes.ZOMBIE || type == EntityTypes.ZOMBIE_VILLAGER || type == EntityTypes.VILLAGER) && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1) && packetEntity.isBaby) {
             return 0.99f;
         }
         return 1.95f;
@@ -438,8 +440,14 @@ public final class BoundingBoxSize {
                         type == EntityTypes.SQUID ||
                         type == EntityTypes.GLOW_SQUID ||
                         type == EntityTypes.AXOLOTL ||
+                        type == EntityTypes.RABBIT ||
+                        type == EntityTypes.ZOMBIE ||
                         type == EntityTypes.VILLAGER ||
-                        type == EntityTypes.ZOMBIE_VILLAGER
+                        type == EntityTypes.ZOMBIE_VILLAGER ||
+                        EntityTypes.isTypeInstanceOf(type, EntityTypes.ABSTRACT_PIGLIN) ||
+                        type == EntityTypes.PIGLIN ||
+                        type == EntityTypes.ZOMBIFIED_PIGLIN ||
+                        type == EntityTypes.PIGLIN_BRUTE
         )) return 1f;
 
         return 0.5f;

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "grimac",
   "version": "${version}",
   "name": "GrimAC",
-  "description": "Libre simulation anticheat designed for 1.21 with 1.8-1.21 support, powered by PacketEvents 2.0.",
+  "description": "Libre simulation anticheat designed for 26.1 with 1.8-26.1 support, powered by PacketEvents 2.0.",
   "authors": [
     "GrimAC"
   ],

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -4,7 +4,7 @@ adventure = "4.23.0"
 adventure-platform-bukkit = "4.4.0"
 paper-api = "1.20.6-R0.1-SNAPSHOT"
 cloud = "2.0.0"
-cloud-paper = "2.0.0-beta.14"
+cloud-paper = "2.0.0-beta.15"
 cloud-fabric = "2.0.0-beta.15"
 cloud-processors-requirements = "1.0.0-rc.1"
 


### PR DESCRIPTION
todo:
- [x] fluid collisions (seems ok? i will look at this later)
- [x] fluid count tracker per chunk section (https://github.com/retrooper/packetevents/issues/1476)
- [x] attack/spectate/interact packet support
- [x] baby entity hitboxes
     - [x] chicken
     - [x] rabbit 
     - [x] zombie/skeleton/normal horse
     - [x] squid/glowsquid
     - [x] axolotl
     - [x] zombie/husk/drowned
     - [x] zombified/normal piglin
     - [x] zombie/normal villager
- [x] hitbox/collisionbox for golden dandelion
- [x] entity metadata offsets
- [X] Update Packetevents
  - [x] Official Mappings (Fabric 26.1 Server) support  
- [x] Commands
  - [x] wait for cloud-paper update
  - [x] wait for cloud-fabric update
