### PR TITLE
inventory: guard SET_PLAYER_INVENTORY against out-of-bounds slot IDs

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedInventory.java
@@ -452,6 +452,7 @@ public class CompensatedInventory extends Check implements PacketCheck {
 
             player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> {
                 if (!isPacketInventoryActive) return;
+                if (slotID < 0 || slotID >= inventory.getSlots().size()) return;
                 inventory.getSlot(slotID).set(item);
             });
         }


### PR DESCRIPTION
Server can send a SET_PLAYER_INVENTORY packet with a slot ID that equals or exceeds the tracked slot count (e.g. slot 46 on a 46-slot player inventory), causing an uncaught IndexOutOfBoundsException in the latency transaction lambda. Added a bounds check to skip the update silently when the slot ID is out of range.

Reproduced with Asteroid fake players on Leaf 1.21.11.