### PR TITLE
punishment: anchor N:M intervals at N

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -130,9 +130,10 @@ public class PunishmentManager implements ConfigReloadable {
                     }
 
                     if (violationCount >= command.threshold) {
-                        // 0 means execute once
-                        // Any other number means execute every X interval
-                        boolean inInterval = command.interval == 0 ? (command.executeCount == 0) : (violationCount % command.interval == 0);
+                        // 0 means execute once at the threshold; otherwise fire at N, N+M, N+2M, ...
+                        boolean inInterval = command.interval == 0
+                                ? (command.executeCount == 0)
+                                : ((violationCount - command.threshold) % command.interval == 0);
                         if (inInterval) {
                             if (COMMAND_CHANNEL.fire(player, check, verbose, cmd)) continue;
 

--- a/common/src/main/resources/punishments/en.yml
+++ b/common/src/main/resources/punishments/en.yml
@@ -22,12 +22,13 @@ Punishments:
       - "NoFall"
     # Threshold:Interval Command
     #
-    # Example, to kick the player with the message "incorrect movement!" after 100 violations, with no interval
-    # commands:
-    # - "100:0 kick %player% incorrect movement!"
-    # 0 means execute exactly once
-    # - "100:50 say %player% is cheating"
-    # Execute when the user hits flag 100, and after that, every 50th flag after 100
+    # Fires on flag N, then every M flags after — i.e. at flags N, N+M, N+2M, ...
+    # An interval of 0 means execute exactly once when the threshold is reached.
+    #
+    # Examples:
+    # - "100:0 kick %player% incorrect movement!"   fires once on flag 100
+    # - "100:50 say %player% is cheating"           fires on flags 100, 150, 200, ...
+    # - "5:3 [alert]"                               fires on flags 5, 8, 11, 14, ...
     #
     commands:
       - "100:40 [alert]"


### PR DESCRIPTION
Grim's `punishments.yml` has not done what its documentation claims for a while. It does not fire for the first time at N at intervals of M. It can be off by 1 on first group flag and the interval calculation requires N be a multiple of itself after second punishment trigger.

The full technical explanation: 
`shouldExecute` did `violationCount % command.interval == 0`, which anchors fires to multiples of M regardless of where N sits. The default Simulation group has `100:40 [alert]` and the en.yml comment claims `100:50` fires "every 50th flag after 100" where neither matches `vc % M`. `100:40` fires on flag 121/161/201 today (the surrounding off-by-one `>= threshold` gate also pushes it one further); should be 100/140/180.

Switch the inline expression to `(violationCount - command.threshold) % command.interval == 0` so the schedule is N, N+M, N+2M, ... like the comment promises. Also updated `punishments/en.yml` to describe the schedule honestly with examples for both aligned and non-aligned configs.

Configs (`100:50`, `100:100`, `25:25`, `5:5`) are unchanged, this is technically a behavior change but it does the expected behaviour.