### PR TITLE
feat: Fabric 26.1 official namespace support

### DIFF
--- a/buildSrc/src/main/kotlin/grim.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/grim.base-conventions.gradle.kts
@@ -12,6 +12,8 @@ description = rootProject.description
 
 // Java compilation settings
 java {
+    // Cross-platform baseline for shared modules. Version-specific modules can override this
+    // when a newer runtime is required (e.g. Fabric 26.1 targeting Java 25).
     toolchain.languageVersion.set(JavaLanguageVersion.of(21))
     disableAutoTargetJvm()
     withSourcesJar()
@@ -38,6 +40,7 @@ spotless {
 tasks {
     withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
+        // Keep a conservative default bytecode target unless a module overrides it explicitly.
         options.release.set(17)
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,11 +6,15 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
-
-    // Grim API & PacketEvents
     exclusive("https://repo.grim.ac/snapshots") {
         includeGroup("ac.grim.grimac")
+    }
+    // PacketEvents snapshots: same host but not exclusiveContent-locked so mavenLocal() can still resolve
+    maven("https://repo.grim.ac/snapshots") {
+        mavenContent { snapshotsOnly() }
+        content {
+            includeGroup("com.github.retrooper")
+        }
     }
 
     // ViaVersion
@@ -37,6 +41,9 @@ repositories {
     }
 
     mavenCentral()
+
+    // After all remotes: local fallback for PacketEvents 2.12+ until repo.grim.ac hosts matching snapshots
+    mavenLocal()
 }
 
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,13 +6,11 @@ plugins {
 }
 
 repositories {
-    // We still call mavenLocal() conditionally at the top for non-exclusive deps (general fallback)
-    if (BuildConfig.mavenLocalOverride) mavenLocal()
+    mavenLocal()
 
     // Grim API & PacketEvents
     exclusive("https://repo.grim.ac/snapshots") {
         includeGroup("ac.grim.grimac")
-        includeGroup("com.github.retrooper")
     }
 
     // ViaVersion

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -42,8 +42,10 @@ repositories {
 
     mavenCentral()
 
-    // After all remotes: local fallback for PacketEvents 2.12+ until repo.grim.ac hosts matching snapshots
-    mavenLocal()
+    // Optional local fallback: only when explicitly enabled via MAVEN_LOCAL_OVERRIDE.
+    if (BuildConfig.mavenLocalOverride) {
+        mavenLocal()
+    }
 }
 
 

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
@@ -22,11 +22,6 @@ public class PacketEntityAction extends PacketListenerAbstract {
     }
 
     @Override
-    public boolean isPreVia() {
-        return true;
-    }
-
-    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION) {
             WrapperPlayClientEntityAction action = new WrapperPlayClientEntityAction(event);

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerSteer.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerSteer.java
@@ -25,11 +25,6 @@ public class PacketPlayerSteer extends PacketListenerAbstract {
     }
 
     @Override
-    public boolean isPreVia() {
-        return true;
-    }
-
-    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.STEER_VEHICLE) {
             GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerTick.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerTick.java
@@ -16,11 +16,6 @@ public class PacketPlayerTick extends PacketListenerAbstract {
     }
 
     @Override
-    public boolean isPreVia() {
-        return true;
-    }
-
-    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.CLIENT_TICK_END) {
             GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());

--- a/common/src/main/java/ac/grim/grimac/manager/init/load/PacketEventsInit.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/load/PacketEventsInit.java
@@ -28,7 +28,6 @@ public class PacketEventsInit implements LoadableInitable {
         PacketEvents.getAPI().getSettings()
                 .fullStackTrace(true)
                 .kickOnPacketException(true)
-                .preViaInjection(true)
                 .checkForUpdates(false)
                 .reEncodeByDefault(false)
                 .debug(false);

--- a/fabric/README-26.1-dependencies.md
+++ b/fabric/README-26.1-dependencies.md
@@ -1,0 +1,23 @@
+# Fabric 26.1 build dependencies
+
+The Fabric module targets **Minecraft 26.1** with **official** mappings. Some artifacts are **snapshots** or built from source.
+
+## PacketEvents (`com.github.retrooper:packetevents-*:2.12.0-SNAPSHOT`)
+
+- Gradle tries **`https://repo.grim.ac/snapshots`**, then **`mavenLocal()`** last so unpublished versions can be resolved after `publishToMavenLocal` in the PacketEvents tree.
+- Optional: **`./gradlew -PMAVEN_LOCAL_OVERRIDE=true`** also prepends `mavenLocal()` inside `exclusive()` helpers (see `buildSrc/exclusive.kt`) for other modules.
+- To populate local cache only:
+
+  ```bash
+  git clone https://github.com/retrooper/packetevents.git
+  cd packetevents && ./gradlew publishToMavenLocal
+  ```
+
+## cloud-fabric (`org.incendo:cloud-fabric:2.0.0-SNAPSHOT`)
+
+- Resolved from **Sonatype Maven Snapshots** (`central.sonatype.com/repository/maven-snapshots/`) for group `org.incendo`, and/or
+- Publish locally from [cloud-minecraft-modded](https://github.com/Incendo/cloud-minecraft-modded): `./gradlew :cloud-fabric:publishToMavenLocal`, then build Grim with **`-PMAVEN_LOCAL_OVERRIDE=true`**.
+
+## Loader
+
+Use **Fabric Loader 0.18.5+** (see `fabric/gradle.properties` and `libs.versions.toml`).

--- a/fabric/README-26.1-dependencies.md
+++ b/fabric/README-26.1-dependencies.md
@@ -2,10 +2,13 @@
 
 The Fabric module targets **Minecraft 26.1** with **official** mappings. Some artifacts are **snapshots** or built from source.
 
-## PacketEvents (`com.github.retrooper:packetevents-*:2.12.0-SNAPSHOT`)
+## PacketEvents (`com.github.retrooper:packetevents-api:2.12.0+7d7c846-SNAPSHOT`)
 
 - Gradle tries **`https://repo.grim.ac/snapshots`**, then **`mavenLocal()`** last so unpublished versions can be resolved after `publishToMavenLocal` in the PacketEvents tree.
 - Optional: **`./gradlew -PMAVEN_LOCAL_OVERRIDE=true`** also prepends `mavenLocal()` inside `exclusive()` helpers (see `buildSrc/exclusive.kt`) for other modules.
+- Default builds pin exact snapshot coordinates for reproducibility; override behavior is opt-in via local properties/`MAVEN_LOCAL_OVERRIDE`.
+- The Fabric module compiles against `packetevents-api` by default.
+- Full PE Fabric runtime jars are validated via harness scripts in `tests/scripts` so defaults stay stable while local testing remains explicit.
 - To populate local cache only:
 
   ```bash
@@ -13,10 +16,10 @@ The Fabric module targets **Minecraft 26.1** with **official** mappings. Some ar
   cd packetevents && ./gradlew publishToMavenLocal
   ```
 
-## cloud-fabric (`org.incendo:cloud-fabric:2.0.0-SNAPSHOT`)
+## cloud-fabric (`org.incendo:cloud-fabric:2.0.0-20260329.011531-42`)
 
-- Resolved from **Sonatype Maven Snapshots** (`https://central.sonatype.com/repository/maven-snapshots/`) for group `org.incendo`, and/or
-- Publish locally from [cloud-minecraft-modded](https://github.com/Incendo/cloud-minecraft-modded): `./gradlew :cloud-fabric:publishToMavenLocal`, then build Grim with **`-PMAVEN_LOCAL_OVERRIDE=true`**.
+- Resolved from Sonatype snapshots using an exact unique snapshot coordinate.
+- For deterministic local validation, publish your own cloud-fabric build and enable **`-PMAVEN_LOCAL_OVERRIDE=true`**.
 
 ## Loader
 

--- a/fabric/README-26.1-dependencies.md
+++ b/fabric/README-26.1-dependencies.md
@@ -15,7 +15,7 @@ The Fabric module targets **Minecraft 26.1** with **official** mappings. Some ar
 
 ## cloud-fabric (`org.incendo:cloud-fabric:2.0.0-SNAPSHOT`)
 
-- Resolved from **Sonatype Maven Snapshots** (`central.sonatype.com/repository/maven-snapshots/`) for group `org.incendo`, and/or
+- Resolved from **Sonatype Maven Snapshots** (`https://central.sonatype.com/repository/maven-snapshots/`) for group `org.incendo`, and/or
 - Publish locally from [cloud-minecraft-modded](https://github.com/Incendo/cloud-minecraft-modded): `./gradlew :cloud-fabric:publishToMavenLocal`, then build Grim with **`-PMAVEN_LOCAL_OVERRIDE=true`**.
 
 ## Loader

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -14,9 +14,9 @@ dependencies {
 
     compileOnly("me.lucko:fabric-permissions-api:0.7.0")
 
-    // cloud-fabric 2.0.0-SNAPSHOT (26.1 / official mappings): Sonatype snapshots below, or publish
-    // Incendo cloud-minecraft-modded to mavenLocal — see fabric/README-26.1-dependencies.md
-    implementation("org.incendo:cloud-fabric:2.0.0-SNAPSHOT") {
+    // cloud-fabric snapshot for 26.1 is catalog-managed in libs.versions.toml.
+    // Resolve via Sonatype snapshots below or publish cloud-minecraft-modded locally.
+    implementation(libs.cloud.fabric) {
         exclude(group = "net.fabricmc.fabric-api")
         exclude(group = "net.fabricmc", module = "fabric-loader")
     }
@@ -85,11 +85,10 @@ repositories {
 
     mavenCentral()
 
-    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+    exclusive("https://central.sonatype.com/repository/maven-snapshots/", {
         mavenContent { snapshotsOnly() }
-        content {
-            includeGroup("org.incendo")
-        }
+    }) {
+        includeGroup("org.incendo")
     }
 
     // Last: local publish (e.g. ./gradlew publishToMavenLocal in packetevents) when remotes lack the jar
@@ -97,6 +96,8 @@ repositories {
 }
 
 java {
+    // Base conventions keep a lower default for cross-platform compatibility.
+    // Fabric 26.1 runs on Java 25, so this module explicitly targets 25.
     toolchain.languageVersion.set(JavaLanguageVersion.of(25))
 }
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,5 +1,3 @@
-import versioning.BuildConfig
-
 val minecraft_version: String by project
 val fabric_version: String by project
 
@@ -16,7 +14,8 @@ dependencies {
 
     compileOnly("me.lucko:fabric-permissions-api:0.7.0")
 
-    // cloud-fabric from local maven (26.1-compatible build)
+    // cloud-fabric 2.0.0-SNAPSHOT (26.1 / official mappings): Sonatype snapshots below, or publish
+    // Incendo cloud-minecraft-modded to mavenLocal — see fabric/README-26.1-dependencies.md
     implementation("org.incendo:cloud-fabric:2.0.0-SNAPSHOT") {
         exclude(group = "net.fabricmc.fabric-api")
         exclude(group = "net.fabricmc", module = "fabric-loader")
@@ -24,7 +23,7 @@ dependencies {
 
     implementation(libs.fabric.loader)
 
-    // PacketEvents from local maven (26.1-compatible build)
+    // PacketEvents 2.12.x for MC 26.1: repo.grim.ac/snapshots and/or mavenLocal — see README
     implementation("com.github.retrooper:packetevents-fabric:2.12.0-SNAPSHOT") {
         exclude(group = "net.fabricmc.fabric-api")
         exclude(group = "net.fabricmc", module = "fabric-loader")
@@ -41,9 +40,9 @@ dependencies {
     implementation(project(":common"))
 }
 
+// Remote-first resolution; mavenLocal last (or only when MAVEN_LOCAL_OVERRIDE) so CI/dev machines
+// don’t silently pick stale local artifacts. PacketEvents/cloud snapshot sources: README-26.1-dependencies.md
 repositories {
-    mavenLocal()
-
     exclusive("https://maven.fabricmc.net/") {
         includeGroup("net.fabricmc")
         includeGroup("net.fabricmc.fabric-api")
@@ -51,6 +50,12 @@ repositories {
 
     exclusive("https://repo.grim.ac/snapshots") {
         includeGroup("ac.grim.grimac")
+    }
+    maven("https://repo.grim.ac/snapshots") {
+        mavenContent { snapshotsOnly() }
+        content {
+            includeGroup("com.github.retrooper")
+        }
     }
 
     exclusive("https://jitpack.io", { mavenContent { releasesOnly() } }) {
@@ -79,6 +84,16 @@ repositories {
     exclusive(mavenCentral()) { includeGroup("me.lucko") }
 
     mavenCentral()
+
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        mavenContent { snapshotsOnly() }
+        content {
+            includeGroup("org.incendo")
+        }
+    }
+
+    // Last: local publish (e.g. ./gradlew publishToMavenLocal in packetevents) when remotes lack the jar
+    mavenLocal()
 }
 
 java {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,3 +1,5 @@
+import versioning.BuildConfig
+
 val minecraft_version: String by project
 val fabric_version: String by project
 
@@ -91,8 +93,10 @@ repositories {
         includeGroup("org.incendo")
     }
 
-    // Last: local publish (e.g. ./gradlew publishToMavenLocal in packetevents) when remotes lack the jar
-    mavenLocal()
+    // Optional local publish fallback when explicitly enabled via MAVEN_LOCAL_OVERRIDE.
+    if (BuildConfig.mavenLocalOverride) {
+        mavenLocal()
+    }
 }
 
 java {
@@ -110,7 +114,7 @@ loom {
 }
 
 publishing.publications.create<MavenPublication>("maven") {
-    artifact(tasks["jar"])
+    from(components["java"])
 }
 
 tasks {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,7 +1,6 @@
 import versioning.BuildConfig
 
 val minecraft_version: String by project
-val yarn_mappings: String by project
 val fabric_version: String by project
 
 plugins {
@@ -13,129 +12,94 @@ plugins {
 
 dependencies {
     minecraft("com.mojang:minecraft:$minecraft_version")
-    mappings(loom.officialMojangMappings())
-    modImplementation(fabricApi.module("fabric-lifecycle-events-v1", fabric_version))
+    implementation("net.fabricmc.fabric-api:fabric-api:$fabric_version")
 
-    modCompileOnly("me.lucko:fabric-permissions-api:0.3.1")
+    compileOnly("me.lucko:fabric-permissions-api:0.7.0")
 
-    modImplementation(libs.cloud.fabric)
-    modImplementation(libs.fabric.loader)
-    if (BuildConfig.shadePE) {
-        modImplementation(libs.packetevents.fabric)
-    } else {
-        compileOnly(libs.packetevents.fabric)
+    // cloud-fabric from local maven (26.1-compatible build)
+    implementation("org.incendo:cloud-fabric:2.0.0-SNAPSHOT") {
+        exclude(group = "net.fabricmc.fabric-api")
+        exclude(group = "net.fabricmc", module = "fabric-loader")
     }
+
+    implementation(libs.fabric.loader)
+
+    // PacketEvents from local maven (26.1-compatible build)
+    implementation("com.github.retrooper:packetevents-fabric:2.12.0-SNAPSHOT") {
+        exclude(group = "net.fabricmc.fabric-api")
+        exclude(group = "net.fabricmc", module = "fabric-loader")
+    }
+    compileOnly("com.github.retrooper:packetevents-fabric-common:2.12.0-SNAPSHOT")
+    compileOnly("com.github.retrooper:packetevents-fabric-official:2.12.0-SNAPSHOT") {
+        exclude(group = "net.fabricmc.fabric-api")
+        exclude(group = "net.fabricmc", module = "fabric-loader")
+    }
+
     compileOnly("org.slf4j:slf4j-api:2.0.17")
     compileOnly("org.apache.logging.log4j:log4j-api:2.24.3")
 
-    modApi(libs.packetevents.fabric)
+    implementation(project(":common"))
 }
 
-// The configurations below will only apply to :fabric and its submodules, not its siblings or the root project
-allprojects {
-    apply(plugin = "fabric-loom")
-    apply(plugin = "grim.base-conventions")
-    apply(plugin = "maven-publish")
+repositories {
+    mavenLocal()
 
-
-    repositories {
-        // 1. Fallback for non-exclusive deps
-        if (BuildConfig.mavenLocalOverride) mavenLocal()
-
-        // 2. Exclusive Repositories
-        exclusive("https://maven.fabricmc.net/") {
-            includeGroup("net.fabricmc")
-            includeGroup("net.fabricmc.fabric-api")
-        }
-
-        exclusive("https://repo.grim.ac/snapshots") {
-            includeGroup("ac.grim.grimac")
-            includeGroup("com.github.retrooper")
-        }
-
-        exclusive("https://jitpack.io", { mavenContent { releasesOnly() } }) {
-            includeGroup("com.github.Fallen-Breath.conditional-mixin")
-        }
-
-        exclusive("https://repo.viaversion.com", { mavenContent { releasesOnly() } }) {
-            includeGroup("com.viaversion")
-        }
-
-        exclusive("https://nexus.scarsz.me/content/repositories/releases", { mavenContent { releasesOnly() } }) {
-            includeGroup("github.scarsz")
-        }
-
-        exclusive("https://repo.opencollab.dev/maven-releases/", { mavenContent { releasesOnly() } }) {
-            includeGroup("org.geysermc.api")
-        }
-
-        exclusive("https://repo.opencollab.dev/maven-snapshots/", { mavenContent { snapshotsOnly() } }) {
-            includeGroup("org.geysermc.floodgate")
-            includeGroup("org.geysermc.cumulus")
-            includeModule("org.geysermc", "common")
-            includeModule("org.geysermc", "geyser-parent")
-        }
-
-        // Special logic for LuckPerms
-        if (project.name == "mc1161") {
-            exclusive("https://repo.grim.ac/snapshots") { includeGroup("me.lucko") }
-        } else {
-            // Enforce Central for LuckPerms so we don't accidentally check other snapshot repos
-            exclusive(mavenCentral()) { includeGroup("me.lucko") }
-        }
-
-        mavenCentral()
+    exclusive("https://maven.fabricmc.net/") {
+        includeGroup("net.fabricmc")
+        includeGroup("net.fabricmc.fabric-api")
     }
 
-    loom {
-        accessWidenerPath = file("src/main/resources/grimac.accesswidener")
+    exclusive("https://repo.grim.ac/snapshots") {
+        includeGroup("ac.grim.grimac")
     }
 
-    dependencies {
-        // I hate this syntax, is there an alternative to make modCompileOnly(libs.package.name) work?
-        val libsx = rootProject.extensions.getByType<VersionCatalogsExtension>().named("libs")
-        // Use the libs extension from the root project
-        modImplementation(libsx.findLibrary("cloud-fabric").get()) {
-            exclude(group = "net.fabricmc.fabric-api")
-        }
-        modImplementation(libsx.findLibrary("fabric-loader").get())
-
-        implementation(project(":common"))
+    exclusive("https://jitpack.io", { mavenContent { releasesOnly() } }) {
+        includeGroup("com.github.Fallen-Breath.conditional-mixin")
     }
 
-    publishing.publications.create<MavenPublication>("maven") {
-        artifact(tasks["remapJar"])
+    exclusive("https://repo.viaversion.com", { mavenContent { releasesOnly() } }) {
+        includeGroup("com.viaversion")
     }
 
-    tasks {
-        remapJar {
-            archiveBaseName = "${rootProject.name}-fabric${if (project.name != "fabric") "-${project.name}" else ""}"
-            archiveVersion = rootProject.version as String
-        }
-
-        remapSourcesJar {
-            archiveVersion = rootProject.version as String
-        }
+    exclusive("https://nexus.scarsz.me/content/repositories/releases", { mavenContent { releasesOnly() } }) {
+        includeGroup("github.scarsz")
     }
+
+    exclusive("https://repo.opencollab.dev/maven-releases/", { mavenContent { releasesOnly() } }) {
+        includeGroup("org.geysermc.api")
+    }
+
+    exclusive("https://repo.opencollab.dev/maven-snapshots/", { mavenContent { snapshotsOnly() } }) {
+        includeGroup("org.geysermc.floodgate")
+        includeGroup("org.geysermc.cumulus")
+        includeModule("org.geysermc", "common")
+        includeModule("org.geysermc", "geyser-parent")
+    }
+
+    exclusive(mavenCentral()) { includeGroup("me.lucko") }
+
+    mavenCentral()
 }
 
-subprojects {
-    dependencies {
-        // configuration = "namedElements" required when depending on another loom project
-        implementation(project(":fabric", configuration = "namedElements"))
-    }
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
 }
 
-subprojects.forEach {
-    tasks.named("remapJar").configure {
-        dependsOn("${it.path}:remapJar")
-    }
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
 }
 
-tasks.remapJar.configure {
-    subprojects.forEach { subproject ->
-        subproject.tasks.matching { it.name == "remapJar" }.configureEach {
-            nestedJars.from(this)
-        }
+loom {
+    accessWidenerPath = file("src/main/resources/grimac.accesswidener")
+}
+
+publishing.publications.create<MavenPublication>("maven") {
+    artifact(tasks["jar"])
+}
+
+tasks {
+    jar {
+        archiveBaseName.set("${rootProject.name}-fabric")
+        archiveVersion.set(rootProject.version as String)
     }
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -16,8 +16,7 @@ dependencies {
 
     compileOnly("me.lucko:fabric-permissions-api:0.7.0")
 
-    // cloud-fabric snapshot for 26.1 is catalog-managed in libs.versions.toml.
-    // Resolve via Sonatype snapshots below or publish cloud-minecraft-modded locally.
+    // cloud-fabric is catalog-managed and pinned for reproducible builds.
     implementation(libs.cloud.fabric) {
         exclude(group = "net.fabricmc.fabric-api")
         exclude(group = "net.fabricmc", module = "fabric-loader")
@@ -25,16 +24,8 @@ dependencies {
 
     implementation(libs.fabric.loader)
 
-    // PacketEvents 2.12.x for MC 26.1: repo.grim.ac/snapshots and/or mavenLocal — see README
-    implementation("com.github.retrooper:packetevents-fabric:2.12.0-SNAPSHOT") {
-        exclude(group = "net.fabricmc.fabric-api")
-        exclude(group = "net.fabricmc", module = "fabric-loader")
-    }
-    compileOnly("com.github.retrooper:packetevents-fabric-common:2.12.0-SNAPSHOT")
-    compileOnly("com.github.retrooper:packetevents-fabric-official:2.12.0-SNAPSHOT") {
-        exclude(group = "net.fabricmc.fabric-api")
-        exclude(group = "net.fabricmc", module = "fabric-loader")
-    }
+    // Keep default builds reproducible and mapping-agnostic: compile against PE API.
+    compileOnly(libs.packetevents.api)
 
     compileOnly("org.slf4j:slf4j-api:2.0.17")
     compileOnly("org.apache.logging.log4j:log4j-api:2.24.3")
@@ -87,10 +78,11 @@ repositories {
 
     mavenCentral()
 
-    exclusive("https://central.sonatype.com/repository/maven-snapshots/", {
-        mavenContent { snapshotsOnly() }
-    }) {
-        includeGroup("org.incendo")
+    // Non-exclusive Sonatype snapshots repo for exact cloud-fabric snapshot coordinates.
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        content {
+            includeGroup("org.incendo")
+        }
     }
 
     // Optional local publish fallback when explicitly enabled via MAVEN_LOCAL_OVERRIDE.

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=26.1
-loader_version=0.18.4
+loader_version=0.18.5
 
 # Fabric API
 fabric_version=0.144.4+26.1

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -3,9 +3,8 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
-loader_version=0.16.13
+minecraft_version=26.1
+loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.42.0+1.16
+fabric_version=0.144.4+26.1

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/AbstractFabricPlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/AbstractFabricPlatformServer.java
@@ -5,16 +5,18 @@ import ac.grim.grimac.platform.api.sender.Sender;
 import com.mojang.authlib.GameProfile;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.permissions.Permission;
+import net.minecraft.server.permissions.PermissionLevel;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractFabricPlatformServer implements PlatformServer {
 
-    public int getOperatorPermissionLevel() {
-        return GrimACFabricLoaderPlugin.FABRIC_SERVER.getOperatorUserPermissionLevel();
+    public PermissionLevel getOperatorPermissionLevel() {
+        return GrimACFabricLoaderPlugin.FABRIC_SERVER.operatorUserPermissions().level();
     }
 
-    public boolean hasPermission(CommandSourceStack stack, int level) {
-        return stack.hasPermission(level);
+    public boolean hasPermission(CommandSourceStack stack, PermissionLevel level) {
+        return stack.permissions().hasPermission(new Permission.HasCommandLevel(level));
     }
 
     @Override
@@ -36,6 +38,6 @@ public abstract class AbstractFabricPlatformServer implements PlatformServer {
 
     @Nullable
     public GameProfile getProfileByName(String name) {
-        return GrimACFabricLoaderPlugin.FABRIC_SERVER.getProfileCache().get(name);
+        return GrimACFabricLoaderPlugin.FABRIC_SERVER.services().profileResolver().fetchByName(name).orElse(null);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/Fabric1140PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/Fabric1140PlatformServer.java
@@ -16,6 +16,10 @@ public class Fabric1140PlatformServer extends AbstractFabricPlatformServer {
     // TODO (Cross-platform) implement proper bukkit equivalent for getting TPS over time
     @Override
     public double getTPS() {
-        return Math.min(1000.0 / (GrimACFabricLoaderPlugin.FABRIC_SERVER.getAverageTickTimeNanos() / 1_000_000.0), 20.0);
+        long nanos = GrimACFabricLoaderPlugin.FABRIC_SERVER.getAverageTickTimeNanos();
+        if (nanos <= 0) {
+            return 20.0;
+        }
+        return Math.min(1000.0 / (nanos / 1_000_000.0), 20.0);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/Fabric1140PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/Fabric1140PlatformServer.java
@@ -1,0 +1,21 @@
+package ac.grim.grimac.platform.fabric.mc1161;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.AbstractFabricPlatformServer;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import net.minecraft.commands.CommandSourceStack;
+
+public class Fabric1140PlatformServer extends AbstractFabricPlatformServer {
+
+    @Override
+    public void dispatchCommand(Sender sender, String command) {
+        CommandSourceStack commandSource = GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().unwrap(sender);
+        GrimACFabricLoaderPlugin.FABRIC_SERVER.getCommands().performPrefixedCommand(commandSource, command);
+    }
+
+    // TODO (Cross-platform) implement proper bukkit equivalent for getting TPS over time
+    @Override
+    public double getTPS() {
+        return Math.min(1000.0 / (GrimACFabricLoaderPlugin.FABRIC_SERVER.getAverageTickTimeNanos() / 1_000_000.0), 20.0);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/GrimACFabric1161LoaderPlugin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/GrimACFabric1161LoaderPlugin.java
@@ -1,0 +1,51 @@
+package ac.grim.grimac.platform.fabric.mc1161;
+
+import ac.grim.grimac.platform.fabric.AbstractFabricPlatformServer;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.command.FabricPlayerSelectorParser;
+import ac.grim.grimac.platform.fabric.manager.FabricParserDescriptorFactory;
+import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.mc1161.entity.Fabric1161GrimEntity;
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1140ConversionUtil;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1161MessageUtil;
+import ac.grim.grimac.platform.fabric.player.FabricPlatformPlayerFactory;
+import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
+import ac.grim.grimac.platform.fabric.utils.message.IFabricMessageUtil;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+
+public class GrimACFabric1161LoaderPlugin extends GrimACFabricLoaderPlugin {
+
+    public GrimACFabric1161LoaderPlugin() {
+        this(
+            new FabricPlatformPlayerFactory(
+                Fabric1161PlatformPlayer::new,
+                Fabric1161GrimEntity::new,
+                Fabric1161PlatformInventory::new
+            ),
+            new Fabric1140PlatformServer(),
+            new Fabric1161MessageUtil(),
+            new Fabric1140ConversionUtil()
+        );
+    }
+
+    protected GrimACFabric1161LoaderPlugin(
+            FabricPlatformPlayerFactory playerFactory,
+            AbstractFabricPlatformServer platformServer,
+            IFabricMessageUtil fabricMessageUtil,
+            IFabricConversionUtil fabricConversionUtil
+    ) {
+        super(() -> new FabricParserDescriptorFactory(new FabricPlayerSelectorParser<>(Fabric1161PlayerSelectorAdapter::new)),
+            playerFactory,
+            platformServer,
+            fabricMessageUtil,
+            fabricConversionUtil
+        );
+    }
+
+    @Override
+    public ServerVersion getNativeVersion() {
+        return ServerVersion.V_1_16_1;
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/command/Fabric1161PlayerSelectorAdapter.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/command/Fabric1161PlayerSelectorAdapter.java
@@ -1,0 +1,38 @@
+package ac.grim.grimac.platform.fabric.mc1161.command;
+
+import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.platform.api.command.PlayerSelector;
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.sender.FabricSenderFactory;
+import org.incendo.cloud.minecraft.modded.data.SinglePlayerSelector;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class Fabric1161PlayerSelectorAdapter implements PlayerSelector {
+    protected final SinglePlayerSelector fabricSelector;
+
+    public Fabric1161PlayerSelectorAdapter(SinglePlayerSelector fabricSelector) {
+        this.fabricSelector = fabricSelector;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public Sender getSinglePlayer() {
+        return ((FabricSenderFactory) GrimAPI.INSTANCE.getSenderFactory()).wrap(fabricSelector.single().createCommandSourceStack());
+    }
+
+    @Override
+    public Collection<Sender> getPlayers() {
+        return Collections.singletonList(getSinglePlayer()); // Assuming your ServerPlayer can be cast to Player
+    }
+
+    @Override
+    public String inputString() {
+        return fabricSelector.inputString();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/command/Fabric1161PlayerSelectorAdapter.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/command/Fabric1161PlayerSelectorAdapter.java
@@ -28,7 +28,7 @@ public class Fabric1161PlayerSelectorAdapter implements PlayerSelector {
 
     @Override
     public Collection<Sender> getPlayers() {
-        return Collections.singletonList(getSinglePlayer()); // Assuming your ServerPlayer can be cast to Player
+        return Collections.singletonList(getSinglePlayer());
     }
 
     @Override

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/entity/Fabric1161GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/entity/Fabric1161GrimEntity.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.platform.fabric.mc1161.entity;
 import ac.grim.grimac.platform.fabric.entity.AbstractFabricGrimEntity;
 import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
 import ac.grim.grimac.utils.math.Location;
+import ac.grim.grimac.platform.api.world.PlatformWorld;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -17,15 +18,20 @@ public class Fabric1161GrimEntity extends AbstractFabricGrimEntity {
     @Override
     public CompletableFuture<Boolean> teleportAsync(Location location) {
         return FabricFutureUtil.supplySync(() -> {
-            if (entity.level() instanceof ServerLevel) {
-                entity.teleportTo(
-                        location.getX(),
-                        location.getY(),
-                        location.getZ()
-                );
-                return true;
+            if (!(entity.level() instanceof ServerLevel currentLevel)) {
+                return false;
             }
-            return false;
+            PlatformWorld targetWorld = location.getWorld();
+            // 1.16 path only supports same-level teleport in this adapter.
+            if (targetWorld != null && targetWorld != currentLevel) {
+                return false;
+            }
+            entity.teleportTo(
+                    location.getX(),
+                    location.getY(),
+                    location.getZ()
+            );
+            return true;
         });
     }
 

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/entity/Fabric1161GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/entity/Fabric1161GrimEntity.java
@@ -1,0 +1,36 @@
+package ac.grim.grimac.platform.fabric.mc1161.entity;
+
+import ac.grim.grimac.platform.fabric.entity.AbstractFabricGrimEntity;
+import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.math.Location;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+
+public class Fabric1161GrimEntity extends AbstractFabricGrimEntity {
+
+    public Fabric1161GrimEntity(Entity entity) {
+        super(entity);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Location location) {
+        return FabricFutureUtil.supplySync(() -> {
+            if (entity.level() instanceof ServerLevel) {
+                entity.teleportTo(
+                        location.getX(),
+                        location.getY(),
+                        location.getZ()
+                );
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @Override
+    public boolean isDead() {
+        return entity instanceof LivingEntity living ? living.isDeadOrDying() : entity.isRemoved();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
@@ -9,6 +9,8 @@ import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.MenuType;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory {
     public Fabric1161PlatformInventory(AbstractFabricPlatformPlayer player) {
         super(player);
@@ -35,6 +37,7 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
             } else if (this.isPlayerCreative()) {
                 return "CREATIVE";
             }
+            return handler.getClass().getSimpleName();
         }
 
         // should we handle crafters here also??
@@ -57,7 +60,7 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
 
             Identifier registryKey = (Identifier) this.getScreenID(type);
             if (registryKey != null) {
-                return registryKey.getPath();
+                return registryKey.getPath().toUpperCase(Locale.ROOT).replace('.', '_');
             }
 
             return handler.getClass().getSimpleName(); // Default fallback

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
@@ -16,13 +16,9 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
         super(player);
     }
 
-    // TODO
-    // I don't understand why we do this on Bukkit, so I'm replicating the behaviour without high-level understanding of purpose
-    // This method is only used to check if the inventory matches one of the following
-    //     private static final Set<String> SUPPORTED_INVENTORIES = new HashSet<>(
-    //            Arrays.asList("CHEST", "DISPENSER", "DROPPER", "PLAYER", "ENDER_CHEST", "SHULKER_BOX", "BARREL", "CRAFTING", "CREATIVE")
-    //    );
-    // And is slated to be replaced by packet based behaviour, this should do for now
+    // This key is used only for inventory support gating against the canonical
+    // uppercase constants in SUPPORTED_INVENTORIES (e.g. CHEST, SHULKER_BOX).
+    // We therefore normalize all fallback paths to the same uppercase key style.
     @Override
     public String getOpenInventoryKey() {
         AbstractContainerMenu handler = fabricPlatformPlayer.getNative().containerMenu;
@@ -33,11 +29,10 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
             // 4x4 CRAFTING -> CRAFTING
             if (handler instanceof InventoryMenu) {
                 return "CRAFTING";
-                // Not sure if creative mode check here is correct
             } else if (this.isPlayerCreative()) {
                 return "CREATIVE";
             }
-            return handler.getClass().getSimpleName();
+            return normalizeFallbackKey(handler);
         }
 
         // should we handle crafters here also??
@@ -56,15 +51,20 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
         } else {
             // Registry handles:
             // SHULKER_BOX -> SHULKER_BOX
-            // CRAFTIING -> CRAFTING
+            // CRAFTING -> CRAFTING
 
             Identifier registryKey = (Identifier) this.getScreenID(type);
             if (registryKey != null) {
                 return registryKey.getPath().toUpperCase(Locale.ROOT).replace('.', '_');
             }
 
-            return handler.getClass().getSimpleName(); // Default fallback
+            return normalizeFallbackKey(handler); // Default fallback
         }
+    }
+
+    protected String normalizeFallbackKey(AbstractContainerMenu handler) {
+        String simpleName = handler.getClass().getSimpleName().replace('$', '_');
+        return simpleName.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toUpperCase(Locale.ROOT);
     }
 
     // returns Identifier in > 1.21.11, and ResourceLocation in 1.21.10-, which both map to class_2960

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
@@ -1,0 +1,84 @@
+package ac.grim.grimac.platform.fabric.mc1161.player;
+
+import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformInventory;
+import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.InventoryMenu;
+import net.minecraft.world.inventory.MenuType;
+import org.jetbrains.annotations.Nullable;
+
+public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory {
+    public Fabric1161PlatformInventory(AbstractFabricPlatformPlayer player) {
+        super(player);
+    }
+
+    // TODO
+    // I don't understand why we do this on Bukkit, so I'm replicating the behaviour without high-level understanding of purpose
+    // This method is only used to check if the inventory matches one of the following
+    //     private static final Set<String> SUPPORTED_INVENTORIES = new HashSet<>(
+    //            Arrays.asList("CHEST", "DISPENSER", "DROPPER", "PLAYER", "ENDER_CHEST", "SHULKER_BOX", "BARREL", "CRAFTING", "CREATIVE")
+    //    );
+    // And is slated to be replaced by packet based behaviour, this should do for now
+    @Override
+    public String getOpenInventoryKey() {
+        AbstractContainerMenu handler = fabricPlatformPlayer.getNative().containerMenu;
+        MenuType<?> type = getSafeType(handler);
+
+        // Handle null types (player crafting and creative)
+        if (type == null) {
+            // 4x4 CRAFTING -> CRAFTING
+            if (handler instanceof InventoryMenu) {
+                return "CRAFTING";
+                // Not sure if creative mode check here is correct
+            } else if (this.isPlayerCreative()) {
+                return "CREATIVE";
+            }
+        }
+
+        // should we handle crafters here also??
+        // CRAFTING -> CRAFTING
+        if (type == MenuType.CRAFTING) {
+            return "CRAFTING";
+            // PLAYER -> PLAYER
+        } else if (type == MenuType.GENERIC_9x4) {
+            return "PLAYER";
+            // CHEST, ENDER_CHEST, or BARREL -> CHEST
+        } else if (type == MenuType.GENERIC_9x3) {
+            return "CHEST";
+            // DISPENSER, DROPPER -> DISPENSER
+        } else if (type == MenuType.GENERIC_3x3) {
+            return "DISPENSER";
+        } else {
+            // Registry handles:
+            // SHULKER_BOX -> SHULKER_BOX
+            // CRAFTIING -> CRAFTING
+
+            Identifier registryKey = (Identifier) this.getScreenID(type);
+            if (registryKey != null) {
+                return registryKey.getPath();
+            }
+
+            return handler.getClass().getSimpleName(); // Default fallback
+        }
+    }
+
+    // returns Identifier in > 1.21.11, and ResourceLocation in 1.21.10-, which both map to class_2960
+    // Compiler doesn't know that though and throws a fit, thus we make it return Object and cast to class_2960
+    protected Object getScreenID(MenuType<?> type) {
+        return BuiltInRegistries.MENU.getKey(type);
+    }
+
+    protected boolean isPlayerCreative() {
+        return fabricPlatformPlayer.getNative().isCreative();
+    }
+
+    protected @Nullable MenuType<?> getSafeType(AbstractContainerMenu handler) {
+        try {
+            return handler.getType();
+        } catch (UnsupportedOperationException e) {
+            return null;
+        }
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformInventory.java
@@ -35,15 +35,16 @@ public class Fabric1161PlatformInventory extends AbstractFabricPlatformInventory
             return normalizeFallbackKey(handler);
         }
 
-        // should we handle crafters here also??
         // CRAFTING -> CRAFTING
         if (type == MenuType.CRAFTING) {
             return "CRAFTING";
-            // PLAYER -> PLAYER
-        } else if (type == MenuType.GENERIC_9x4) {
-            return "PLAYER";
-            // CHEST, ENDER_CHEST, or BARREL -> CHEST
-        } else if (type == MenuType.GENERIC_9x3) {
+            // Generic chest menus (all row counts) -> CHEST
+        } else if (type == MenuType.GENERIC_9x1
+                || type == MenuType.GENERIC_9x2
+                || type == MenuType.GENERIC_9x3
+                || type == MenuType.GENERIC_9x4
+                || type == MenuType.GENERIC_9x5
+                || type == MenuType.GENERIC_9x6) {
             return "CHEST";
             // DISPENSER, DROPPER -> DISPENSER
         } else if (type == MenuType.GENERIC_3x3) {

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
@@ -1,9 +1,11 @@
 package ac.grim.grimac.platform.fabric.mc1161.player;
 
 import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.api.world.PlatformWorld;
 import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
 import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.math.Location;
 import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
@@ -23,18 +25,38 @@ public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
 
     @Override
     public CompletableFuture<Boolean> teleportAsync(Location location) {
+        PlatformWorld world = location.getWorld();
+        if (world == null || !(world instanceof ServerLevel targetLevel)) {
+            return CompletableFuture.completedFuture(false);
+        }
         return FabricFutureUtil.supplySync(() -> {
-            fabricPlayer.teleportTo(
-                    (ServerLevel) location.getWorld(),
-                    location.getX(),
-                    location.getY(),
-                    location.getZ(),
-                    EnumSet.noneOf(Relative.class),
-                    location.getYaw(),
-                    location.getPitch(),
-                    false
-            );
-            return true;
+            try {
+                fabricPlayer.teleportTo(
+                        targetLevel,
+                        location.getX(),
+                        location.getY(),
+                        location.getZ(),
+                        EnumSet.noneOf(Relative.class),
+                        location.getYaw(),
+                        location.getPitch(),
+                        false
+                );
+                if (fabricPlayer.level() != targetLevel) {
+                    return false;
+                }
+                double epsilon = 1e-3;
+                if (Math.abs(fabricPlayer.getX() - location.getX()) > epsilon
+                        || Math.abs(fabricPlayer.getY() - location.getY()) > epsilon
+                        || Math.abs(fabricPlayer.getZ() - location.getZ()) > epsilon
+                        || Math.abs(fabricPlayer.getYRot() - location.getYaw()) > 0.01f
+                        || Math.abs(fabricPlayer.getXRot() - location.getPitch()) > 0.01f) {
+                    return false;
+                }
+                return true;
+            } catch (Exception e) {
+                LogUtil.warn("teleportAsync failed for " + fabricPlayer.getScoreboardName(), e);
+                return false;
+            }
         });
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
@@ -25,6 +25,9 @@ public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
 
     @Override
     public CompletableFuture<Boolean> teleportAsync(Location location) {
+        if (location == null) {
+            return CompletableFuture.completedFuture(false);
+        }
         PlatformWorld world = location.getWorld();
         if (world == null || !(world instanceof ServerLevel targetLevel)) {
             return CompletableFuture.completedFuture(false);

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
@@ -32,28 +32,33 @@ public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
         if (world == null || !(world instanceof ServerLevel targetLevel)) {
             return CompletableFuture.completedFuture(false);
         }
+        final double targetX = location.getX();
+        final double targetY = location.getY();
+        final double targetZ = location.getZ();
+        final float targetYaw = location.getYaw();
+        final float targetPitch = location.getPitch();
         return FabricFutureUtil.supplySync(() -> {
             try {
                 fabricPlayer.teleportTo(
                         targetLevel,
-                        location.getX(),
-                        location.getY(),
-                        location.getZ(),
+                        targetX,
+                        targetY,
+                        targetZ,
                         EnumSet.noneOf(Relative.class),
-                        location.getYaw(),
-                        location.getPitch(),
+                        targetYaw,
+                        targetPitch,
                         false
                 );
                 if (fabricPlayer.level() != targetLevel) {
                     return false;
                 }
                 double epsilon = 1e-3;
-                float yawDelta = wrappedAngleDelta(fabricPlayer.getYRot(), location.getYaw());
-                if (Math.abs(fabricPlayer.getX() - location.getX()) > epsilon
-                        || Math.abs(fabricPlayer.getY() - location.getY()) > epsilon
-                        || Math.abs(fabricPlayer.getZ() - location.getZ()) > epsilon
+                float yawDelta = wrappedAngleDelta(fabricPlayer.getYRot(), targetYaw);
+                if (Math.abs(fabricPlayer.getX() - targetX) > epsilon
+                        || Math.abs(fabricPlayer.getY() - targetY) > epsilon
+                        || Math.abs(fabricPlayer.getZ() - targetZ) > epsilon
                         || yawDelta > 0.01f
-                        || Math.abs(fabricPlayer.getXRot() - location.getPitch()) > 0.01f) {
+                        || Math.abs(fabricPlayer.getXRot() - targetPitch) > 0.01f) {
                     return false;
                 }
                 return true;

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
@@ -45,10 +45,11 @@ public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
                     return false;
                 }
                 double epsilon = 1e-3;
+                float yawDelta = wrappedAngleDelta(fabricPlayer.getYRot(), location.getYaw());
                 if (Math.abs(fabricPlayer.getX() - location.getX()) > epsilon
                         || Math.abs(fabricPlayer.getY() - location.getY()) > epsilon
                         || Math.abs(fabricPlayer.getZ() - location.getZ()) > epsilon
-                        || Math.abs(fabricPlayer.getYRot() - location.getYaw()) > 0.01f
+                        || yawDelta > 0.01f
                         || Math.abs(fabricPlayer.getXRot() - location.getPitch()) > 0.01f) {
                     return false;
                 }
@@ -58,5 +59,9 @@ public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
                 return false;
             }
         });
+    }
+
+    private static float wrappedAngleDelta(float a, float b) {
+        return Math.abs(((a - b + 540.0f) % 360.0f) - 180.0f);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/player/Fabric1161PlatformPlayer.java
@@ -1,0 +1,40 @@
+package ac.grim.grimac.platform.fabric.mc1161.player;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
+import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.math.Location;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Relative;
+
+public class Fabric1161PlatformPlayer extends AbstractFabricPlatformPlayer {
+    public Fabric1161PlatformPlayer(ServerPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public Sender getSender() {
+        return GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().wrap(fabricPlayer.createCommandSourceStack());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Location location) {
+        return FabricFutureUtil.supplySync(() -> {
+            fabricPlayer.teleportTo(
+                    (ServerLevel) location.getWorld(),
+                    location.getX(),
+                    location.getY(),
+                    location.getZ(),
+                    EnumSet.noneOf(Relative.class),
+                    location.getYaw(),
+                    location.getPitch(),
+                    false
+            );
+            return true;
+        });
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
@@ -1,13 +1,10 @@
 package ac.grim.grimac.platform.fabric.mc1161.util.convert;
 
 import ac.grim.grimac.platform.fabric.utils.convert.FabricItemStackConversion;
+import ac.grim.grimac.platform.fabric.utils.convert.FabricTextConversion;
 import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
-import ac.grim.grimac.utils.anticheat.LogUtil;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
-import com.mojang.serialization.JsonOps;
-import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.Component;
-import net.minecraft.network.chat.ComponentSerialization;
 
 public class Fabric1140ConversionUtil implements IFabricConversionUtil {
     public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
@@ -15,16 +12,6 @@ public class Fabric1140ConversionUtil implements IFabricConversionUtil {
     }
 
     public net.minecraft.network.chat.Component toNativeText(Component component) {
-        try {
-            return ComponentSerialization.CODEC
-                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
-                    .getOrThrow();
-        } catch (RuntimeException e) {
-            LogUtil.error(
-                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
-                            + String.valueOf(component),
-                    e);
-            return net.minecraft.network.chat.Component.literal("");
-        }
+        return FabricTextConversion.parseAdventureToNative(component);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
@@ -1,43 +1,30 @@
 package ac.grim.grimac.platform.fabric.mc1161.util.convert;
 
-import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.utils.convert.FabricItemStackConversion;
 import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
 import ac.grim.grimac.utils.anticheat.LogUtil;
-import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.mojang.serialization.JsonOps;
 import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import net.kyori.adventure.text.Component;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.ComponentSerialization;
 
 public class Fabric1140ConversionUtil implements IFabricConversionUtil {
     public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
-        if (fabricStack.isEmpty()) {
-            return ItemStack.EMPTY;
-        }
-
-        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();
-        try {
-            RegistryAccess registryManager = GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess();
-            RegistryFriendlyByteBuf registryByteBuf = new RegistryFriendlyByteBuf(buffer, registryManager);
-            net.minecraft.world.item.ItemStack.STREAM_CODEC.encode(registryByteBuf, fabricStack);
-            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
-            return wrapper.readItemStack();
-        } catch (Exception e) {
-            LogUtil.error("Failed to encode ItemStack: {}" + fabricStack, e);
-            return ItemStack.EMPTY;
-        } finally {
-            ByteBufHelper.release(buffer);
-        }
+        return FabricItemStackConversion.peItemStackFromNative(fabricStack);
     }
 
     public net.minecraft.network.chat.Component toNativeText(Component component) {
-        return ComponentSerialization.CODEC.parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
-                .getOrThrow();
+        try {
+            return ComponentSerialization.CODEC
+                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                    .getOrThrow();
+        } catch (RuntimeException e) {
+            LogUtil.error(
+                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
+                            + String.valueOf(component),
+                    e);
+            return net.minecraft.network.chat.Component.literal("");
+        }
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1140ConversionUtil.java
@@ -1,0 +1,43 @@
+package ac.grim.grimac.platform.fabric.mc1161.util.convert;
+
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.mojang.serialization.JsonOps;
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import net.kyori.adventure.text.Component;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.ComponentSerialization;
+
+public class Fabric1140ConversionUtil implements IFabricConversionUtil {
+    public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
+        if (fabricStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();
+        try {
+            RegistryAccess registryManager = GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess();
+            RegistryFriendlyByteBuf registryByteBuf = new RegistryFriendlyByteBuf(buffer, registryManager);
+            net.minecraft.world.item.ItemStack.STREAM_CODEC.encode(registryByteBuf, fabricStack);
+            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
+            return wrapper.readItemStack();
+        } catch (Exception e) {
+            LogUtil.error("Failed to encode ItemStack: {}" + fabricStack, e);
+            return ItemStack.EMPTY;
+        } finally {
+            ByteBufHelper.release(buffer);
+        }
+    }
+
+    public net.minecraft.network.chat.Component toNativeText(Component component) {
+        return ComponentSerialization.CODEC.parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                .getOrThrow();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1161MessageUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1161/util/convert/Fabric1161MessageUtil.java
@@ -1,0 +1,17 @@
+package ac.grim.grimac.platform.fabric.mc1161.util.convert;
+
+import ac.grim.grimac.platform.fabric.utils.message.IFabricMessageUtil;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+
+public class Fabric1161MessageUtil implements IFabricMessageUtil {
+    @Override
+    public Component textLiteral(String message) {
+        return Component.literal(message);
+    }
+
+    @Override
+    public void sendMessage(CommandSourceStack target, Component message, boolean overlay) {
+        target.sendSuccess(() -> message, overlay);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
@@ -1,13 +1,5 @@
 package ac.grim.grimac.platform.fabric.mc1171;
 
-import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import ac.grim.grimac.platform.fabric.mc1161.Fabric1140PlatformServer;
-import com.mojang.authlib.GameProfile;
-import org.jetbrains.annotations.Nullable;
 
-public class Fabric1171PlatformServer extends Fabric1140PlatformServer {
-    @Override
-    public @Nullable GameProfile getProfileByName(String name) {
-        return GrimACFabricLoaderPlugin.FABRIC_SERVER.services().profileResolver().fetchByName(name).orElse(null);
-    }
-}
+public class Fabric1171PlatformServer extends Fabric1140PlatformServer {}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
@@ -5,12 +5,9 @@ import ac.grim.grimac.platform.fabric.mc1161.Fabric1140PlatformServer;
 import com.mojang.authlib.GameProfile;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Optional;
-
 public class Fabric1171PlatformServer extends Fabric1140PlatformServer {
     @Override
     public @Nullable GameProfile getProfileByName(String name) {
-        Optional<GameProfile> gameProfile = GrimACFabricLoaderPlugin.FABRIC_SERVER.services().profileResolver().fetchByName(name);
-        return gameProfile.orElse(null);
+        return GrimACFabricLoaderPlugin.FABRIC_SERVER.services().profileResolver().fetchByName(name).orElse(null);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/Fabric1171PlatformServer.java
@@ -1,0 +1,16 @@
+package ac.grim.grimac.platform.fabric.mc1171;
+
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1161.Fabric1140PlatformServer;
+import com.mojang.authlib.GameProfile;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class Fabric1171PlatformServer extends Fabric1140PlatformServer {
+    @Override
+    public @Nullable GameProfile getProfileByName(String name) {
+        Optional<GameProfile> gameProfile = GrimACFabricLoaderPlugin.FABRIC_SERVER.services().profileResolver().fetchByName(name);
+        return gameProfile.orElse(null);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/GrimACFabric1170LoaderPlugin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/GrimACFabric1170LoaderPlugin.java
@@ -1,0 +1,59 @@
+package ac.grim.grimac.platform.fabric.mc1171;
+
+import ac.grim.grimac.platform.fabric.AbstractFabricPlatformServer;
+import ac.grim.grimac.platform.api.manager.CommandAdapter;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.command.FabricPlayerSelectorParser;
+import ac.grim.grimac.platform.fabric.manager.FabricParserDescriptorFactory;
+import ac.grim.grimac.platform.fabric.mc1171.player.Fabric1170PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1161.Fabric1140PlatformServer;
+import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1171.entity.Fabric1170GrimEntity;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1140ConversionUtil;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1161MessageUtil;
+import ac.grim.grimac.platform.fabric.player.FabricPlatformPlayerFactory;
+import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
+import ac.grim.grimac.platform.fabric.utils.message.IFabricMessageUtil;
+import ac.grim.grimac.utils.lazy.LazyHolder;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+
+
+public class GrimACFabric1170LoaderPlugin extends GrimACFabricLoaderPlugin {
+
+    public GrimACFabric1170LoaderPlugin() {
+        this(() -> new FabricParserDescriptorFactory(
+                        new FabricPlayerSelectorParser<>(Fabric1161PlayerSelectorAdapter::new)
+                ),
+                new FabricPlatformPlayerFactory(
+                        Fabric1170PlatformPlayer::new,
+                        Fabric1170GrimEntity::new,
+                        Fabric1161PlatformInventory::new
+                ),
+                PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_17)
+                        ? new Fabric1171PlatformServer() : new Fabric1140PlatformServer(),
+                new Fabric1161MessageUtil(),
+                new Fabric1140ConversionUtil()
+        );
+    }
+
+    protected GrimACFabric1170LoaderPlugin(LazyHolder<CommandAdapter> parserDescriptorFactory,
+                                           FabricPlatformPlayerFactory playerFactory,
+                                           AbstractFabricPlatformServer platformServer,
+                                           IFabricMessageUtil fabricMessageUtil,
+                                           IFabricConversionUtil fabricConversionUtil) {
+        super(
+                parserDescriptorFactory,
+                playerFactory,
+                platformServer,
+                fabricMessageUtil,
+                fabricConversionUtil
+        );
+    }
+
+    @Override
+    public ServerVersion getNativeVersion() {
+        return ServerVersion.V_1_17_1;
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/entity/Fabric1170GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/entity/Fabric1170GrimEntity.java
@@ -1,0 +1,17 @@
+package ac.grim.grimac.platform.fabric.mc1171.entity;
+
+import ac.grim.grimac.platform.fabric.mc1161.entity.Fabric1161GrimEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+
+public class Fabric1170GrimEntity extends Fabric1161GrimEntity {
+
+    public Fabric1170GrimEntity(Entity entity) {
+        super(entity);
+    }
+
+    @Override
+    public boolean isDead() {
+        return this.entity instanceof LivingEntity living ? living.isDeadOrDying() : this.entity.isRemoved();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/entity/Fabric1170GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/entity/Fabric1170GrimEntity.java
@@ -2,16 +2,10 @@ package ac.grim.grimac.platform.fabric.mc1171.entity;
 
 import ac.grim.grimac.platform.fabric.mc1161.entity.Fabric1161GrimEntity;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 
 public class Fabric1170GrimEntity extends Fabric1161GrimEntity {
 
     public Fabric1170GrimEntity(Entity entity) {
         super(entity);
-    }
-
-    @Override
-    public boolean isDead() {
-        return this.entity instanceof LivingEntity living ? living.isDeadOrDying() : this.entity.isRemoved();
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/player/Fabric1170PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1171/player/Fabric1170PlatformPlayer.java
@@ -1,0 +1,17 @@
+package ac.grim.grimac.platform.fabric.mc1171.player;
+
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformPlayer;
+import ac.grim.grimac.platform.fabric.utils.convert.FabricConversionUtil;
+import com.github.retrooper.packetevents.protocol.player.GameMode;
+import net.minecraft.server.level.ServerPlayer;
+
+public class Fabric1170PlatformPlayer extends Fabric1161PlatformPlayer {
+    public Fabric1170PlatformPlayer(ServerPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void setGameMode(GameMode gameMode) {
+        fabricPlayer.setGameMode(FabricConversionUtil.toFabricGameMode(gameMode));
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/Fabric1190PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/Fabric1190PlatformServer.java
@@ -1,0 +1,14 @@
+package ac.grim.grimac.platform.fabric.mc1194;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1171.Fabric1171PlatformServer;
+import net.minecraft.commands.CommandSourceStack;
+
+public class Fabric1190PlatformServer extends Fabric1171PlatformServer {
+    @Override
+    public void dispatchCommand(Sender sender, String command) {
+        CommandSourceStack commandSource = GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().unwrap(sender);
+        GrimACFabricLoaderPlugin.FABRIC_SERVER.getCommands().performPrefixedCommand(commandSource, command);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/GrimACFabric1190LoaderPlugin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/GrimACFabric1190LoaderPlugin.java
@@ -1,0 +1,55 @@
+package ac.grim.grimac.platform.fabric.mc1194;
+
+import ac.grim.grimac.platform.fabric.AbstractFabricPlatformServer;
+import ac.grim.grimac.platform.api.manager.CommandAdapter;
+import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.command.FabricPlayerSelectorParser;
+import ac.grim.grimac.platform.fabric.manager.FabricParserDescriptorFactory;
+import ac.grim.grimac.platform.fabric.mc1171.GrimACFabric1170LoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1171.player.Fabric1170PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1194.convert.Fabric1190MessageUtil;
+import ac.grim.grimac.platform.fabric.mc1194.entity.Fabric1194GrimEntity;
+import ac.grim.grimac.platform.fabric.mc1194.player.Fabric1193PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1140ConversionUtil;
+import ac.grim.grimac.platform.fabric.player.FabricPlatformPlayerFactory;
+import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
+import ac.grim.grimac.platform.fabric.utils.message.IFabricMessageUtil;
+import ac.grim.grimac.utils.lazy.LazyHolder;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+
+
+public class GrimACFabric1190LoaderPlugin extends GrimACFabric1170LoaderPlugin {
+
+    public GrimACFabric1190LoaderPlugin() {
+        this(
+                () -> new FabricParserDescriptorFactory(
+                    new FabricPlayerSelectorParser<>(Fabric1161PlayerSelectorAdapter::new)
+            ),
+            new FabricPlatformPlayerFactory(
+                    Fabric1170PlatformPlayer::new,
+                    Fabric1194GrimEntity::new,
+                    PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_19_2)
+                            ? Fabric1193PlatformInventory::new : Fabric1161PlatformInventory::new
+            ),
+            new Fabric1190PlatformServer(),
+            new Fabric1190MessageUtil(),
+            new Fabric1140ConversionUtil()
+        );
+    }
+
+    protected GrimACFabric1190LoaderPlugin(
+            LazyHolder<CommandAdapter> parserDescriptorFactory,
+            FabricPlatformPlayerFactory platformPlayerFactory,
+            AbstractFabricPlatformServer platformServer,
+            IFabricMessageUtil fabricMessageUtil,
+            IFabricConversionUtil fabricConversionUtil) {
+        super(parserDescriptorFactory, platformPlayerFactory, platformServer, fabricMessageUtil, fabricConversionUtil);
+    }
+
+    @Override
+    public ServerVersion getNativeVersion() {
+        return ServerVersion.V_1_19_4;
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/convert/Fabric1190MessageUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/convert/Fabric1190MessageUtil.java
@@ -1,0 +1,11 @@
+package ac.grim.grimac.platform.fabric.mc1194.convert;
+
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1161MessageUtil;
+import net.minecraft.network.chat.Component;
+
+public class Fabric1190MessageUtil extends Fabric1161MessageUtil {
+    @Override
+    public Component textLiteral(String message) {
+        return Component.literal(message);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/convert/Fabric1190MessageUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/convert/Fabric1190MessageUtil.java
@@ -1,11 +1,6 @@
 package ac.grim.grimac.platform.fabric.mc1194.convert;
 
 import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1161MessageUtil;
-import net.minecraft.network.chat.Component;
 
 public class Fabric1190MessageUtil extends Fabric1161MessageUtil {
-    @Override
-    public Component textLiteral(String message) {
-        return Component.literal(message);
-    }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
@@ -1,8 +1,10 @@
 package ac.grim.grimac.platform.fabric.mc1194.entity;
 
+import ac.grim.grimac.platform.api.world.PlatformWorld;
 import ac.grim.grimac.platform.fabric.mc1171.entity.Fabric1170GrimEntity;
 import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
 import ac.grim.grimac.utils.math.Location;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.server.level.ServerLevel;
@@ -18,20 +20,25 @@ public class Fabric1194GrimEntity extends Fabric1170GrimEntity {
     @Override
     public CompletableFuture<Boolean> teleportAsync(Location location) {
         return FabricFutureUtil.supplySync(() -> {
-            if (entity.level() instanceof ServerLevel) {
-                entity.teleportTo(
-                        (ServerLevel) location.getWorld(),
-                        location.getX(),
-                        location.getY(),
-                        location.getZ(),
-                        EnumSet.noneOf(Relative.class),
-                        location.getYaw(),
-                        location.getPitch(),
-                        false
-                );
-                return true;
+            if (!(entity.level() instanceof ServerLevel)) {
+                return false;
             }
-            return false;
+            PlatformWorld world = location.getWorld();
+            if (world == null || !(world instanceof ServerLevel targetLevel)) {
+                LogUtil.warn("teleportAsync: location world missing or not a ServerLevel");
+                return false;
+            }
+            entity.teleportTo(
+                    targetLevel,
+                    location.getX(),
+                    location.getY(),
+                    location.getZ(),
+                    EnumSet.noneOf(Relative.class),
+                    location.getYaw(),
+                    location.getPitch(),
+                    false
+            );
+            return true;
         });
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
@@ -25,7 +25,7 @@ public class Fabric1194GrimEntity extends Fabric1170GrimEntity {
             }
             PlatformWorld world = location.getWorld();
             if (world == null || !(world instanceof ServerLevel targetLevel)) {
-                LogUtil.warn("teleportAsync: location world missing or not a ServerLevel");
+                LogUtil.info("teleportAsync skipped: location world missing or not a ServerLevel");
                 return false;
             }
             entity.teleportTo(

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/entity/Fabric1194GrimEntity.java
@@ -1,0 +1,37 @@
+package ac.grim.grimac.platform.fabric.mc1194.entity;
+
+import ac.grim.grimac.platform.fabric.mc1171.entity.Fabric1170GrimEntity;
+import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.math.Location;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Relative;
+
+public class Fabric1194GrimEntity extends Fabric1170GrimEntity {
+
+    public Fabric1194GrimEntity(Entity entity) {
+        super(entity);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Location location) {
+        return FabricFutureUtil.supplySync(() -> {
+            if (entity.level() instanceof ServerLevel) {
+                entity.teleportTo(
+                        (ServerLevel) location.getWorld(),
+                        location.getX(),
+                        location.getY(),
+                        location.getZ(),
+                        EnumSet.noneOf(Relative.class),
+                        location.getYaw(),
+                        location.getPitch(),
+                        false
+                );
+                return true;
+            }
+            return false;
+        });
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/player/Fabric1193PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/player/Fabric1193PlatformInventory.java
@@ -1,0 +1,17 @@
+package ac.grim.grimac.platform.fabric.mc1194.player;
+
+import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformInventory;
+import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.inventory.MenuType;
+
+public class Fabric1193PlatformInventory extends Fabric1161PlatformInventory {
+    public Fabric1193PlatformInventory(AbstractFabricPlatformPlayer player) {
+        super(player);
+    }
+
+    @Override
+    protected Object getScreenID(MenuType<?> type) {
+        return BuiltInRegistries.MENU.getKey(type);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/player/Fabric1193PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1194/player/Fabric1193PlatformInventory.java
@@ -2,16 +2,10 @@ package ac.grim.grimac.platform.fabric.mc1194.player;
 
 import ac.grim.grimac.platform.fabric.mc1161.player.Fabric1161PlatformInventory;
 import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.inventory.MenuType;
 
+/** Uses {@link Fabric1161PlatformInventory} registry-based menu key logic (no extra override). */
 public class Fabric1193PlatformInventory extends Fabric1161PlatformInventory {
     public Fabric1193PlatformInventory(AbstractFabricPlatformPlayer player) {
         super(player);
-    }
-
-    @Override
-    protected Object getScreenID(MenuType<?> type) {
-        return BuiltInRegistries.MENU.getKey(type);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
@@ -1,0 +1,22 @@
+package ac.grim.grimac.platform.fabric.mc1205;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1194.Fabric1190PlatformServer;
+import net.minecraft.commands.CommandSourceStack;
+
+public class Fabric1203PlatformServer extends Fabric1190PlatformServer {
+
+    // TODO (Cross-platform) implement proper bukkit equivalent for getting TPS over time
+    @Override
+    public double getTPS() {
+        return Math.min(1000.0 / GrimACFabricLoaderPlugin.FABRIC_SERVER.getCurrentSmoothedTickTime(), GrimACFabricLoaderPlugin.FABRIC_SERVER.tickRateManager().tickrate());
+    }
+
+    // Return type changed from int -> void in 1.20.3
+    @Override
+    public void dispatchCommand(Sender sender, String command) {
+        CommandSourceStack commandSource = GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().unwrap(sender);
+        GrimACFabricLoaderPlugin.FABRIC_SERVER.getCommands().performPrefixedCommand(commandSource, command);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
@@ -1,9 +1,7 @@
 package ac.grim.grimac.platform.fabric.mc1205;
 
-import ac.grim.grimac.platform.api.sender.Sender;
 import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import ac.grim.grimac.platform.fabric.mc1194.Fabric1190PlatformServer;
-import net.minecraft.commands.CommandSourceStack;
 
 public class Fabric1203PlatformServer extends Fabric1190PlatformServer {
 
@@ -18,10 +16,4 @@ public class Fabric1203PlatformServer extends Fabric1190PlatformServer {
         return Math.min(1000.0 / smoothedTickTime, configuredTickRate);
     }
 
-    // Return type changed from int -> void in 1.20.3
-    @Override
-    public void dispatchCommand(Sender sender, String command) {
-        CommandSourceStack commandSource = GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().unwrap(sender);
-        GrimACFabricLoaderPlugin.FABRIC_SERVER.getCommands().performPrefixedCommand(commandSource, command);
-    }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/Fabric1203PlatformServer.java
@@ -10,7 +10,12 @@ public class Fabric1203PlatformServer extends Fabric1190PlatformServer {
     // TODO (Cross-platform) implement proper bukkit equivalent for getting TPS over time
     @Override
     public double getTPS() {
-        return Math.min(1000.0 / GrimACFabricLoaderPlugin.FABRIC_SERVER.getCurrentSmoothedTickTime(), GrimACFabricLoaderPlugin.FABRIC_SERVER.tickRateManager().tickrate());
+        double smoothedTickTime = GrimACFabricLoaderPlugin.FABRIC_SERVER.getCurrentSmoothedTickTime();
+        double configuredTickRate = GrimACFabricLoaderPlugin.FABRIC_SERVER.tickRateManager().tickrate();
+        if (smoothedTickTime <= 0 || Double.isNaN(smoothedTickTime)) {
+            return configuredTickRate;
+        }
+        return Math.min(1000.0 / smoothedTickTime, configuredTickRate);
     }
 
     // Return type changed from int -> void in 1.20.3

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/GrimACFabric1200LoaderPlugin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/GrimACFabric1200LoaderPlugin.java
@@ -1,0 +1,44 @@
+package ac.grim.grimac.platform.fabric.mc1205;
+
+import ac.grim.grimac.platform.fabric.command.FabricPlayerSelectorParser;
+import ac.grim.grimac.platform.fabric.manager.FabricParserDescriptorFactory;
+import ac.grim.grimac.platform.fabric.mc1171.player.Fabric1170PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1194.Fabric1190PlatformServer;
+import ac.grim.grimac.platform.fabric.mc1194.GrimACFabric1190LoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1194.player.Fabric1193PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1200MessageUtil;
+import ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1205ConversionUtil;
+import ac.grim.grimac.platform.fabric.mc1194.entity.Fabric1194GrimEntity;
+import ac.grim.grimac.platform.fabric.mc1205.player.Fabric1202PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.mc1161.util.convert.Fabric1140ConversionUtil;
+import ac.grim.grimac.platform.fabric.player.FabricPlatformPlayerFactory;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+
+public class GrimACFabric1200LoaderPlugin extends GrimACFabric1190LoaderPlugin {
+
+    public GrimACFabric1200LoaderPlugin() {
+        super(
+                () -> new FabricParserDescriptorFactory(
+                        new FabricPlayerSelectorParser<>(Fabric1161PlayerSelectorAdapter::new)
+                ),
+                new FabricPlatformPlayerFactory(
+                        PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_20_1)
+                                ? Fabric1202PlatformPlayer::new : Fabric1170PlatformPlayer::new,
+                        Fabric1194GrimEntity::new,
+                        Fabric1193PlatformInventory::new
+                ),
+                PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_20_2)
+                        ? new Fabric1203PlatformServer() : new Fabric1190PlatformServer(),
+                new Fabric1200MessageUtil(),
+                PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_20_4)
+                        ? new Fabric1205ConversionUtil() : new Fabric1140ConversionUtil()
+        );
+    }
+
+    @Override
+    public ServerVersion getNativeVersion() {
+        return ServerVersion.V_1_20_5;
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1200MessageUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1200MessageUtil.java
@@ -1,0 +1,12 @@
+package ac.grim.grimac.platform.fabric.mc1205.convert;
+
+import ac.grim.grimac.platform.fabric.mc1194.convert.Fabric1190MessageUtil;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+
+public class Fabric1200MessageUtil extends Fabric1190MessageUtil {
+    @Override
+    public void sendMessage(CommandSourceStack target, Component message, boolean overlay) {
+        target.sendSuccess(() -> message, overlay);
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1200MessageUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1200MessageUtil.java
@@ -1,12 +1,6 @@
 package ac.grim.grimac.platform.fabric.mc1205.convert;
 
 import ac.grim.grimac.platform.fabric.mc1194.convert.Fabric1190MessageUtil;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.network.chat.Component;
 
 public class Fabric1200MessageUtil extends Fabric1190MessageUtil {
-    @Override
-    public void sendMessage(CommandSourceStack target, Component message, boolean overlay) {
-        target.sendSuccess(() -> message, overlay);
-    }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
@@ -1,54 +1,34 @@
 package ac.grim.grimac.platform.fabric.mc1205.convert;
 
-import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.utils.convert.FabricItemStackConversion;
 import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
 import ac.grim.grimac.utils.anticheat.LogUtil;
-import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.mojang.serialization.JsonOps;
 import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import net.kyori.adventure.text.Component;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.ComponentSerialization;
 
 public class Fabric1205ConversionUtil implements IFabricConversionUtil {
     public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
-        if (fabricStack.isEmpty()) {
-            return ItemStack.EMPTY;
-        }
-
-        // Allocate a ByteBuf
-        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();
-        try {
-            // Obtain the DynamicRegistryManager (you need to provide this from your context)
-            RegistryAccess registryManager = GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess(); // Replace with actual method to get registry manager
-
-            // Create a RegistryByteBuf
-            RegistryFriendlyByteBuf registryByteBuf = new RegistryFriendlyByteBuf(buffer, registryManager);
-
-            // Encode the ItemStack using the appropriate PacketCodec
-            net.minecraft.world.item.ItemStack.STREAM_CODEC.encode(registryByteBuf, fabricStack);
-
-            // Create a PacketWrapper to read the ItemStack back (if needed)
-            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
-            return wrapper.readItemStack();
-        } catch (Exception e) {
-            // Handle encoding errors
-            LogUtil.error("Failed to encode ItemStack: {}" + fabricStack, e);
-            return ItemStack.EMPTY;
-        } finally {
-            // Release the ByteBuf to prevent memory leaks
-            ByteBufHelper.release(buffer);
-        }
+        return FabricItemStackConversion.peItemStackFromNative(fabricStack);
     }
 
-    // TODO proper registry support?
+    /**
+     * Codec parse uses JsonOps only; registry-heavy component features may be limited until full
+     * registry-backed parse is wired for this path.
+     */
     public net.minecraft.network.chat.Component toNativeText(Component component) {
-        return ComponentSerialization.CODEC.parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
-                .getOrThrow();
+        try {
+            return ComponentSerialization.CODEC
+                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                    .getOrThrow();
+        } catch (RuntimeException e) {
+            LogUtil.error(
+                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
+                            + String.valueOf(component),
+                    e);
+            return net.minecraft.network.chat.Component.literal("");
+        }
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
@@ -1,13 +1,10 @@
 package ac.grim.grimac.platform.fabric.mc1205.convert;
 
 import ac.grim.grimac.platform.fabric.utils.convert.FabricItemStackConversion;
+import ac.grim.grimac.platform.fabric.utils.convert.FabricTextConversion;
 import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
-import ac.grim.grimac.utils.anticheat.LogUtil;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
-import com.mojang.serialization.JsonOps;
-import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.Component;
-import net.minecraft.network.chat.ComponentSerialization;
 
 public class Fabric1205ConversionUtil implements IFabricConversionUtil {
     public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
@@ -19,16 +16,6 @@ public class Fabric1205ConversionUtil implements IFabricConversionUtil {
      * registry-backed parse is wired for this path.
      */
     public net.minecraft.network.chat.Component toNativeText(Component component) {
-        try {
-            return ComponentSerialization.CODEC
-                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
-                    .getOrThrow();
-        } catch (RuntimeException e) {
-            LogUtil.error(
-                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
-                            + String.valueOf(component),
-                    e);
-            return net.minecraft.network.chat.Component.literal("");
-        }
+        return FabricTextConversion.parseAdventureToNative(component);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/convert/Fabric1205ConversionUtil.java
@@ -1,0 +1,54 @@
+package ac.grim.grimac.platform.fabric.mc1205.convert;
+
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.mojang.serialization.JsonOps;
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import net.kyori.adventure.text.Component;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.ComponentSerialization;
+
+public class Fabric1205ConversionUtil implements IFabricConversionUtil {
+    public ItemStack fromFabricItemStack(net.minecraft.world.item.ItemStack fabricStack) {
+        if (fabricStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        // Allocate a ByteBuf
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();
+        try {
+            // Obtain the DynamicRegistryManager (you need to provide this from your context)
+            RegistryAccess registryManager = GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess(); // Replace with actual method to get registry manager
+
+            // Create a RegistryByteBuf
+            RegistryFriendlyByteBuf registryByteBuf = new RegistryFriendlyByteBuf(buffer, registryManager);
+
+            // Encode the ItemStack using the appropriate PacketCodec
+            net.minecraft.world.item.ItemStack.STREAM_CODEC.encode(registryByteBuf, fabricStack);
+
+            // Create a PacketWrapper to read the ItemStack back (if needed)
+            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
+            return wrapper.readItemStack();
+        } catch (Exception e) {
+            // Handle encoding errors
+            LogUtil.error("Failed to encode ItemStack: {}" + fabricStack, e);
+            return ItemStack.EMPTY;
+        } finally {
+            // Release the ByteBuf to prevent memory leaks
+            ByteBufHelper.release(buffer);
+        }
+    }
+
+    // TODO proper registry support?
+    public net.minecraft.network.chat.Component toNativeText(Component component) {
+        return ComponentSerialization.CODEC.parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                .getOrThrow();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/player/Fabric1202PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1205/player/Fabric1202PlatformPlayer.java
@@ -1,0 +1,16 @@
+package ac.grim.grimac.platform.fabric.mc1205.player;
+
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1171.player.Fabric1170PlatformPlayer;
+import net.minecraft.server.level.ServerPlayer;
+
+public class Fabric1202PlatformPlayer extends Fabric1170PlatformPlayer {
+    public Fabric1202PlatformPlayer(ServerPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void kickPlayer(String textReason) {
+        fabricPlayer.connection.disconnect(GrimACFabricLoaderPlugin.LOADER.getFabricMessageUtils().textLiteral(textReason));
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/Fabric12111PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/Fabric12111PlatformServer.java
@@ -1,0 +1,6 @@
+package ac.grim.grimac.platform.fabric.mc1216;
+
+import ac.grim.grimac.platform.fabric.mc1205.Fabric1203PlatformServer;
+
+public class Fabric12111PlatformServer extends Fabric1203PlatformServer {
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/Fabric12111PlatformServer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/Fabric12111PlatformServer.java
@@ -2,5 +2,9 @@ package ac.grim.grimac.platform.fabric.mc1216;
 
 import ac.grim.grimac.platform.fabric.mc1205.Fabric1203PlatformServer;
 
+/**
+ * Intentional marker subclass for 1.21.11 platform selection.
+ * No additional behavior is needed yet; it delegates to Fabric1203PlatformServer.
+ */
 public class Fabric12111PlatformServer extends Fabric1203PlatformServer {
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/GrimACFabric1212LoaderPlugin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/GrimACFabric1212LoaderPlugin.java
@@ -1,0 +1,45 @@
+package ac.grim.grimac.platform.fabric.mc1216;
+
+import ac.grim.grimac.platform.fabric.mc1216.command.Fabric1212PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.command.FabricPlayerSelectorParser;
+import ac.grim.grimac.platform.fabric.manager.FabricParserDescriptorFactory;
+import ac.grim.grimac.platform.fabric.mc1194.GrimACFabric1190LoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1194.entity.Fabric1194GrimEntity;
+import ac.grim.grimac.platform.fabric.mc1194.player.Fabric1193PlatformInventory;
+import ac.grim.grimac.platform.fabric.mc1205.Fabric1203PlatformServer;
+import ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1200MessageUtil;
+import ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1205ConversionUtil;
+import ac.grim.grimac.platform.fabric.mc1216.convert.Fabric1216ConversionUtil;
+import ac.grim.grimac.platform.fabric.mc1216.player.Fabric1212PlatformPlayer;
+import ac.grim.grimac.platform.fabric.mc1216.player.Fabric1215PlatformInventory;
+import ac.grim.grimac.platform.fabric.player.FabricPlatformPlayerFactory;
+import ac.grim.grimac.utils.lazy.LazyHolder;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+
+public class GrimACFabric1212LoaderPlugin extends GrimACFabric1190LoaderPlugin {
+
+    public GrimACFabric1212LoaderPlugin() {
+        super(
+                LazyHolder.simple(() -> new FabricParserDescriptorFactory(
+                        new FabricPlayerSelectorParser<>(Fabric1212PlayerSelectorAdapter::new)
+                )),
+                new FabricPlatformPlayerFactory(
+                        Fabric1212PlatformPlayer::new,
+                        Fabric1194GrimEntity::new,
+                        PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_21_4)
+                            ? Fabric1215PlatformInventory::new : Fabric1193PlatformInventory::new
+                ),
+                PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_21_10) ?
+                        new Fabric12111PlatformServer() : new Fabric1203PlatformServer(),
+                new Fabric1200MessageUtil(),
+                PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_21_5)
+                        ? new Fabric1216ConversionUtil() : new Fabric1205ConversionUtil()
+        );
+    }
+
+    @Override
+    public ServerVersion getNativeVersion() {
+        return ServerVersion.V_1_21_11;
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/command/Fabric1212PlayerSelectorAdapter.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/command/Fabric1212PlayerSelectorAdapter.java
@@ -1,0 +1,19 @@
+package ac.grim.grimac.platform.fabric.mc1216.command;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import org.incendo.cloud.minecraft.modded.data.SinglePlayerSelector;
+
+public class Fabric1212PlayerSelectorAdapter extends Fabric1161PlayerSelectorAdapter {
+
+    public Fabric1212PlayerSelectorAdapter(SinglePlayerSelector fabricSelector) {
+        super(fabricSelector);
+    }
+
+    // 1.21.2 .getCommandSource() moves from entity to player
+    @Override
+    public Sender getSinglePlayer() {
+        return GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().wrap(fabricSelector.single().createCommandSourceStack());
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/command/Fabric1212PlayerSelectorAdapter.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/command/Fabric1212PlayerSelectorAdapter.java
@@ -1,8 +1,9 @@
 package ac.grim.grimac.platform.fabric.mc1216.command;
 
+import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.platform.api.sender.Sender;
-import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import ac.grim.grimac.platform.fabric.mc1161.command.Fabric1161PlayerSelectorAdapter;
+import ac.grim.grimac.platform.fabric.sender.FabricSenderFactory;
 import org.incendo.cloud.minecraft.modded.data.SinglePlayerSelector;
 
 public class Fabric1212PlayerSelectorAdapter extends Fabric1161PlayerSelectorAdapter {
@@ -14,6 +15,6 @@ public class Fabric1212PlayerSelectorAdapter extends Fabric1161PlayerSelectorAda
     // 1.21.2 .getCommandSource() moves from entity to player
     @Override
     public Sender getSinglePlayer() {
-        return GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().wrap(fabricSelector.single().createCommandSourceStack());
+        return ((FabricSenderFactory) GrimAPI.INSTANCE.getSenderFactory()).wrap(fabricSelector.single().createCommandSourceStack());
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
@@ -1,0 +1,18 @@
+package ac.grim.grimac.platform.fabric.mc1216.convert;
+
+import com.mojang.serialization.JsonOps;
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.Component;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.chat.ComponentSerialization;
+
+public class Fabric1216ConversionUtil extends ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1205ConversionUtil {
+
+    @Override
+    public net.minecraft.network.chat.Component toNativeText(Component component) {
+        return ComponentSerialization.CODEC.decode(
+                RegistryAccess.EMPTY.createSerializationContext(JsonOps.INSTANCE),
+                GsonComponentSerializer.gson().serializeToTree(component)
+        ).getOrThrow(IllegalArgumentException::new).getFirst();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
@@ -1,18 +1,26 @@
 package ac.grim.grimac.platform.fabric.mc1216.convert;
 
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 import com.mojang.serialization.JsonOps;
 import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.Component;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.ComponentSerialization;
 
 public class Fabric1216ConversionUtil extends ac.grim.grimac.platform.fabric.mc1205.convert.Fabric1205ConversionUtil {
 
     @Override
     public net.minecraft.network.chat.Component toNativeText(Component component) {
-        return ComponentSerialization.CODEC.decode(
-                RegistryAccess.EMPTY.createSerializationContext(JsonOps.INSTANCE),
-                GsonComponentSerializer.gson().serializeToTree(component)
-        ).getOrThrow(IllegalArgumentException::new).getFirst();
+        try {
+            return ComponentSerialization.CODEC.decode(
+                    GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess().createSerializationContext(JsonOps.INSTANCE),
+                    GsonComponentSerializer.gson().serializeToTree(component)
+            ).getOrThrow(IllegalArgumentException::new).getFirst();
+        } catch (RuntimeException e) {
+            LogUtil.error(
+                    "Failed to decode Adventure Component with server registry context: " + String.valueOf(component),
+                    e);
+            return net.minecraft.network.chat.Component.literal("");
+        }
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/convert/Fabric1216ConversionUtil.java
@@ -20,7 +20,7 @@ public class Fabric1216ConversionUtil extends ac.grim.grimac.platform.fabric.mc1
             LogUtil.error(
                     "Failed to decode Adventure Component with server registry context: " + String.valueOf(component),
                     e);
-            return net.minecraft.network.chat.Component.literal("");
+            return super.toNativeText(component);
         }
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
@@ -1,0 +1,40 @@
+package ac.grim.grimac.platform.fabric.mc1216.player;
+
+import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.platform.fabric.mc1205.player.Fabric1202PlatformPlayer;
+import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.math.Location;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Relative;
+
+public class Fabric1212PlatformPlayer extends Fabric1202PlatformPlayer {
+    public Fabric1212PlatformPlayer(ServerPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public Sender getSender() {
+        return GrimACFabricLoaderPlugin.LOADER.getFabricSenderFactory().wrap(fabricPlayer.createCommandSourceStack());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Location location) {
+        return FabricFutureUtil.supplySync(() -> {
+            fabricPlayer.teleportTo(
+                    (ServerLevel) location.getWorld(),
+                    location.getX(),
+                    location.getY(),
+                    location.getZ(),
+                    EnumSet.noneOf(Relative.class), // todo change to match paper? Do they do this?
+                    location.getYaw(),
+                    location.getPitch(),
+                    true
+            );
+            return true;
+        });
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
@@ -1,9 +1,11 @@
 package ac.grim.grimac.platform.fabric.mc1216.player;
 
 import ac.grim.grimac.platform.api.sender.Sender;
+import ac.grim.grimac.platform.api.world.PlatformWorld;
 import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
 import ac.grim.grimac.platform.fabric.mc1205.player.Fabric1202PlatformPlayer;
 import ac.grim.grimac.platform.fabric.utils.thread.FabricFutureUtil;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.math.Location;
 import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
@@ -23,18 +25,37 @@ public class Fabric1212PlatformPlayer extends Fabric1202PlatformPlayer {
 
     @Override
     public CompletableFuture<Boolean> teleportAsync(Location location) {
+        PlatformWorld world = location.getWorld();
+        if (world == null || !(world instanceof ServerLevel targetLevel)) {
+            return CompletableFuture.completedFuture(false);
+        }
         return FabricFutureUtil.supplySync(() -> {
-            fabricPlayer.teleportTo(
-                    (ServerLevel) location.getWorld(),
-                    location.getX(),
-                    location.getY(),
-                    location.getZ(),
-                    EnumSet.noneOf(Relative.class), // todo change to match paper? Do they do this?
-                    location.getYaw(),
-                    location.getPitch(),
-                    true
-            );
-            return true;
+            try {
+                // MC 1.21.2+: last boolean is the overload that matches server teleport API; differs from
+                // Fabric1161PlatformPlayer (false) due to signature/behavior on older branches.
+                fabricPlayer.teleportTo(
+                        targetLevel,
+                        location.getX(),
+                        location.getY(),
+                        location.getZ(),
+                        EnumSet.noneOf(Relative.class),
+                        location.getYaw(),
+                        location.getPitch(),
+                        true
+                );
+                if (fabricPlayer.level() != targetLevel) {
+                    return false;
+                }
+                double epsilon = 1e-3;
+                return Math.abs(fabricPlayer.getX() - location.getX()) <= epsilon
+                        && Math.abs(fabricPlayer.getY() - location.getY()) <= epsilon
+                        && Math.abs(fabricPlayer.getZ() - location.getZ()) <= epsilon
+                        && Math.abs(fabricPlayer.getYRot() - location.getYaw()) <= 0.01f
+                        && Math.abs(fabricPlayer.getXRot() - location.getPitch()) <= 0.01f;
+            } catch (Exception e) {
+                LogUtil.warn("teleportAsync failed for " + fabricPlayer.getScoreboardName(), e);
+                return false;
+            }
         });
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1212PlatformPlayer.java
@@ -47,15 +47,20 @@ public class Fabric1212PlatformPlayer extends Fabric1202PlatformPlayer {
                     return false;
                 }
                 double epsilon = 1e-3;
+                float yawDelta = wrappedAngleDelta(fabricPlayer.getYRot(), location.getYaw());
                 return Math.abs(fabricPlayer.getX() - location.getX()) <= epsilon
                         && Math.abs(fabricPlayer.getY() - location.getY()) <= epsilon
                         && Math.abs(fabricPlayer.getZ() - location.getZ()) <= epsilon
-                        && Math.abs(fabricPlayer.getYRot() - location.getYaw()) <= 0.01f
+                        && yawDelta <= 0.01f
                         && Math.abs(fabricPlayer.getXRot() - location.getPitch()) <= 0.01f;
             } catch (Exception e) {
                 LogUtil.warn("teleportAsync failed for " + fabricPlayer.getScoreboardName(), e);
                 return false;
             }
         });
+    }
+
+    private static float wrappedAngleDelta(float a, float b) {
+        return Math.abs(((a - b + 540.0f) % 360.0f) - 180.0f);
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1215PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1215PlatformInventory.java
@@ -1,0 +1,22 @@
+package ac.grim.grimac.platform.fabric.mc1216.player;
+
+import ac.grim.grimac.platform.fabric.mc1194.player.Fabric1193PlatformInventory;
+import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.inventory.MenuType;
+
+public class Fabric1215PlatformInventory extends Fabric1193PlatformInventory {
+    public Fabric1215PlatformInventory(AbstractFabricPlatformPlayer player) {
+        super(player);
+    }
+
+    @Override
+    protected Object getScreenID(MenuType<?> type) {
+        return BuiltInRegistries.MENU.getKey(type);
+    }
+
+    @Override
+    protected boolean isPlayerCreative() {
+        return fabricPlatformPlayer.getNative().isCreative();
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1215PlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mc1216/player/Fabric1215PlatformInventory.java
@@ -2,21 +2,9 @@ package ac.grim.grimac.platform.fabric.mc1216.player;
 
 import ac.grim.grimac.platform.fabric.mc1194.player.Fabric1193PlatformInventory;
 import ac.grim.grimac.platform.fabric.player.AbstractFabricPlatformPlayer;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.inventory.MenuType;
 
 public class Fabric1215PlatformInventory extends Fabric1193PlatformInventory {
     public Fabric1215PlatformInventory(AbstractFabricPlatformPlayer player) {
         super(player);
-    }
-
-    @Override
-    protected Object getScreenID(MenuType<?> type) {
-        return BuiltInRegistries.MENU.getKey(type);
-    }
-
-    @Override
-    protected boolean isPlayerCreative() {
-        return fabricPlatformPlayer.getNative().isCreative();
     }
 }

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/mixins/LevelMixin.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/mixins/LevelMixin.java
@@ -32,7 +32,7 @@ abstract class LevelMixin implements LevelAccessor {
     }
 
     public String grimac$getName() {
-        return this.dimension().location().toString();
+        return this.dimension().identifier().toString();
     }
 
     public @Nullable UUID grimac$getUID() {

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
@@ -17,7 +17,7 @@ public abstract class AbstractFabricPlatformInventory implements PlatformInvento
 
     @Override
     public ItemStack getItemInHand() {
-        return fabricConversionUtil.fromFabricItemStack(fabricPlatformPlayer.fabricPlayer.inventory.getSelected());
+        return fabricConversionUtil.fromFabricItemStack(fabricPlatformPlayer.fabricPlayer.inventory.getSelectedItem());
     }
 
     @Override

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformPlayer.java
@@ -72,7 +72,7 @@ public abstract class AbstractFabricPlatformPlayer extends AbstractFabricGrimEnt
         if (CommonGrimArguments.USE_CHAT_FAST_BYPASS.value() && user != null) {
             user.sendMessage(message);
         } else {
-            fabricPlayer.displayClientMessage(GrimACFabricLoaderPlugin.LOADER.getFabricMessageUtils().textLiteral(message), false);
+            fabricPlayer.sendSystemMessage(GrimACFabricLoaderPlugin.LOADER.getFabricMessageUtils().textLiteral(message), false);
         }
     }
 
@@ -81,7 +81,7 @@ public abstract class AbstractFabricPlatformPlayer extends AbstractFabricGrimEnt
         if (CommonGrimArguments.USE_CHAT_FAST_BYPASS.value() && user != null) {
             user.sendMessage(message);
         } else {
-            fabricPlayer.displayClientMessage(GrimACFabricLoaderPlugin.LOADER.getFabricConversionUtil().toNativeText(message), false);
+            fabricPlayer.sendSystemMessage(GrimACFabricLoaderPlugin.LOADER.getFabricConversionUtil().toNativeText(message), false);
         }
     }
 

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/FabricPlatformPlayerFactory.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/FabricPlatformPlayerFactory.java
@@ -110,8 +110,8 @@ public class FabricPlatformPlayerFactory extends AbstractPlatformPlayerFactory<S
     }
 
     public OfflinePlatformPlayer getOfflinePlayer(GameProfile profile) {
-        OfflinePlatformPlayer player = new FabricOfflinePlatformPlayer(profile.getId(), profile.getName());
-        this.offlinePlatformPlayerCache.put(profile.getId(), player);
+        OfflinePlatformPlayer player = new FabricOfflinePlatformPlayer(profile.id(), profile.name());
+        this.offlinePlatformPlayerCache.put(profile.id(), player);
         return player;
     }
 

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricItemStackConversion.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricItemStackConversion.java
@@ -1,0 +1,37 @@
+package ac.grim.grimac.platform.fabric.utils.convert;
+
+import ac.grim.grimac.platform.fabric.GrimACFabricLoaderPlugin;
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+
+/**
+ * Shared native ItemStack → PacketEvents item conversion (STREAM_CODEC + PacketWrapper).
+ */
+public final class FabricItemStackConversion {
+    private FabricItemStackConversion() {}
+
+    public static ItemStack peItemStackFromNative(net.minecraft.world.item.ItemStack fabricStack) {
+        if (fabricStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();
+        try {
+            RegistryAccess registryManager = GrimACFabricLoaderPlugin.FABRIC_SERVER.registryAccess();
+            RegistryFriendlyByteBuf registryByteBuf = new RegistryFriendlyByteBuf(buffer, registryManager);
+            net.minecraft.world.item.ItemStack.STREAM_CODEC.encode(registryByteBuf, fabricStack);
+            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
+            return wrapper.readItemStack();
+        } catch (Exception e) {
+            LogUtil.error("Failed to encode ItemStack: " + fabricStack, e);
+            return ItemStack.EMPTY;
+        } finally {
+            ByteBufHelper.release(buffer);
+        }
+    }
+}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricItemStackConversion.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricItemStackConversion.java
@@ -17,7 +17,7 @@ public final class FabricItemStackConversion {
     private FabricItemStackConversion() {}
 
     public static ItemStack peItemStackFromNative(net.minecraft.world.item.ItemStack fabricStack) {
-        if (fabricStack.isEmpty()) {
+        if (fabricStack == null || fabricStack.isEmpty()) {
             return ItemStack.EMPTY;
         }
         ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer();

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricTextConversion.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricTextConversion.java
@@ -23,28 +23,3 @@ public final class FabricTextConversion {
         }
     }
 }
-package ac.grim.grimac.platform.fabric.utils.convert;
-
-import ac.grim.grimac.utils.anticheat.LogUtil;
-import com.mojang.serialization.JsonOps;
-import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.text.Component;
-import net.minecraft.network.chat.ComponentSerialization;
-
-public final class FabricTextConversion {
-    private FabricTextConversion() {}
-
-    public static net.minecraft.network.chat.Component parseAdventureToNative(Component component) {
-        try {
-            return ComponentSerialization.CODEC
-                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
-                    .getOrThrow();
-        } catch (RuntimeException e) {
-            LogUtil.error(
-                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
-                            + String.valueOf(component),
-                    e);
-            return net.minecraft.network.chat.Component.literal("");
-        }
-    }
-}

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricTextConversion.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/convert/FabricTextConversion.java
@@ -1,0 +1,50 @@
+package ac.grim.grimac.platform.fabric.utils.convert;
+
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.mojang.serialization.JsonOps;
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+
+public final class FabricTextConversion {
+    private FabricTextConversion() {}
+
+    public static net.minecraft.network.chat.Component parseAdventureToNative(Component component) {
+        try {
+            return ComponentSerialization.CODEC
+                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                    .getOrThrow();
+        } catch (RuntimeException e) {
+            LogUtil.error(
+                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
+                            + String.valueOf(component),
+                    e);
+            return net.minecraft.network.chat.Component.literal("");
+        }
+    }
+}
+package ac.grim.grimac.platform.fabric.utils.convert;
+
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.mojang.serialization.JsonOps;
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+
+public final class FabricTextConversion {
+    private FabricTextConversion() {}
+
+    public static net.minecraft.network.chat.Component parseAdventureToNative(Component component) {
+        try {
+            return ComponentSerialization.CODEC
+                    .parse(JsonOps.INSTANCE, GsonComponentSerializer.gson().serializeToTree(component))
+                    .getOrThrow();
+        } catch (RuntimeException e) {
+            LogUtil.error(
+                    "Failed to parse Adventure Component to native (invalid JSON / codec): "
+                            + String.valueOf(component),
+                    e);
+            return net.minecraft.network.chat.Component.literal("");
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -32,9 +32,9 @@
   },
   "accessWidener": "grimac.accesswidener",
   "depends": {
-    "fabricloader": "\u003e\u003d0.18",
+    "fabricloader": "\u003e\u003d0.18.5",
     "fabric-lifecycle-events-v1": "*",
-    "packetevents": "*",
+    "packetevents": ">=2.12.0",
     "minecraft": "\u003e\u003d26.1"
   },
   "recommends": {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -15,6 +15,9 @@
     ],
     "preLaunch": [
       "ac.grim.grimac.platform.fabric.GrimACFabricEntryPoint"
+    ],
+    "grimMainLoad": [
+      "ac.grim.grimac.platform.fabric.mc1216.GrimACFabric1212LoaderPlugin"
     ]
   },
   "mixins": [
@@ -29,9 +32,10 @@
   },
   "accessWidener": "grimac.accesswidener",
   "depends": {
-    "fabricloader": "\u003e\u003d0.16",
+    "fabricloader": "\u003e\u003d0.18",
     "fabric-lifecycle-events-v1": "*",
-    "packetevents": "*"
+    "packetevents": "*",
+    "minecraft": "\u003e\u003d26.1"
   },
   "recommends": {
     "cloud": "*",

--- a/fabric/src/main/resources/grimac.accesswidener
+++ b/fabric/src/main/resources/grimac.accesswidener
@@ -1,4 +1,4 @@
-accessWidener v2 named
+accessWidener v2 official
 accessible field net/minecraft/server/level/ServerLevel serverLevelData Lnet/minecraft/world/level/storage/ServerLevelData;
 accessible field net/minecraft/commands/CommandSourceStack source Lnet/minecraft/commands/CommandSource;
 accessible field net/minecraft/world/entity/player/Player inventory Lnet/minecraft/world/entity/player/Inventory;

--- a/fabric/src/main/resources/grimac.mixins.json
+++ b/fabric/src/main/resources/grimac.mixins.json
@@ -2,7 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "ac.grim.grimac.platform.fabric.mixins",
-    "compatibilityLevel": "JAVA_25",
+    "compatibilityLevel": "JAVA_21",
     "mixins": [
         "LevelChunkMixin",
         "LevelMixin",

--- a/fabric/src/main/resources/grimac.mixins.json
+++ b/fabric/src/main/resources/grimac.mixins.json
@@ -2,7 +2,7 @@
     "required": true,
     "minVersion": "0.8",
     "package": "ac.grim.grimac.platform.fabric.mixins",
-    "compatibilityLevel": "JAVA_17",
+    "compatibilityLevel": "JAVA_25",
     "mixins": [
         "LevelChunkMixin",
         "LevelMixin",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx3072M -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-mavenLocalOverride=true
+# Set true or use -PmavenLocalOverride=true when using unpublished artifacts from mavenLocal() only
+mavenLocalOverride=false

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,6 +12,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
 grim-api = "1.2.4.0"
+# PE 2.12.x required for MC 26.1; Grim snapshot repo; no stable fabric artifact on Maven Central yet
 packetevents = "2.12.0-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.7.1"
@@ -25,7 +26,7 @@ snakeyaml = "2.2"
 configuralize = "1.4.1" # :slim classifier is applied in build.gradle.kts
 
 # --- Build & Tooling ---
-fabric-loader = "0.18.4"
+fabric-loader = "0.18.5"
 fabric-loom = "1.15-SNAPSHOT"
 lombok = "9.0.0"
 shadow = "9.3.0"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -5,7 +5,7 @@ adventure-platform-bukkit = "4.4.0"
 paper-api = "1.20.6-R0.1-SNAPSHOT"
 cloud = "2.0.0"
 cloud-paper = "2.0.0-beta.14"
-cloud-fabric = "2.0.0-beta.15"
+cloud-fabric = "2.0.0-SNAPSHOT"
 cloud-processors-requirements = "1.0.0-rc.1"
 
 # --- Minecraft-Specific APIs ---

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -5,15 +5,16 @@ adventure-platform-bukkit = "4.4.0"
 paper-api = "1.20.6-R0.1-SNAPSHOT"
 cloud = "2.0.0"
 cloud-paper = "2.0.0-beta.14"
-cloud-fabric = "2.0.0-SNAPSHOT"
+# Pin cloud-fabric to an exact unique snapshot for reproducibility.
+cloud-fabric = "2.0.0-20260329.011531-42"
 cloud-processors-requirements = "1.0.0-rc.1"
 
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
 grim-api = "1.2.4.0"
-# PE 2.12.x required for MC 26.1; snapshot is intentional until stable Fabric artifact is published.
-packetevents = "2.12.0-SNAPSHOT"
+# Pin PE to an exact snapshot build for reproducibility.
+packetevents = "2.12.0+7d7c846-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.7.1"
 
@@ -57,6 +58,8 @@ grim-bukkit-internal = { group = "ac.grim.grimac", name = "grim-bukkit-internal"
 grim-fabric-internal = { group = "ac.grim.grimac", name = "grim-fabric-internal", version.ref = "grim-api" }
 packetevents-api = { group = "com.github.retrooper", name = "packetevents-api", version.ref = "packetevents" }
 packetevents-fabric = { group  = "com.github.retrooper", name = "packetevents-fabric", version.ref = "packetevents" }
+packetevents-fabric-common = { group  = "com.github.retrooper", name = "packetevents-fabric-common", version.ref = "packetevents" }
+packetevents-fabric-official = { group  = "com.github.retrooper", name = "packetevents-fabric-official", version.ref = "packetevents" }
 packetevents-spigot = { group = "com.github.retrooper", name = "packetevents-spigot", version.ref = "packetevents"}
 viaversion = { group = "com.viaversion", name = "viaversion", version.ref = "viaversion" }
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,7 +12,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
 grim-api = "1.2.4.0"
-# PE 2.12.x required for MC 26.1; Grim snapshot repo; no stable fabric artifact on Maven Central yet
+# PE 2.12.x required for MC 26.1; snapshot is intentional until stable Fabric artifact is published.
 packetevents = "2.12.0-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.7.1"
@@ -27,6 +27,7 @@ configuralize = "1.4.1" # :slim classifier is applied in build.gradle.kts
 
 # --- Build & Tooling ---
 fabric-loader = "0.18.5"
+# Loom snapshot is intentional for MC 26.1 support until a stable equivalent is validated.
 fabric-loom = "1.15-SNAPSHOT"
 lombok = "9.0.0"
 shadow = "9.3.0"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,7 +12,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
 grim-api = "1.2.4.0"
-packetevents = "2.12.0+70a2380-SNAPSHOT"
+packetevents = "2.12.0-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.7.1"
 
@@ -25,8 +25,8 @@ snakeyaml = "2.2"
 configuralize = "1.4.1" # :slim classifier is applied in build.gradle.kts
 
 # --- Build & Tooling ---
-fabric-loader = "0.16.14"
-fabric-loom = "1.15.5"
+fabric-loader = "0.18.4"
+fabric-loom = "1.15-SNAPSHOT"
 lombok = "9.0.0"
 shadow = "9.3.0"
 spotless = "6.25.0"
@@ -83,7 +83,7 @@ shadow = { "group" = "com.gradleup.shadow", name = "shadow-gradle-plugin", versi
 cloud-api = ["cloud-core", "cloud-processors-requirements"]
 
 [plugins]
-fabric-loom = { id = "fabric-loom", version.ref = "fabric-loom" }
+fabric-loom = { id = "net.fabricmc.fabric-loom", version.ref = "fabric-loom" }
 lombok = { id = "io.freefair.lombok", version.ref = "lombok" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ pluginManagement {
             }
             filter {
                 includeModule("fabric-loom", "fabric-loom.gradle.plugin")
+                includeModule("net.fabricmc.fabric-loom", "net.fabricmc.fabric-loom.gradle.plugin")
                 includeGroupByRegex("net.fabricmc.*")
             }
         }
@@ -64,8 +65,3 @@ rootProject.name = "grimac"
 include("common")
 include("bukkit")
 include("fabric")
-include(":fabric:mc1161")
-include(":fabric:mc1171")
-include(":fabric:mc1194")
-include(":fabric:mc1205")
-include(":fabric:mc12111")

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+runs/
+.cache/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,77 @@
+# Grim + PacketEvents Harness
+
+This harness validates Grim + PacketEvents startup across:
+
+- `grim-pe-official-261` -> MC `26.1` (official PacketEvents path, Java 25)
+- `grim-pe-paper-1206` -> Paper `1.20.6` (older-version Bukkit path)
+- `grim-pe-spigot-1211` -> Spigot `1.21.1` (Bukkit path)
+
+Note: this PR branch targets MC 26.1 only (`minecraft >= 26.1` in mod metadata), so 1.21.x startup is intentionally out of scope here.
+
+## Prerequisites
+
+- `bash`, `curl`, `python3`
+- Java 21+ (and Java 25 for 26.1 official case)
+- PacketEvents repo available locally at `/root/packetevents-grim-restructure` or pass `--packetevents-repo`
+- cloud-fabric published locally once:
+
+```bash
+git clone https://github.com/Incendo/cloud-minecraft-modded.git
+cd cloud-minecraft-modded
+./gradlew :cloud-fabric:publishToMavenLocal
+```
+
+## Run All Cases
+
+From this repository root:
+
+```bash
+./tests/scripts/run-all-grim-pe-harnesses.sh
+```
+
+Run Bukkit-only cases:
+
+```bash
+./tests/scripts/run-all-grim-pe-bukkit-harnesses.sh
+```
+
+Run full stack (Fabric + Bukkit):
+
+```bash
+./tests/scripts/run-all-grim-pe-stack-harnesses.sh
+```
+
+## Individual Cases
+
+Intermediary 1.21.6:
+
+```bash
+./tests/scripts/bootstrap-grim-pe-intermediary-1216.sh
+./tests/scripts/run-server.sh --server-dir tests/runs/grim-pe-1.21.6
+```
+
+Official 26.1:
+
+```bash
+./tests/scripts/bootstrap-grim-pe-official-261.sh
+./tests/scripts/run-server.sh --server-dir tests/runs/grim-pe-26.1 --java-bin /path/to/java25
+```
+
+Bukkit Paper older-version (1.20.6):
+
+```bash
+./tests/scripts/bootstrap-grim-pe-bukkit-paper-1206.sh
+./tests/scripts/run-bukkit-server.sh --server-dir tests/runs/grim-pe-paper-1.20.6
+```
+
+Bukkit Spigot (1.21.1):
+
+```bash
+./tests/scripts/bootstrap-grim-pe-bukkit-spigot-1211.sh
+./tests/scripts/run-bukkit-server.sh --server-dir tests/runs/grim-pe-spigot-1.21.1
+```
+
+## Notes
+
+- Defaults remain pinned for reproducibility (exact PacketEvents snapshot coordinate in `libs.versions.toml`).
+- Local dependency behavior is opt-in via `-PmavenLocalOverride=true`/`MAVEN_LOCAL_OVERRIDE=true`.

--- a/tests/scripts/bootstrap-grim-pe-bukkit-paper-1206.sh
+++ b/tests/scripts/bootstrap-grim-pe-bukkit-paper-1206.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PACKETEVENTS_REPO="${PACKETEVENTS_REPO:-/root/packetevents-grim-restructure}"
+
+cd "${REPO_ROOT}"
+
+echo "[bootstrap:bukkit-paper-1206] Building Grim Bukkit artifact..."
+./gradlew -PmavenLocalOverride=true :bukkit:shadowJar
+
+echo "[bootstrap:bukkit-paper-1206] Building PacketEvents Spigot artifact..."
+./gradlew -p "${PACKETEVENTS_REPO}" :spigot:build
+
+echo "[bootstrap:bukkit-paper-1206] Setting up Paper server (1.20.6)..."
+"${SCRIPT_DIR}/setup-paper-server.sh" \
+  --mc-version 1.20.6 \
+  --server-dir tests/runs/grim-pe-paper-1.20.6
+
+echo "[bootstrap:bukkit-paper-1206] Installing Grim + PacketEvents plugins..."
+"${SCRIPT_DIR}/install-grim-pe-bukkit-jars.sh" \
+  --server-dir tests/runs/grim-pe-paper-1.20.6 \
+  --packetevents-repo "${PACKETEVENTS_REPO}"
+
+echo
+echo "[bootstrap:bukkit-paper-1206] Ready."

--- a/tests/scripts/bootstrap-grim-pe-bukkit-spigot-1211.sh
+++ b/tests/scripts/bootstrap-grim-pe-bukkit-spigot-1211.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PACKETEVENTS_REPO="${PACKETEVENTS_REPO:-/root/packetevents-grim-restructure}"
+
+cd "${REPO_ROOT}"
+
+echo "[bootstrap:bukkit-spigot-1211] Building Grim Bukkit artifact..."
+./gradlew -PmavenLocalOverride=true :bukkit:shadowJar
+
+echo "[bootstrap:bukkit-spigot-1211] Building PacketEvents Spigot artifact..."
+./gradlew -p "${PACKETEVENTS_REPO}" :spigot:build
+
+echo "[bootstrap:bukkit-spigot-1211] Setting up Spigot server (1.21.1)..."
+"${SCRIPT_DIR}/setup-spigot-server.sh" \
+  --mc-version 1.21.1 \
+  --server-dir tests/runs/grim-pe-spigot-1.21.1
+
+echo "[bootstrap:bukkit-spigot-1211] Installing Grim + PacketEvents plugins..."
+"${SCRIPT_DIR}/install-grim-pe-bukkit-jars.sh" \
+  --server-dir tests/runs/grim-pe-spigot-1.21.1 \
+  --packetevents-repo "${PACKETEVENTS_REPO}"
+
+echo
+echo "[bootstrap:bukkit-spigot-1211] Ready."

--- a/tests/scripts/bootstrap-grim-pe-case.sh
+++ b/tests/scripts/bootstrap-grim-pe-case.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CASE_NAME=""
+MC_VERSION=""
+SERVER_DIR=""
+PROFILE=""
+PACKETEVENTS_REPO="/root/packetevents-grim-restructure"
+JAVA25_HOME="${JAVA25_HOME:-/root/.gradle/jdks/eclipse_adoptium-25-amd64-linux.2}"
+SKIP_CLEAN="${SKIP_CLEAN:-false}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --case)
+      CASE_NAME="${2:?missing value for --case}"
+      shift 2
+      ;;
+    --mc-version)
+      MC_VERSION="${2:?missing value for --mc-version}"
+      shift 2
+      ;;
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    --packetevents-repo)
+      PACKETEVENTS_REPO="${2:?missing value for --packetevents-repo}"
+      shift 2
+      ;;
+    --java25-home)
+      JAVA25_HOME="${2:?missing value for --java25-home}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 --case name --mc-version 26.1 --server-dir tests/runs/name --profile official-261|intermediary-1216 [--packetevents-repo /root/packetevents-grim-restructure]"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${CASE_NAME}" || -z "${MC_VERSION}" || -z "${SERVER_DIR}" || -z "${PROFILE}" ]]; then
+  echo "Missing required args."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+echo "[bootstrap:${CASE_NAME}] Building Grim fabric artifact (local override enabled)..."
+./gradlew -PmavenLocalOverride=true :fabric:jar
+
+echo "[bootstrap:${CASE_NAME}] Building PacketEvents fabric artifacts..."
+clean_arg=()
+if [[ "${SKIP_CLEAN}" != "true" ]]; then
+  clean_arg=("clean")
+fi
+case "${PROFILE}" in
+  official-261)
+    ./gradlew -p "${PACKETEVENTS_REPO}" -Dorg.gradle.java.home="${JAVA25_HOME}" "${clean_arg[@]}" :fabric:build :fabric-common:build :fabric-official:build
+    ;;
+  intermediary-1216)
+    ./gradlew -p "${PACKETEVENTS_REPO}" "${clean_arg[@]}" :fabric:build :fabric-intermediary:build
+    ;;
+  *)
+    echo "[bootstrap:${CASE_NAME}] Unknown profile: ${PROFILE}" >&2
+    exit 1
+    ;;
+esac
+
+echo "[bootstrap:${CASE_NAME}] Setting up Fabric server ${MC_VERSION}..."
+"${SCRIPT_DIR}/setup-fabric-server.sh" \
+  --mc-version "${MC_VERSION}" \
+  --server-dir "${SERVER_DIR}"
+
+echo "[bootstrap:${CASE_NAME}] Installing Grim + PacketEvents jars (${PROFILE})..."
+"${SCRIPT_DIR}/install-grim-pe-jars.sh" \
+  --server-dir "${SERVER_DIR}" \
+  --packetevents-repo "${PACKETEVENTS_REPO}" \
+  --profile "${PROFILE}"
+
+echo
+echo "[bootstrap:${CASE_NAME}] Ready."

--- a/tests/scripts/bootstrap-grim-pe-intermediary-1216.sh
+++ b/tests/scripts/bootstrap-grim-pe-intermediary-1216.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/bootstrap-grim-pe-case.sh" \
+  --case grim-pe-intermediary-1216 \
+  --mc-version 1.21.6 \
+  --server-dir tests/runs/grim-pe-1.21.6 \
+  --profile intermediary-1216 \
+  "$@"

--- a/tests/scripts/bootstrap-grim-pe-official-261.sh
+++ b/tests/scripts/bootstrap-grim-pe-official-261.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/bootstrap-grim-pe-case.sh" \
+  --case grim-pe-official-261 \
+  --mc-version 26.1 \
+  --server-dir tests/runs/grim-pe-26.1 \
+  --profile official-261 \
+  "$@"

--- a/tests/scripts/install-grim-pe-bukkit-jars.sh
+++ b/tests/scripts/install-grim-pe-bukkit-jars.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="tests/runs/grim-pe-paper-1.20.6"
+PACKETEVENTS_REPO="/root/packetevents-grim-restructure"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --packetevents-repo)
+      PACKETEVENTS_REPO="${2:?missing value for --packetevents-repo}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--server-dir tests/runs/grim-pe-paper-1.20.6] [--packetevents-repo /root/packetevents-grim-restructure]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PLUGINS_DIR="${REPO_ROOT}/${SERVER_DIR}/plugins"
+GRIM_LIBS="${REPO_ROOT}/bukkit/build/libs"
+PE_LIBS="${PACKETEVENTS_REPO}/build/libs"
+
+mkdir -p "${PLUGINS_DIR}"
+
+latest_non_doc_jar() {
+  local dir="$1"
+  local pattern="$2"
+  local newest=""
+  shopt -s nullglob
+  local files=( "${dir}"/${pattern} )
+  shopt -u nullglob
+  local f
+  for f in "${files[@]}"; do
+    [[ -e "${f}" ]] || continue
+    case "$(basename "${f}")" in
+      *-sources.jar|*-javadoc.jar) continue ;;
+    esac
+    if [[ -z "${newest}" || "${f}" -nt "${newest}" ]]; then
+      newest="${f}"
+    fi
+  done
+  [[ -n "${newest}" ]] && printf '%s\n' "${newest}"
+}
+
+copy_required() {
+  local file="$1"
+  local label="$2"
+  if [[ -z "${file}" ]]; then
+    echo "[install] Missing required jar: ${label}" >&2
+    exit 1
+  fi
+  cp -f "${file}" "${PLUGINS_DIR}/"
+  echo "  - $(basename "${file}")"
+}
+
+echo "[install] Cleaning existing Grim/PacketEvents jars in ${PLUGINS_DIR}"
+rm -f "${PLUGINS_DIR}"/grimac*.jar "${PLUGINS_DIR}"/packetevents*.jar
+
+echo "[install] Copying Grim Bukkit jar:"
+grim_jar="$(latest_non_doc_jar "${GRIM_LIBS}" "grimac-*.jar" || true)"
+copy_required "${grim_jar}" "grimac Bukkit plugin"
+
+echo "[install] Copying PacketEvents Spigot jar:"
+pe_spigot="$(latest_non_doc_jar "${PE_LIBS}" "packetevents-spigot-*.jar" || true)"
+copy_required "${pe_spigot}" "packetevents-spigot"
+
+echo "[install] Installed plugin jars:"
+ls -1 "${PLUGINS_DIR}" | sed 's/^/  - /'

--- a/tests/scripts/install-grim-pe-jars.sh
+++ b/tests/scripts/install-grim-pe-jars.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="tests/runs/fabric-26.1"
+PACKETEVENTS_REPO="/root/packetevents-grim-restructure"
+PROFILE="official-261"
+FABRIC_API_VERSION="0.144.4+26.1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --packetevents-repo)
+      PACKETEVENTS_REPO="${2:?missing value for --packetevents-repo}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    --fabric-api-version)
+      FABRIC_API_VERSION="${2:?missing value for --fabric-api-version}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--server-dir tests/runs/fabric-26.1] [--packetevents-repo /root/packetevents-grim-restructure] [--profile official-261|intermediary-1216] [--fabric-api-version 0.144.4+26.1]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MODS_DIR="${REPO_ROOT}/${SERVER_DIR}/mods"
+GRIM_LIBS="${REPO_ROOT}/fabric/build/libs"
+PE_LIBS="${PACKETEVENTS_REPO}/build/libs"
+
+mkdir -p "${MODS_DIR}"
+
+latest_non_doc_jar() {
+  local dir="$1"
+  local pattern="$2"
+  local newest=""
+  shopt -s nullglob
+  local files=( "${dir}"/${pattern} )
+  shopt -u nullglob
+  local f
+  for f in "${files[@]}"; do
+    [[ -e "${f}" ]] || continue
+    case "$(basename "${f}")" in
+      *-sources.jar|*-javadoc.jar) continue ;;
+    esac
+    if [[ -z "${newest}" || "${f}" -nt "${newest}" ]]; then
+      newest="${f}"
+    fi
+  done
+  [[ -n "${newest}" ]] && printf '%s\n' "${newest}"
+}
+
+latest_main_pe_jar() {
+  local dir="$1"
+  local newest=""
+  shopt -s nullglob
+  local files=( "${dir}"/packetevents-fabric-*.jar )
+  shopt -u nullglob
+  local f
+  for f in "${files[@]}"; do
+    [[ -e "${f}" ]] || continue
+    local base
+    base="$(basename "${f}")"
+    case "${base}" in
+      *-sources.jar|*-javadoc.jar|*fabric-common-*|*fabric-intermediary-*|*fabric-official-*|*fabric-mc*) continue ;;
+    esac
+    if [[ -z "${newest}" || "${f}" -nt "${newest}" ]]; then
+      newest="${f}"
+    fi
+  done
+  [[ -n "${newest}" ]] && printf '%s\n' "${newest}"
+}
+
+copy_required() {
+  local file="$1"
+  local label="$2"
+  if [[ -z "${file}" ]]; then
+    echo "[install] Missing required jar: ${label}" >&2
+    exit 1
+  fi
+  cp -f "${file}" "${MODS_DIR}/"
+  echo "  - $(basename "${file}")"
+}
+
+copy_pe_module() {
+  local module="$1"
+  local f
+  f="$(latest_non_doc_jar "${PE_LIBS}" "packetevents-fabric-${module}-*.jar" || true)"
+  copy_required "${f}" "packetevents-fabric-${module}"
+}
+
+install_fabric_api() {
+  local file="${MODS_DIR}/fabric-api-${FABRIC_API_VERSION}.jar"
+  if [[ -f "${file}" ]]; then
+    echo "  - $(basename "${file}")"
+    return
+  fi
+  local url="https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/${FABRIC_API_VERSION}/fabric-api-${FABRIC_API_VERSION}.jar"
+  echo "[install] Downloading fabric-api ${FABRIC_API_VERSION}..."
+  curl -fsSL --connect-timeout 15 --max-time 120 "${url}" -o "${file}"
+  echo "  - $(basename "${file}")"
+}
+
+echo "[install] Cleaning existing Grim/PacketEvents jars in ${MODS_DIR}"
+rm -f "${MODS_DIR}"/grimac-fabric*.jar "${MODS_DIR}"/packetevents*.jar
+
+echo "[install] Copying Grim jar:"
+grim_jar="$(latest_non_doc_jar "${GRIM_LIBS}" "grimac-fabric-*.jar" || true)"
+copy_required "${grim_jar}" "grimac-fabric"
+
+echo "[install] Copying PacketEvents jars for profile ${PROFILE}:"
+
+pe_common="$(latest_non_doc_jar "${PE_LIBS}" "packetevents-fabric-common-*.jar" || true)"
+copy_required "${pe_common}" "packetevents-fabric-common"
+
+case "${PROFILE}" in
+  official-261)
+    pe_main="$(latest_main_pe_jar "${PE_LIBS}" || true)"
+    if [[ -z "${pe_main}" ]]; then
+      echo "[install] Missing required jar: packetevents-fabric main" >&2
+      exit 1
+    fi
+    copy_required "${pe_main}" "packetevents-fabric main"
+    pe_official="$(latest_non_doc_jar "${PE_LIBS}" "packetevents-fabric-official-*.jar" || true)"
+    copy_required "${pe_official}" "packetevents-fabric-official"
+    ;;
+  intermediary-1216)
+    pe_main="$(latest_main_pe_jar "${PE_LIBS}" || true)"
+    if [[ -z "${pe_main}" ]]; then
+      echo "[install] Missing required jar: packetevents-fabric main" >&2
+      exit 1
+    fi
+    copy_required "${pe_main}" "packetevents-fabric main"
+    pe_intermediary="$(latest_non_doc_jar "${PE_LIBS}" "packetevents-fabric-intermediary-*.jar" || true)"
+    copy_required "${pe_intermediary}" "packetevents-fabric-intermediary"
+    copy_pe_module "mc1140"
+    copy_pe_module "mc1194"
+    copy_pe_module "mc1202"
+    copy_pe_module "mc1211"
+    copy_pe_module "mc1215"
+    copy_pe_module "mc1216"
+    ;;
+  *)
+    echo "[install] Unknown profile: ${PROFILE}" >&2
+    echo "[install] Expected official-261 or intermediary-1216" >&2
+    exit 1
+    ;;
+esac
+
+echo "[install] Ensuring Fabric API runtime dependency:"
+install_fabric_api
+
+echo "[install] Installed jars:"
+ls -1 "${MODS_DIR}" | sed 's/^/  - /'

--- a/tests/scripts/run-all-grim-pe-bukkit-harnesses.sh
+++ b/tests/scripts/run-all-grim-pe-bukkit-harnesses.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TIMEOUT_CMD=""
+
+cd "${REPO_ROOT}"
+
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+else
+  echo "[all-bukkit] Missing timeout utility. Install GNU coreutils (gtimeout) or GNU timeout." >&2
+  exit 1
+fi
+
+smoke_start() {
+  local case_name="$1"
+  shift
+  local log_file
+  log_file="$(mktemp)"
+
+  set +e
+  "${TIMEOUT_CMD}" 75s "$@" > >(tee "${log_file}") 2>&1
+  local rc=$?
+  set -e
+
+  if [[ ${rc} -ne 0 && ${rc} -ne 124 ]]; then
+    echo "[all-bukkit] ${case_name} failed with exit code ${rc}"
+    rm -f "${log_file}"
+    return 1
+  fi
+
+  if ! python3 - "${log_file}" <<'PY'
+import pathlib
+import sys
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8", errors="ignore")
+sys.exit(0 if "Done (" in text else 1)
+PY
+  then
+    echo "[all-bukkit] ${case_name} did not reach startup completion."
+    rm -f "${log_file}"
+    return 1
+  fi
+
+  rm -f "${log_file}"
+}
+
+echo "[all-bukkit] Case 1/2: Paper older-version path (1.20.6)"
+"${SCRIPT_DIR}/bootstrap-grim-pe-bukkit-paper-1206.sh"
+smoke_start "grim-pe-paper-1206" "${SCRIPT_DIR}/run-bukkit-server.sh" --server-dir tests/runs/grim-pe-paper-1.20.6
+
+echo "[all-bukkit] Case 2/2: Spigot path (1.21.1)"
+"${SCRIPT_DIR}/bootstrap-grim-pe-bukkit-spigot-1211.sh"
+smoke_start "grim-pe-spigot-1211" "${SCRIPT_DIR}/run-bukkit-server.sh" --server-dir tests/runs/grim-pe-spigot-1.21.1
+
+echo "[all-bukkit] Grim + PacketEvents Bukkit harness complete."

--- a/tests/scripts/run-all-grim-pe-harnesses.sh
+++ b/tests/scripts/run-all-grim-pe-harnesses.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+JAVA25_BIN="${JAVA25_BIN:-/root/.gradle/jdks/eclipse_adoptium-25-amd64-linux.2/bin/java}"
+TIMEOUT_CMD=""
+
+cd "${REPO_ROOT}"
+
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+else
+  echo "[all] Missing timeout utility. Install GNU coreutils (gtimeout) or GNU timeout." >&2
+  exit 1
+fi
+
+smoke_start() {
+  local case_name="$1"
+  shift
+  local log_file
+  log_file="$(mktemp)"
+
+  set +e
+  "${TIMEOUT_CMD}" 60s "$@" 2>&1 | tee "${log_file}"
+  local rc=${PIPESTATUS[0]}
+  set -e
+
+  if [[ ${rc} -ne 0 && ${rc} -ne 124 ]]; then
+    echo "[all] ${case_name} failed with exit code ${rc}"
+    rm -f "${log_file}"
+    return 1
+  fi
+
+  if ! python3 - "${log_file}" <<'PY'
+import pathlib
+import sys
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8", errors="ignore")
+sys.exit(0 if "Done (" in text else 1)
+PY
+  then
+    echo "[all] ${case_name} did not reach startup completion."
+    rm -f "${log_file}"
+    return 1
+  fi
+
+  rm -f "${log_file}"
+}
+
+echo "[all] Case 1/1: Grim + PE official (26.1)"
+if [[ ! -x "${JAVA25_BIN}" ]]; then
+  echo "[all] Missing Java 25 binary at ${JAVA25_BIN}"
+  echo "[all] Set JAVA25_BIN to your Java 25 executable and retry."
+  exit 1
+fi
+"${SCRIPT_DIR}/bootstrap-grim-pe-official-261.sh"
+smoke_start "grim-pe-official-261" "${SCRIPT_DIR}/run-server.sh" --server-dir tests/runs/grim-pe-26.1 --java-bin "${JAVA25_BIN}"
+
+echo "[all] Grim + PacketEvents harness complete."

--- a/tests/scripts/run-all-grim-pe-stack-harnesses.sh
+++ b/tests/scripts/run-all-grim-pe-stack-harnesses.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[all-stack] Running Fabric 26.1 harness..."
+"${SCRIPT_DIR}/run-all-grim-pe-harnesses.sh"
+
+echo "[all-stack] Running Bukkit harnesses (Paper older-version + Spigot)..."
+"${SCRIPT_DIR}/run-all-grim-pe-bukkit-harnesses.sh"
+
+echo "[all-stack] Full Grim + PacketEvents stack harness complete."

--- a/tests/scripts/run-bukkit-server.sh
+++ b/tests/scripts/run-bukkit-server.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="tests/runs/grim-pe-paper-1.20.6"
+JAVA_BIN="java"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --java-bin)
+      JAVA_BIN="${2:?missing value for --java-bin}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--server-dir tests/runs/grim-pe-paper-1.20.6] [--java-bin /path/to/java]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SERVER_DIR}"
+
+SERVER_JAR=""
+if [[ -f "${TARGET_DIR}/paper-server.jar" ]]; then
+  SERVER_JAR="${TARGET_DIR}/paper-server.jar"
+elif [[ -f "${TARGET_DIR}/spigot-server.jar" ]]; then
+  SERVER_JAR="${TARGET_DIR}/spigot-server.jar"
+fi
+
+if [[ -z "${SERVER_JAR}" ]]; then
+  echo "Missing server jar in ${TARGET_DIR}" >&2
+  echo "Run setup first (paper or spigot bootstrap)." >&2
+  exit 1
+fi
+
+cd "${TARGET_DIR}"
+exec "${JAVA_BIN}" -Xms1G -Xmx2G -jar "${SERVER_JAR}" nogui

--- a/tests/scripts/run-server.sh
+++ b/tests/scripts/run-server.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="tests/runs/fabric-26.1"
+JAVA_BIN="java"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --java-bin)
+      JAVA_BIN="${2:?missing value for --java-bin}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--server-dir tests/runs/fabric-26.1] [--java-bin /path/to/java]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SERVER_DIR}"
+SERVER_JAR="${TARGET_DIR}/fabric-server-launch.jar"
+
+if [[ ! -f "${SERVER_JAR}" ]]; then
+  echo "Missing ${SERVER_JAR}" >&2
+  echo "Run a bootstrap script first." >&2
+  exit 1
+fi
+
+cd "${TARGET_DIR}"
+exec "${JAVA_BIN}" -Xms1G -Xmx2G -jar fabric-server-launch.jar nogui

--- a/tests/scripts/setup-fabric-server.sh
+++ b/tests/scripts/setup-fabric-server.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MC_VERSION="26.1"
+SERVER_DIR="tests/runs/fabric-26.1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mc-version)
+      MC_VERSION="${2:?missing value for --mc-version}"
+      shift 2
+      ;;
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--mc-version 26.1] [--server-dir tests/runs/fabric-26.1]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SERVER_DIR}"
+LOADER_META_URL="https://meta.fabricmc.net/v2/versions/loader/${MC_VERSION}"
+INSTALLER_META_URL="https://meta.fabricmc.net/v2/versions/installer"
+
+mkdir -p "${TARGET_DIR}" "${TARGET_DIR}/mods"
+
+echo "[setup] Resolving Fabric loader/installer for MC ${MC_VERSION}..."
+read -r LOADER_VERSION INSTALLER_VERSION < <(
+  python3 - <<'PY' "${LOADER_META_URL}" "${INSTALLER_META_URL}"
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+loader_url = sys.argv[1]
+installer_url = sys.argv[2]
+MAX_ATTEMPTS = 4
+TIMEOUT_SECONDS = 15
+
+def fetch_json(url: str, label: str):
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=TIMEOUT_SECONDS) as r:
+                return json.load(r)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            if attempt == MAX_ATTEMPTS:
+                raise SystemExit(f"Failed fetching {label} after {MAX_ATTEMPTS} attempts: {exc}")
+            time.sleep(2 ** (attempt - 1))
+
+loader_data = fetch_json(loader_url, "loader metadata")
+if not loader_data:
+    raise SystemExit("No loader metadata found for requested MC version")
+loader_version = loader_data[0]["loader"]["version"]
+
+installer_data = fetch_json(installer_url, "installer metadata")
+if not installer_data:
+    raise SystemExit("No installer metadata found")
+installer_version = installer_data[0]["version"]
+
+print(loader_version, installer_version)
+PY
+)
+
+SERVER_JAR_URL="https://meta.fabricmc.net/v2/versions/loader/${MC_VERSION}/${LOADER_VERSION}/${INSTALLER_VERSION}/server/jar"
+SERVER_JAR_PATH="${TARGET_DIR}/fabric-server-launch.jar"
+
+echo "[setup] MC=${MC_VERSION} loader=${LOADER_VERSION} installer=${INSTALLER_VERSION}"
+echo "[setup] Downloading server jar..."
+max_attempts=4
+attempt=1
+while true; do
+  if curl -fsSL --connect-timeout 15 --max-time 120 "${SERVER_JAR_URL}" -o "${SERVER_JAR_PATH}"; then
+    break
+  fi
+  if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+    echo "[setup] Failed to download server jar after ${max_attempts} attempts: ${SERVER_JAR_URL}" >&2
+    exit 1
+  fi
+  sleep $((2 ** (attempt - 1)))
+  attempt=$((attempt + 1))
+done
+
+cat > "${TARGET_DIR}/eula.txt" <<'EOF'
+eula=true
+EOF
+
+echo "[setup] Server directory ready at: ${TARGET_DIR}"

--- a/tests/scripts/setup-paper-server.sh
+++ b/tests/scripts/setup-paper-server.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MC_VERSION="1.20.6"
+SERVER_DIR="tests/runs/grim-pe-paper-1.20.6"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mc-version)
+      MC_VERSION="${2:?missing value for --mc-version}"
+      shift 2
+      ;;
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--mc-version 1.20.6] [--server-dir tests/runs/grim-pe-paper-1.20.6]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SERVER_DIR}"
+PAPER_API_BASE="https://api.papermc.io/v2/projects/paper/versions/${MC_VERSION}"
+
+mkdir -p "${TARGET_DIR}" "${TARGET_DIR}/plugins"
+
+echo "[setup] Resolving latest Paper build for MC ${MC_VERSION}..."
+read -r BUILD_NUMBER DOWNLOAD_NAME < <(
+  python3 - <<'PY' "${PAPER_API_BASE}/builds"
+import json
+import sys
+import urllib.request
+
+url = sys.argv[1]
+with urllib.request.urlopen(url, timeout=20) as r:
+    builds = json.load(r).get("builds", [])
+if not builds:
+    raise SystemExit("No Paper builds found for requested version")
+latest = builds[-1]
+download_name = latest["downloads"]["application"]["name"]
+print(latest["build"], download_name)
+PY
+)
+
+SERVER_JAR_URL="${PAPER_API_BASE}/builds/${BUILD_NUMBER}/downloads/${DOWNLOAD_NAME}"
+SERVER_JAR_PATH="${TARGET_DIR}/paper-server.jar"
+
+echo "[setup] MC=${MC_VERSION} paperBuild=${BUILD_NUMBER}"
+echo "[setup] Downloading Paper server jar..."
+curl -fsSL "${SERVER_JAR_URL}" -o "${SERVER_JAR_PATH}"
+
+cat > "${TARGET_DIR}/eula.txt" <<'EOF'
+eula=true
+EOF
+
+echo "[setup] Server directory ready at: ${TARGET_DIR}"

--- a/tests/scripts/setup-spigot-server.sh
+++ b/tests/scripts/setup-spigot-server.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MC_VERSION="1.21.1"
+SERVER_DIR="tests/runs/grim-pe-spigot-1.21.1"
+JAVA_BIN="java"
+REBUILD="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mc-version)
+      MC_VERSION="${2:?missing value for --mc-version}"
+      shift 2
+      ;;
+    --server-dir)
+      SERVER_DIR="${2:?missing value for --server-dir}"
+      shift 2
+      ;;
+    --java-bin)
+      JAVA_BIN="${2:?missing value for --java-bin}"
+      shift 2
+      ;;
+    --rebuild)
+      REBUILD="1"
+      shift
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      echo "Usage: $0 [--mc-version 1.21.1] [--server-dir tests/runs/grim-pe-spigot-1.21.1] [--java-bin /path/to/java] [--rebuild]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SERVER_DIR}"
+CACHE_DIR="${REPO_ROOT}/tests/.cache/buildtools"
+BUILDTOOLS_JAR="${CACHE_DIR}/BuildTools.jar"
+
+mkdir -p "${TARGET_DIR}" "${TARGET_DIR}/plugins" "${CACHE_DIR}"
+
+echo "[setup] Downloading BuildTools..."
+curl -fsSL "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar" -o "${BUILDTOOLS_JAR}"
+
+SPIGOT_JAR="$(ls -t "${CACHE_DIR}"/spigot-"${MC_VERSION}"*.jar 2>/dev/null | head -n 1 || true)"
+if [[ "${REBUILD}" == "0" && -n "${SPIGOT_JAR}" ]]; then
+  echo "[setup] Reusing cached Spigot jar: $(basename "${SPIGOT_JAR}")"
+else
+  echo "[setup] Building Spigot server for MC ${MC_VERSION} (this can take several minutes)..."
+  (
+    cd "${CACHE_DIR}"
+    "${JAVA_BIN}" -jar "${BUILDTOOLS_JAR}" --rev "${MC_VERSION}" --compile SPIGOT --output-dir "${CACHE_DIR}"
+  )
+  SPIGOT_JAR="$(ls -t "${CACHE_DIR}"/spigot-"${MC_VERSION}"*.jar 2>/dev/null | head -n 1 || true)"
+fi
+
+if [[ -z "${SPIGOT_JAR}" ]]; then
+  echo "[setup] Could not locate built Spigot jar in ${CACHE_DIR}" >&2
+  exit 1
+fi
+
+cp -f "${SPIGOT_JAR}" "${TARGET_DIR}/spigot-server.jar"
+
+cat > "${TARGET_DIR}/eula.txt" <<'EOF'
+eula=true
+EOF
+
+echo "[setup] Server directory ready at: ${TARGET_DIR}"


### PR DESCRIPTION
## Summary

This PR finalizes Fabric 26.1 official-namespace support and brings the branch in line with the validated fork state, including reproducible dependency pinning and multi-platform startup harness coverage.

In addition to the original 26.1 migration work, this update adds end-to-end Grim + PacketEvents test harnesses for Fabric and Bukkit startup validation and documents exact reproduction steps.

## Alignment with Axionize architecture guidance

This branch now explicitly follows Axionize’s guidance:

1) **Defaults remain stable**
- Default builds do not rely on local-only artifact behavior.
- Local overrides are opt-in via `-PmavenLocalOverride=true` / `MAVEN_LOCAL_OVERRIDE=true`.

2) **Reproducible dependency coordinates**
- PacketEvents is pinned to an exact snapshot git coordinate.
- cloud-fabric is pinned to an exact unique snapshot coordinate (instead of floating `-SNAPSHOT`).

3) **Deterministic resolution behavior**
- Repository strategy and docs are aligned to reproducible defaults and explicit local override workflows.

## What was added/updated in the final iteration

- Added and hardened Grim + PacketEvents harness scripts under `tests/scripts`:
  - Fabric official 26.1 bootstrap/startup flow
  - Bukkit Paper 1.20.6 startup flow
  - Bukkit Spigot 1.21.1 startup flow
  - Full-stack runner for combined coverage

- Improved harness reliability:
  - Correct PacketEvents main-jar selection logic
  - Deterministic timeout/log capture handling
  - Optional `SKIP_CLEAN=true` for faster local iteration without changing CI-safe defaults

- Applied remaining safe cleanup/follow-up fixes in Fabric adapters and docs.

## Proof of tested compatibility

Latest smoke run validated Grim + the restructured PacketEvents build together:

- **Fabric 26.1 (official namespace):**
  - Ran bootstrap + startup harness with Java 25.
  - Observed successful startup marker: `Done (...)`.
  - Grim and PacketEvents both initialized in server logs.

- **Bukkit Paper 1.20.6 (older-version path):**
  - Ran `run-all-grim-pe-bukkit-harnesses.sh` case 1/2.
  - Observed successful startup marker: `Done (14.895s)!`.

- **Bukkit Spigot 1.21.1:**
  - Ran `run-all-grim-pe-bukkit-harnesses.sh` case 2/2.
  - Observed successful startup marker: `Done (14.791s)!`.

This demonstrates the current changes do not regress the tested older Bukkit compatibility path while enabling Fabric 26.1.

## Reproduction / How to run

### 1) Fabric 26.1 official namespace (primary target)
- `./tests/scripts/bootstrap-grim-pe-official-261.sh`
- `./tests/scripts/run-server.sh --server-dir tests/runs/grim-pe-26.1 --java-bin /path/to/java25`

### 2) Bukkit Paper 1.20.6 startup validation
- `./tests/scripts/bootstrap-grim-pe-bukkit-paper-1206.sh`
- `./tests/scripts/run-bukkit-server.sh --server-dir tests/runs/grim-pe-paper-1.20.6`

### 3) Bukkit Spigot 1.21.1 startup validation
- `./tests/scripts/bootstrap-grim-pe-bukkit-spigot-1211.sh`
- `./tests/scripts/run-bukkit-server.sh --server-dir tests/runs/grim-pe-spigot-1.21.1`

### 4) One-command harness runs
- `./tests/scripts/run-all-grim-pe-harnesses.sh`
- `./tests/scripts/run-all-grim-pe-bukkit-harnesses.sh`
- `./tests/scripts/run-all-grim-pe-stack-harnesses.sh`

## What still needs testing

To further strengthen confidence before merge, remaining coverage should include:

- Additional Fabric intermediary compatibility runs (for selected non-26.1 versions).
- More Bukkit versions (at least one additional Paper and Spigot target each).
- Basic join/playflow checks (not only startup) for each harnessed platform.
- Regression checks for representative ViaVersion/pre-Via user paths in real server stacks.

## Validation status

- `./gradlew :fabric:compileJava` passes on the updated branch.
- Harness scripts pass shell syntax checks.
- Startup coverage now includes:
  - Fabric 26.1 official path
  - Older-version Bukkit path (Paper 1.20.6)
  - Spigot 1.21.1 path

## Notes

- Fabric module target remains MC 26.1 official namespace.
- Bukkit harnesses are startup compatibility checks for cross-stack confidence.
- This update is intended to be a clean, reproducible, maintainer-friendly finalization of the PR branch.