### PR TITLE
Fix book page length check

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/exploit/ExploitB.java
@@ -279,7 +279,7 @@ public class ExploitB extends Check implements PacketCheck {
     }
 
     private boolean checkPage(String page, PacketReceiveEvent event) {
-        if (page.length() > 256) {
+        if (page.length() > (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_14) ? 1023 : 256)) {
             if (flagAndAlert("page too long") && shouldModifyPackets()) {
                 event.setCancelled(true);
                 player.onPacketCancel();


### PR DESCRIPTION
The book page length was limited to 256 characters. This limit was the hard character length limit in versions 1.13 and below, but it was increased to 1023 in 1.14 and above. This PR simply adds adds an additional check of the client version to limit the page length correctly.

This issue was regularly encountered by players writing books normally on my server, indicating that it is easy for modern clients to reach the 256 character limit.