### PR TITLE
fix: MultiActions Inventory Check Issues

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsC.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsC.java
@@ -39,12 +39,15 @@ public class MultiActionsC extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW && !player.serverOpenedInventoryThisTick) {
-            String verbose = getVerbose(player);
-            if (!verbose.isEmpty() && flagAndAlert(verbose) && shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-            }
+        if (event.getPacketType() != PacketType.Play.Client.CLICK_WINDOW) return;
+        if (player.serverOpenedInventoryThisTick) return;
+
+        String verbose = getVerbose(player);
+        if (verbose.isEmpty()) return;
+
+        if (flagAndAlert(verbose) && shouldModifyPackets()) {
+            event.setCancelled(true);
+            player.onPacketCancel();
         }
     }
 }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/multiactions/MultiActionsD.java
@@ -15,12 +15,15 @@ public class MultiActionsD extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLOSE_WINDOW) {
-            String verbose = MultiActionsC.getVerbose(player);
-            if (!verbose.isEmpty() && flagAndAlert(verbose) && shouldModifyPackets()) {
-                event.setCancelled(true);
-                player.onPacketCancel();
-            }
-        }
+        if (event.getPacketType() != PacketType.Play.Client.CLOSE_WINDOW) return;
+        if (player.serverOpenedInventoryThisTick) return;
+
+        String verbose = MultiActionsC.getVerbose(player);
+        if (verbose.isEmpty()) return;
+
+        // Don't cancel this packet, because it won't do anything except for making chests
+        // look like they are still open (desynced),
+        // and it can cause incompatibility issues with plugins
+        flagAndAlert(verbose);
     }
 }

--- a/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/CheckManagerListener.java
@@ -22,6 +22,7 @@ import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.item.type.ItemType;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.DiggingAction;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
@@ -574,7 +575,7 @@ public class CheckManagerListener extends PacketListenerAbstract {
             player.packetStateData.cancelDuplicatePacket = false;
         }
 
-        if (event.getPacketType() == PacketType.Play.Client.CLIENT_TICK_END) {
+        if (event.getPacketType() == PacketType.Play.Client.CLIENT_TICK_END && player.supportsEndTick()) {
             player.serverOpenedInventoryThisTick = false;
             if (!player.packetStateData.didSendMovementBeforeTickEnd) {
                 // The player didn't send a movement packet, so we can predict this like we had idle tick on 1.8
@@ -600,11 +601,12 @@ public class CheckManagerListener extends PacketListenerAbstract {
         GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
         if (player == null) return;
 
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
+        final PacketTypeCommon packetType = event.getPacketType();
+        if (packetType == PacketType.Play.Server.OPEN_WINDOW || packetType == PacketType.Play.Server.OPEN_HORSE_WINDOW) {
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> player.serverOpenedInventoryThisTick = true);
         }
 
-        if (event.getPacketType() == PacketType.Play.Server.BUNDLE) {
+        if (packetType == PacketType.Play.Server.BUNDLE) {
             player.packetStateData.sendingBundlePacket = !player.packetStateData.sendingBundlePacket;
         }
 


### PR DESCRIPTION
Fixed: MultiActionsD not checking if the inventory got opened this tick
Fixed: MultiActionsD cancelling the close window packet causing desync / compatibility issues (like chests remaining open)
Fixed: CheckManagerListener not using the open horse window to set `serverOpenedInventoryThisTick`
Fixed: CheckManagerListener not checking if the player supports the tick end packet at line 578

Possible closes #2373, however I am still worried about MultiActionsC. Perhaps `serverOpenedInventoryThisTick` is set to false to quickly?