### PR TITLE
Fix simulation false with fence's/iron bars and daylight detectors

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
+++ b/common/src/main/java/ac/grim/grimac/utils/collisions/blocks/connecting/DynamicConnecting.java
@@ -102,7 +102,7 @@ public class DynamicConnecting {
 
         return m == StateTypes.ENCHANTING_TABLE || m == StateTypes.FARMLAND || m == StateTypes.CARVED_PUMPKIN || m == StateTypes.JACK_O_LANTERN || m == StateTypes.PUMPKIN || m == StateTypes.MELON ||
                 m == StateTypes.BEACON || BlockTags.CAULDRONS.contains(m) || m == StateTypes.GLOWSTONE || m == StateTypes.SEA_LANTERN || m == StateTypes.ICE
-                || m == StateTypes.PISTON || m == StateTypes.STICKY_PISTON || m == StateTypes.PISTON_HEAD || (!canConnectToGlassBlock()
+                || m == StateTypes.PISTON || m == StateTypes.STICKY_PISTON || m == StateTypes.PISTON_HEAD || m == StateTypes.DAYLIGHT_DETECTOR || (!canConnectToGlassBlock()
                 && BlockTags.GLASS_BLOCKS.contains(m));
     }
 


### PR DESCRIPTION
Fixes an old issue with older versions where Grim thinks that daylight detectors are a block that fences / iron bars can connect to.

Tested patch on both 1.8.9 spigot / client and 1.20.5 and works on both.

Related issue: https://github.com/GrimAnticheat/Grim/issues/1856