### PR TITLE
fix entity boundingbox replication regression

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -171,6 +171,7 @@ tasks {
             vendor = JvmVendorSpec.JETBRAINS
             languageVersion = JavaLanguageVersion.of(25)
         }
+        systemProperties(mapOf("paper.explicit-flush" to "true"))
         minecraftVersion("26.1.2")
     }
 

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -45,8 +45,10 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
         if (!super.shouldInjectEndTick()) {
             return;
         }
+        boolean flush = false;
         if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_11_2) && !Boolean.getBoolean("paper.explicit-flush")) {
             LogUtil.warn("Reach.enable-post-packet=true but paper.explicit-flush=false, add \"-Dpaper.explicit-flush=true\" to your server's startup flags for fully functional extra reach accuracy.");
+            flush = true;
         }
         // this is necessary for folia
         if (GrimAPI.INSTANCE.getPlatform() == Platform.FOLIA) {
@@ -54,7 +56,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             return;
         }
         // if it fails to register Paper event, try to inject via reflection
-        if (!PaperUtils.registerTickEndEvent(this, this::tickAllPlayers) && !injectWithReflection()) {
+        if (!PaperUtils.registerTickEndEvent(this, () -> this.tickAllPlayers(true)) && !injectWithReflection(flush)) {
             LogUtil.error("Failed to inject into the end of tick event!");
 
             if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_14_4)) {
@@ -68,10 +70,10 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
         }
     }
 
-    private void tickAllPlayers() {
+    private void tickAllPlayers(boolean flush) {
         for (GrimPlayer player : GrimAPI.INSTANCE.getPlayerDataManager().getEntries()) {
             if (player.disableGrim) continue;
-            super.onEndOfTick(player);
+            super.onEndOfTick(player, flush);
         }
     }
 
@@ -81,11 +83,11 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             if (player.platformPlayer == null) continue;
             Player p = ((BukkitPlatformPlayer) player.platformPlayer).getNative();
             if (!Bukkit.isOwnedByCurrentRegion(p)) continue;
-            super.onEndOfTick(player);
+            super.onEndOfTick(player, true);
         }
     }
 
-    private boolean injectWithReflection() {
+    private boolean injectWithReflection(boolean flush) {
         // Inject so we can add the final transaction pre-flush event
         try {
             Object connection = SpigotReflectionUtil.getMinecraftServerConnectionInstance();
@@ -102,7 +104,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             List<?> wrapper = Collections.synchronizedList(new HookedListWrapper<>(endOfTickObject) {
                 @Override
                 public void onIterator() {
-                    tickAllPlayers();
+                    tickAllPlayers(flush);
                 }
             });
 

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/initables/BukkitTickEndEvent.java
@@ -46,7 +46,7 @@ public class BukkitTickEndEvent extends AbstractTickEndEvent implements Listener
             return;
         }
         boolean flush = false;
-        if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThan(ServerVersion.V_1_11_2) && !Boolean.getBoolean("paper.explicit-flush")) {
+        if (!PaperUtils.HAS_TICK_END_EVENT && !Boolean.getBoolean("paper.explicit-flush")) {
             LogUtil.warn("Reach.enable-post-packet=true but paper.explicit-flush=false, add \"-Dpaper.explicit-flush=true\" to your server's startup flags for fully functional extra reach accuracy.");
             flush = true;
         }

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/utils/reflection/PaperUtils.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/utils/reflection/PaperUtils.java
@@ -15,6 +15,8 @@ public class PaperUtils {
     public static final boolean PAPER = ReflectionUtils.hasClass("com.destroystokyo.paper.PaperConfig")
             || ReflectionUtils.hasClass("io.papermc.paper.configuration.Configuration");
     public static final boolean HAS_TELEPORT_ASYNC = ReflectionUtils.hasMethod(Entity.class, "teleportAsync");
+    private static final Class<?> SERVER_TICK_END_EVENT_CLASS = ReflectionUtils.getClass("com.destroystokyo.paper.event.server.ServerTickEndEvent");
+    public static final boolean HAS_TICK_END_EVENT = SERVER_TICK_END_EVENT_CLASS != null;
 
     public static CompletableFuture<Boolean> teleportAsync(final Entity entity, final Location location) {
         return HAS_TELEPORT_ASYNC ? entity.teleportAsync(location) : CompletableFuture.completedFuture(entity.teleport(location));
@@ -23,10 +25,9 @@ public class PaperUtils {
     @SuppressWarnings("unchecked")
     public static boolean registerTickEndEvent(Listener listener, Runnable runnable) {
         try {
-            Class<?> clazz = ReflectionUtils.getClass("com.destroystokyo.paper.event.server.ServerTickEndEvent");
-            if (clazz == null) return false;
+            if (!HAS_TICK_END_EVENT) return false;
             GrimACBukkitLoaderPlugin.LOADER.getServer().getPluginManager().registerEvent(
-                    (Class<? extends Event>) clazz,
+                    (Class<? extends Event>) SERVER_TICK_END_EVENT_CLASS,
                     listener,
                     EventPriority.NORMAL,
                     (l, event) -> runnable.run(),

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -550,9 +550,10 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                 (player.compensatedEntities.serverPlayerVehicle != null && entityID == player.compensatedEntities.serverPlayerVehicle);
     }
 
-    public void onEndOfTickEvent() {
+    public void onEndOfTickEvent(boolean async, boolean flush) {
         // Only send a transaction at the end of the tick if we are tracking players
-        player.sendTransaction(true); // We injected before vanilla flushes :) we don't need to flush
+        player.sendTransaction(async);
+        if (flush) player.user.flushPackets();
     }
 
     public void tickStartTick() {

--- a/common/src/main/java/ac/grim/grimac/manager/init/start/AbstractTickEndEvent.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/start/AbstractTickEndEvent.java
@@ -11,8 +11,8 @@ public abstract class AbstractTickEndEvent implements StartableInitable {
 
     }
 
-    protected void onEndOfTick(GrimPlayer player) {
-        player.checkManager.getPacketEntityReplication().onEndOfTickEvent();
+    protected void onEndOfTick(GrimPlayer player, boolean flush) {
+        player.checkManager.getPacketEntityReplication().onEndOfTickEvent(true, flush);
     }
 
     protected boolean shouldInjectEndTick() {

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/initables/FabricTickEndEvent.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/initables/FabricTickEndEvent.java
@@ -25,7 +25,7 @@ public class FabricTickEndEvent extends AbstractTickEndEvent {
     private void tickAllPlayers() {
         for (GrimPlayer player : GrimAPI.INSTANCE.getPlayerDataManager().getEntries()) {
             if (player.disableGrim) continue;
-            super.onEndOfTick(player);
+            super.onEndOfTick(player, true);
         }
     }
 }


### PR DESCRIPTION
started with https://github.com/GrimAnticheat/Grim/pull/2388

it's the same reason why we need ``"-Dpaper.explicit-flush=true"``
we need to flush channel if we're using tick end event