### PR TITLE
Feat: Add toggle for Polymer block translation hook

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/config/BaseConfigManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/config/BaseConfigManager.java
@@ -43,6 +43,8 @@ public class BaseConfigManager {
 
     @Getter
     private boolean disablePongCancelling;
+    @Getter
+    private boolean polymerHook;
 
     // initialize the config
     public void load(ConfigManager config) {
@@ -77,6 +79,7 @@ public class BaseConfigManager {
                 "<red>Your forge version is blacklisted due to inbuilt reach hacks.<newline><gold>Versions affected: 1.18.2-1.19.3<newline><newline><red>Please see https://github.com/MinecraftForge/MinecraftForge/issues/9309.");
 
         disablePongCancelling = config.getBooleanElse("disable-pong-cancelling", false);
+        polymerHook = config.getBooleanElse("polymer-hook", true);
     }
 
     // ran on start, can be used to handle things that can't be done while loading

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -55,9 +55,9 @@ disable-pong-cancelling: false
 # Dies erzwingt die Verwendung eines "NoOp" (No Operation) Handlers, es sei denn, über die API wird ein eigener bereitgestellt.
 disable-default-resync-handler: false
 
-# Should Grim hook into Polymer to translate custom blocks?
-# This is only applicable on Fabric servers with Polymer installed.
-# If enabled, Grim will ask Polymer for the client-side block state when performing resynchronization.
+# Moet Grim inhaken op Polymer om aangepaste blokken te vertalen?
+# Dit is alleen van toepassing op Fabric-servers waarop Polymer is geïnstalleerd.
+# Indien ingeschakeld, zal Grim Polymer vragen om de client-side blokstatus tijdens het uitvoeren van een resynchronisatie.
 polymer-hook: true
 
 # Should the duplicate movement packet be cancelled?

--- a/common/src/main/resources/config/de.yml
+++ b/common/src/main/resources/config/de.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Dies erzwingt die Verwendung eines "NoOp" (No Operation) Handlers, es sei denn, über die API wird ein eigener bereitgestellt.
 disable-default-resync-handler: false
 
+# Should Grim hook into Polymer to translate custom blocks?
+# This is only applicable on Fabric servers with Polymer installed.
+# If enabled, Grim will ask Polymer for the client-side block state when performing resynchronization.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/en.yml
+++ b/common/src/main/resources/config/en.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # This forces the use of a "NoOp" (No Operation) handler unless a custom one is provided via API.
 disable-default-resync-handler: false
 
+# Should Grim hook into Polymer to translate custom blocks?
+# This is only applicable on Fabric servers with Polymer installed.
+# If enabled, Grim will ask Polymer for the client-side block state when performing resynchronization.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/es.yml
+++ b/common/src/main/resources/config/es.yml
@@ -56,6 +56,11 @@ disable-pong-cancelling: false
 # Esto fuerza el uso de un manejador "NoOp" (Sin Operación) a menos que se proporcione uno personalizado vía API.
 disable-default-resync-handler: false
 
+# ¿Debería Grim integrarse con Polymer para traducir bloques personalizados?
+# Esta opción es aplicable solo a servidores Fabric con Polymer instalado.
+# Si está habilitado, Grim solicitará a Polymer el estado del bloque del lado del cliente al realizar la resincronización.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/fr.yml
+++ b/common/src/main/resources/config/fr.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Cela force l'utilisation d'un gestionnaire "NoOp" (Aucune Opération) sauf si un personnalisé est fourni via l'API.
 disable-default-resync-handler: false
 
+# Grim devrait-il s'intégrer à Polymer pour traduire les blocs personnalisés ?
+# Cette option est applicable uniquement aux serveurs Fabric avec Polymer installé.
+# Si activé, Grim demandera à Polymer l'état du bloc côté client lors de la resynchronisation.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/it.yml
+++ b/common/src/main/resources/config/it.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Questo forza l'uso di un gestore "NoOp" (Nessuna Operazione) a meno che non ne venga fornito uno personalizzato via API.
 disable-default-resync-handler: false
 
+# Grim dovrebbe integrarsi con Polymer per tradurre i blocchi personalizzati?
+# Questa opzione è applicabile solo ai server Fabric con Polymer installato.
+# Se abilitata, Grim richiederà a Polymer lo stato del blocco lato client durante la risincronizzazione.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/ja.yml
+++ b/common/src/main/resources/config/ja.yml
@@ -57,6 +57,11 @@ disable-pong-cancelling: false
 # これにより、API経由でカスタムハンドラーが提供されない限り、"NoOp"（何もしない）ハンドラーの使用が強制されます。
 disable-default-resync-handler: false
 
+# Grimはカスタムブロックを翻訳するためにPolymerにフックすべきですか？
+# これはPolymerがインストールされているFabricサーバーにのみ適用されます。
+# 有効にすると、Grimは再同期を実行する際にクライアント側のブロック状態をPolymerに要求します。
+polymer-hook: true
+
 # 重複した移動パケットをキャンセルしますか？
 # 1.21でこの問題は修正されました。重複パケットの問題は、Mojangが「バケツの同期ズレ」を修正しようとしたことに起因するものでした。 https://bugs.mojang.com/browse/MC-12363
 # この設定は、V1.17-1.20.5クライアントが、V1.8サーバーに接続している際にのみ適用されます。

--- a/common/src/main/resources/config/nl.yml
+++ b/common/src/main/resources/config/nl.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Dit forceert het gebruik van een "NoOp" (No Operation) handler tenzij er een aangepaste via de API wordt geleverd.
 disable-default-resync-handler: false
 
+# Moet Grim zich aansluiten bij Polymer om aangepaste blokken te vertalen?
+# Dit is alleen van toepassing op Fabric-servers met Polymer geïnstalleerd.
+# Als het is ingeschakeld, zal Grim Polymer vragen om de blokstatus aan de clientzijde bij het uitvoeren van resynchronisatie.
+polymer-hook: true
+
 # Moet het dubbele bewegingspakket worden geannuleerd?
 # Mojang heeft dit probleem opgelost in 1.21. Dit was hun poging om de "bucket desync" op te lossen. https://bugs.mojang.com/browse/MC-12363
 # Deze instelling geldt alleen voor 1.17-1.20.5 clients op 1.8 servers

--- a/common/src/main/resources/config/pl.yml
+++ b/common/src/main/resources/config/pl.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Wymusza to użycie procedury obsługi „NoOp” (No Operation), chyba że zostanie ona udostępniona za pośrednictwem API.
 disable-default-resync-handler: false
 
+# Czy Grim powinien podłączyć się do Polymer, aby tłumaczyć niestandardowe bloki?
+# Dotyczy to tylko serwerów Fabric z zainstalowanym Polymer.
+# Jeśli włączone, Grim zapyta Polymer o stan bloku po stronie klienta podczas wykonywania resynchronizacji.
+polymer-hook: true
+
 # Czy zduplikowany pakiet ruchu powinien zostać anulowany?
 # Mojang naprawił ten problem w wersji 1.21. To była ich próba naprawienia „desynchronizacji kontenera”. https://bugs.mojang.com/browse/MC-12363
 # To ustawienie dotyczy tylko klientów 1.17-1.20.5 na serwerach 1.8.

--- a/common/src/main/resources/config/pt.yml
+++ b/common/src/main/resources/config/pt.yml
@@ -56,6 +56,11 @@ disable-pong-cancelling: false
 # Isso força o uso de um manipulador "NoOp" (Sem Operação), a menos que um personalizado seja fornecido via API.
 disable-default-resync-handler: false
 
+# O Grim deve se conectar ao Polymer para traduzir blocos personalizados?
+# Isso é aplicável apenas em servidores Fabric com Polymer instalado.
+# Se ativado, o Grim solicitará ao Polymer o estado do bloco do lado do cliente ao realizar a ressincronização.
+polymer-hook: true
+
 # Deve-se cancelar o pacote de movimento duplicado?
 # A Mojang arrumou esse erro na 1.21, sendo sua tentativa de concertar a dessincronização do balde. https://bugs.mojang.com/browse/MC-12363
 # Isso só se aplica à clientes da 1.17-1.20.5 em servidores da 1.8.

--- a/common/src/main/resources/config/ro.yml
+++ b/common/src/main/resources/config/ro.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Acest lucru forțează utilizarea unui handler "NoOp" (Fără Operațiune), cu excepția cazului în care unul personalizat este furnizat prin API.
 disable-default-resync-handler: false
 
+# Grim ar trebui să se conecteze la Polymer pentru a traduce blocurile personalizate?
+# Acest lucru este valabil doar pe serverele Fabric cu Polymer instalat.
+# Dacă este activat, Grim va cere starea blocului de pe partea clientului de la Polymer atunci când efectuează resincronizarea.
+polymer-hook: true
+
 # Ar trebui să fie anulat pachetul de mișcare duplicat?
 # Mojang a reparat această problemă în 1.21. A fost încercarea lor de a rezolva „bucket desync”. https://bugs.mojang.com/browse/MC-12363
 # Această setare se aplică doar clienților 1.17-1.20.5 pe servere 1.8.

--- a/common/src/main/resources/config/ru.yml
+++ b/common/src/main/resources/config/ru.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Это принудительно включает использование обработчика "NoOp" (бездействия), если через API не предоставлен свой.
 disable-default-resync-handler: false
 
+# Grim должен подключиться к Polymer для перевода пользовательских блоков?
+# Это применимо только на Fabric серверах с установленным Polymer.
+# Если включено, Grim будет запрашивать у Polymer состояние блока на стороне клиента при выполнении ресинхронизации.
+polymer-hook: true
+
 # Should the duplicate movement packet be cancelled?
 # Mojang has fixed this issue in 1.21. This was their attempt to fix the "bucket desync". https://bugs.mojang.com/browse/MC-12363
 # This setting only applies to 1.17-1.20.5 clients on 1.8 servers.

--- a/common/src/main/resources/config/tr.yml
+++ b/common/src/main/resources/config/tr.yml
@@ -55,6 +55,11 @@ disable-pong-cancelling: false
 # Bu, API aracılığıyla özel bir tane sağlanmadıkça bir "NoOp" (İşlemsiz) işleyicisinin kullanılmasını zorlar.
 disable-default-resync-handler: false
 
+# Grim, özel blokları çevirmek için Polymer'e bağlanmalı mı?
+# Bu yalnızca Polymer kurulu olan Fabric sunucularında geçerlidir.
+# Etkinleştirilirse, Grim yeniden senkronizasyon gerçekleştirirken istemci tarafındaki blok durumunu Polymer'den isteyecektir.
+polymer-hook: true
+
 # Kopya hareket paketinin iptal edilip edilmemesi gerektiği
 # Mojang bu sorunu 1.21'de çözdü. Bu, "kova senkronizasyonu" sorununu düzeltme girişimiydi. https://bugs.mojang.com/browse/MC-12363
 # Bu ayar yalnızca 1.17-1.20.5 istemcileri için 1.8 sunucularında geçerlidir.

--- a/common/src/main/resources/config/zh.yml
+++ b/common/src/main/resources/config/zh.yml
@@ -58,6 +58,11 @@ disable-pong-cancelling: false
 # 除非通过 API 提供了自定义处理程序，否则这将强制使用 "NoOp"（无操作）处理程序。
 disable-default-resync-handler: false
 
+# Grim是否应该挂钩到Polymer以翻译自定义方块？
+# 这仅适用于安装了Polymer的Fabric服务器。
+# 如果启用，Grim在进行重新同步时会向Polymer请求客户端侧的方块状态。
+polymer-hook: true
+
 # 是否对重复的移动数据包进行撤销?
 # 这可以修复 "bucket desync"（桶不同步问题）. https://bugs.mojang.com/browse/MC-12363,不过Mojang已经在1.21修复了这个问题
 # 这仅仅适用于1.8服务器中使用1.17-1.20.5版本的玩家

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/PolymerHook.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/utils/PolymerHook.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.platform.fabric.utils;
 
+import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.platform.api.player.BlockTranslator;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.level.ServerPlayer;
@@ -56,7 +57,7 @@ public class PolymerHook {
     }
 
     public static BlockTranslator createTranslator(ServerPlayer player) {
-        if (!HAS_POLYMER || CREATE_CONTEXT == null || GET_STATE == null) {
+        if (!HAS_POLYMER || !GrimAPI.INSTANCE.getConfigManager().isPolymerHook() || CREATE_CONTEXT == null || GET_STATE == null) {
             return BlockTranslator.IDENTITY;
         }
 


### PR DESCRIPTION
This simply adds a toggle for Grim's polymer hook.

Why?
It makes it so ViaFabric, ViaBackwards, Grim, and Polymer all play nice together. The issue is that Polymer allows you to disable its networking in its own config, but Grim doesn't have a way to 'see' that change. If Polymer's networking is off but Grim keeps trying to hook into it, it causes some weird packet junk I don't understand at all. This setting lets you manually tell Grim to stop hooking into Polymer, making it way easier to keep all four mods so you don't have to recompile Grim just for this niche bug.