### PR TITLE
Require external PacketEvents for Bukkit builds

### DIFF
--- a/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
@@ -6,12 +6,19 @@ plugins {
 }
 
 tasks.named<ShadowJar>("shadowJar") {
+    val bundlePacketEvents = BuildConfig.shadePE && project.name != "bukkit"
+
     minimize()
     archiveFileName = "${rootProject.name}-${project.name}-${rootProject.version}.jar"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
+    if (!bundlePacketEvents) {
+        exclude("com/github/retrooper/packetevents/**")
+        exclude("io/github/retrooper/packetevents/**")
+    }
+
     if (BuildConfig.relocate) {
-        if (BuildConfig.shadePE) {
+        if (bundlePacketEvents) {
             relocate("io.github.retrooper.packetevents", "ac.grim.grimac.shaded.io.github.retrooper.packetevents")
             relocate("com.github.retrooper.packetevents", "ac.grim.grimac.shaded.com.github.retrooper.packetevents")
             relocate("net.kyori", "ac.grim.grimac.shaded.kyori") // use PE's built-in adventure instead when not shading PE

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -43,12 +43,7 @@ repositories {
 dependencies {
     compileOnly(libs.paper.api)
     compileOnly(libs.placeholderapi)
-
-    if (BuildConfig.shadePE) {
-        implementation(libs.packetevents.spigot)
-    } else {
-        compileOnly(libs.packetevents.spigot)
-    }
+    compileOnly(libs.packetevents.spigot)
     implementation(libs.cloud.paper)
     implementation(libs.adventure.platform.bukkit)
     implementation(libs.grim.bukkit.internal)
@@ -65,27 +60,20 @@ bukkit {
     apiVersion = "1.13"
     foliaSupported = true
 
-    if (!BuildConfig.shadePE) {
-        depend = listOf("packetevents")
-    }
+    depend = listOf("packetevents")
 
-    softDepend = buildList {
-        // When Grim bundles PacketEvents, still load after the standalone plugin if it is present.
-        if (BuildConfig.shadePE) add("packetevents")
-
-        addAll(listOf(
-            "ProtocolLib",
-            "ProtocolSupport",
-            "Essentials",
-            "ViaVersion",
-            "ViaBackwards",
-            "ViaRewind",
-            "Geyser-Spigot",
-            "floodgate",
-            "FastLogin",
-            "PlaceholderAPI",
-        ))
-    }
+    softDepend = listOf(
+        "ProtocolLib",
+        "ProtocolSupport",
+        "Essentials",
+        "ViaVersion",
+        "ViaBackwards",
+        "ViaRewind",
+        "Geyser-Spigot",
+        "floodgate",
+        "FastLogin",
+        "PlaceholderAPI",
+    )
 
     permissions {
         register("grim.alerts") {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -69,18 +69,23 @@ bukkit {
         depend = listOf("packetevents")
     }
 
-    softDepend = listOf(
-        "ProtocolLib",
-        "ProtocolSupport",
-        "Essentials",
-        "ViaVersion",
-        "ViaBackwards",
-        "ViaRewind",
-        "Geyser-Spigot",
-        "floodgate",
-        "FastLogin",
-        "PlaceholderAPI",
-    )
+    softDepend = buildList {
+        // When Grim bundles PacketEvents, still load after the standalone plugin if it is present.
+        if (BuildConfig.shadePE) add("packetevents")
+
+        addAll(listOf(
+            "ProtocolLib",
+            "ProtocolSupport",
+            "Essentials",
+            "ViaVersion",
+            "ViaBackwards",
+            "ViaRewind",
+            "Geyser-Spigot",
+            "floodgate",
+            "FastLogin",
+            "PlaceholderAPI",
+        ))
+    }
 
     permissions {
         register("grim.alerts") {

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/player/BukkitPlatformPlayer.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/player/BukkitPlatformPlayer.java
@@ -47,7 +47,7 @@ public class BukkitPlatformPlayer extends BukkitGrimEntity implements PlatformPl
         this.inventory = new BukkitPlatformInventory(bukkitPlayer);
         if (CommonGrimArguments.USE_CHAT_FAST_BYPASS.value()) {
             Object channel = PacketEvents.getAPI().getProtocolManager().getChannel(bukkitPlayer.getUniqueId());
-            this.user = PacketEvents.getAPI().getProtocolManager().getUser(channel);
+            this.user = channel != null ? PacketEvents.getAPI().getProtocolManager().getUser(channel) : null;
         } else {
             this.user = null;
         }

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerJoinQuit.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerJoinQuit.java
@@ -9,9 +9,6 @@ import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-
-
 public class PacketPlayerJoinQuit extends PacketListenerAbstract {
 
     @Override
@@ -33,7 +30,11 @@ public class PacketPlayerJoinQuit extends PacketListenerAbstract {
 
     @Override
     public void onUserLogin(UserLoginEvent event) {
-        Object nativePlayerObject = Objects.requireNonNull(event.getPlayer());
+        Object nativePlayerObject = event.getPlayer();
+        if (nativePlayerObject == null) {
+            LogUtil.warn("Skipping Grim login setup because PacketEvents did not provide a player yet.");
+            return;
+        }
 
         // This will never throw a NPE because code is run in OnUserConnect -> onPacketSend -> OnUserLogin order
         // And the user will be added to the map before the getPlayer() method call


### PR DESCRIPTION
## Summary
- switch the Bukkit release artifact to depend on the standalone `packetevents` plugin instead of bundling a second PacketEvents copy
- keep PacketEvents shaded for non-Bukkit modules while excluding it from the Bukkit shadow jar
- add null guards around login-time player and channel lookups so PacketEvents timing issues do not cascade into Grim exceptions

## Why
Servers that already install the standalone PacketEvents plugin currently end up with two independent PacketEvents injectors when using the Bukkit release jar. This can break login on translated connections and produce duplicate pipeline handling.

By making the Bukkit artifact consistently use the external PacketEvents plugin, one official jar can support PacketEvents-based server setups without shipping a second embedded injector.

## Test plan
- [x] Run `./gradlew :bukkit:shadowJar`
- [x] Verify the generated Bukkit `plugin.yml` contains `depend: [packetevents]`
- [x] Verify the generated Bukkit jar no longer contains bundled PacketEvents classes
- [ ] Reproduce on a Purpur 1.20.1 server with Grim, PacketEvents, and ViaVersion installed