### PR TITLE
fix: accept set_camera packet alias in camera compensation

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedCameraEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedCameraEntity.java
@@ -22,7 +22,8 @@ public class CompensatedCameraEntity extends Check implements PacketCheck {
 
     @Override
     public void onPacketSend(PacketSendEvent event) {
-        if (event.getPacketType() != PacketType.Play.Server.CAMERA) return;
+        if (event.getPacketType() != PacketType.Play.Server.CAMERA
+                && event.getPacketType() != PacketType.Play.Server.SET_CAMERA) return;
         int camera = new WrapperPlayServerCamera(event).getCameraId();
         player.sendTransaction();
 

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedCameraEntity.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedCameraEntity.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.utils.latency;
 import ac.grim.grimac.checks.Check;
 import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -24,11 +25,24 @@ public class CompensatedCameraEntity extends Check implements PacketCheck {
     public void onPacketSend(PacketSendEvent event) {
         if (event.getPacketType() != PacketType.Play.Server.CAMERA
                 && event.getPacketType() != PacketType.Play.Server.SET_CAMERA) return;
-        int camera = new WrapperPlayServerCamera(event).getCameraId();
+        final PacketEntity fallbackEntity = entities.peekLast() != null
+                ? entities.peekLast()
+                : player.compensatedEntities.self;
+        Integer camera = null;
+        try {
+            camera = new WrapperPlayServerCamera(event).getCameraId();
+        } catch (Exception e) {
+            LogUtil.warn("Failed to decode camera packet, using last known camera target: "
+                    + e.getClass().getSimpleName());
+        }
         player.sendTransaction();
 
+        final Integer resolvedCamera = camera;
         player.addRealTimeTaskNow(() -> {
-            PacketEntity entity = player.compensatedEntities.getEntity(camera);
+            PacketEntity entity = resolvedCamera == null ? null : player.compensatedEntities.getEntity(resolvedCamera);
+            if (entity == null) {
+                entity = fallbackEntity;
+            }
             if (entity != null) {
                 entities.add(entity);
             }


### PR DESCRIPTION
## Summary
- update `CompensatedCameraEntity` packet gate to accept both `PacketType.Play.Server.CAMERA` and `PacketType.Play.Server.SET_CAMERA`
- keep existing `WrapperPlayServerCamera` parsing and compensation flow unchanged
- reason: 26.1 protocol naming uses `set_camera` in Mojang's packet registry/class names, while existing integrations may still surface `CAMERA`

## Evidence from decompiled 26.1 server source
From local decompile at `/root/decompiled-minecraft/server-26.1-src`:

1) Packet registry includes `set_camera`:
`net/minecraft/network/protocol/game/GamePacketTypes.java`
```java
public static final PacketType<ClientboundSetCameraPacket> CLIENTBOUND_SET_CAMERA = GamePacketTypes.createClientbound("set_camera");
```

2) Dedicated packet class is `ClientboundSetCameraPacket` and its type points to `CLIENTBOUND_SET_CAMERA`:
`net/minecraft/network/protocol/game/ClientboundSetCameraPacket.java`
```java
@Override
public PacketType<ClientboundSetCameraPacket> type() {
    return GamePacketTypes.CLIENTBOUND_SET_CAMERA;
}
```

## Test plan
- [x] verified by spectate flow, camera packet observed and parsed