### PR TITLE
Fix Soul Speed + Swift Sneak simulation false positive on 1.21+

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/BlockProperties.java
@@ -200,9 +200,11 @@ public class BlockProperties {
         if (type == StateTypes.SOUL_SAND) {
             // Soul speed is a 1.16+ enchantment
             // This new method for detecting soul speed was added in 1.16.2
-            // On 1.21, let attributes handle this
-            if (player.getClientVersion().isOlderThan(ClientVersion.V_1_21)
-                    && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16_2)
+            // On 1.21+, soul speed uses a location_changed enchantment effect that sets
+            // movement_efficiency to 1.0 (completely negating the slowdown). The client applies
+            // this locally, but the server-sent attribute update can arrive late, causing
+            // false positives. We check the enchantment directly to stay in sync with the client.
+            if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16_2)
                     && player.inventory.getBoots().getEnchantmentLevel(EnchantmentTypes.SOUL_SPEED) > 0)
                 return 1.0f;
             return 0.4f;


### PR DESCRIPTION
## Description

Fixes continuous simulation false positives when a player with **Swift Sneak 3 leggings** and **Soul Speed 3 boots** is sneaking and bridging over soul sand/soul soil on 1.21+ servers.

## Root Cause

In vanilla 1.21+, Soul Speed is a location_changed enchantment effect ([soul_speed.json](https://github.com/misode/mcmeta/blob/data/data/minecraft/enchantment/soul_speed.json)). When the player steps on a soul speed block, the client applies the movement_efficiency = 1.0 modifier **locally and immediately**. However, the server sends the UPDATE_ATTRIBUTES packet asynchronously.

GrimAC's getBlockSpeedFactor for 1.21+ clients deferred to the MOVEMENT_EFFICIENCY attribute (via getModernVelocityMultiplier), relying on the server-sent value. During bridging where block position changes constantly the attribute updates lagged behind the client's local state, causing GrimAC to predict with movement_efficiency = 0 (soul sand slowdown) while the client used 1.0 (no slowdown).

## Fix

Removed the V_1_21 version gate in getBlockSpeedFactor so Soul Speed is checked directly from the player's boots inventory for **all 1.16.2+ clients**, matching the client's local behavior and avoiding the attribute timing desync.

## Testing

- Player with Swift Sneak 3 + Soul Speed 3, sneaking and bridging over soul sand no longer flags simulation.