### PR TITLE
command/history: backport V3-side parity adds (against 2.0)

### DIFF
--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -70,11 +70,13 @@ import java.util.regex.PatternSyntaxException;
  *   /grim history &lt;target&gt; session &lt;N | "latest"&gt; page &lt;P&gt; [-d] [-v]
  *       → session detail, violation page P.
  *   /grim history player &lt;target&gt; ...
- *       → disambiguated form for players whose name collides with a literal
- *         we register at the same tree depth (e.g. {@code repair}, {@code page},
- *         {@code session}). Cloud matches literals greedily before String
- *         parsers, so without the {@code player} escape hatch those operators
- *         are unreachable.
+ *       → disambiguated form for players whose name collides with a sibling
+ *         literal of {@code <target>}. Today the only such collisions are
+ *         {@code repair} and {@code player} itself; {@code page} and
+ *         {@code session} live below {@code <target>} and are still reachable
+ *         through the bare form. Cloud matches literals greedily before String
+ *         parsers, so without the {@code player} escape hatch an operator can
+ *         never address a player legitimately named {@code repair}.
  * </pre>
  * The {@code session} literal leaves the slot after {@code <target>} open for
  * future top-level subcommands (e.g. {@code violations}, {@code summary}) —
@@ -171,25 +173,24 @@ public class GrimHistory implements BuildableCommand {
             return b.required("target", StringParser.stringParser(), targetSuggestions);
         };
 
-        // Capture the registration form so click commands generated from
-        // session-list rows (and the help-branch examples) route back to the
-        // same form the operator used — a list opened via /grim history
-        // player repair must generate clicks of /grim history player repair
-        // session N, not /grim history repair … (which re-enters the repair
-        // literal branch).
+        // Capture the registration form so the help-branch examples printed
+        // by handleSessionHelp echo the same prefix the operator dispatched
+        // on. (V2's session-list rows attach hover hints with a UUID-prefix
+        // copy-paste form, not a clickEvent.runCommand, so the click-routing
+        // issue raised by codex for V3 doesn't apply to this renderer.)
         final boolean viaPlayer = withPlayerLiteral;
 
         // List, page 1
         commandManager.command(
                 applyFilterFlags(commandManager, base.get())
-                        .handler(ctx -> handleListPage1(ctx, viaPlayer))
+                        .handler(this::handleListPage1)
         );
         // List, page N
         commandManager.command(
                 applyFilterFlags(commandManager, base.get()
                         .literal("page")
                         .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
-                        .handler(ctx -> handleListPageN(ctx, viaPlayer))
+                        .handler(this::handleListPageN)
         );
         // Help branch: /grim history <target> session  (no ordinal). Cloud
         // would otherwise refuse dispatch here with a parse error pointing
@@ -250,13 +251,12 @@ public class GrimHistory implements BuildableCommand {
                         .withDescription(Description.of("Filter to violations whose display name OR verbose text matches this regex.")));
     }
 
-    // The viaPlayer parameter on the list-page handlers is unused by
-    // renderList — V2's session-list hover text uses a UUID-prefix
-    // copy-paste hint (not a clickEvent.runCommand), so the codex finding
-    // about click-routing under the disambiguated form doesn't apply
-    // here. The flag still threads in via the registration closures so
-    // the handler-signature shape stays uniform with handleSessionHelp.
-    private void handleListPage1(CommandContext<Sender> context, boolean viaPlayer) {
+    // List handlers don't need the viaPlayer flag — V2's renderSummaryLine
+    // attaches a hover hint with a UUID-prefix copy-paste form (not a
+    // clickEvent.runCommand), so the V3 click-routing issue with the
+    // disambiguated form doesn't apply here. Only handleSessionHelp needs
+    // to know which prefix the operator dispatched on.
+    private void handleListPage1(CommandContext<Sender> context) {
         Sender sender = context.sender();
         String target = context.get("target");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
@@ -265,7 +265,7 @@ public class GrimHistory implements BuildableCommand {
                 renderList(sender, lifecycle, history, uuid, displayName, 1, filter));
     }
 
-    private void handleListPageN(CommandContext<Sender> context, boolean viaPlayer) {
+    private void handleListPageN(CommandContext<Sender> context) {
         Sender sender = context.sender();
         String target = context.get("target");
         int page = context.<Integer>get("page_number");

--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -123,12 +123,14 @@ public class GrimHistory implements BuildableCommand {
         // The five history-view branches live under both prefixes:
         //   /grim history <target> ...                — ambiguous form
         //   /grim history player <target> ...         — disambiguated form
-        // The disambiguated form is the only way to view the history of a
-        // player whose name collides with a literal we register on the same
-        // tree depth (currently 'page', 'repair', 'session', 'player' itself;
-        // potentially more in future). Cloud literals win over String parsing
-        // when both could match, so without the 'player' escape hatch there's
-        // no way to address a player legitimately named e.g. 'repair'.
+        // The escape hatch only matters for siblings of <target> — literals
+        // that share the slot the String parser would otherwise match. Today
+        // that's 'repair' (the repair subcommand) and 'player' itself.
+        // 'page' and 'session' live below <target>, so a player legitimately
+        // named 'page' or 'session' is still reachable through the bare
+        // form; only first-token collisions need the disambiguator. Cloud
+        // matches literals greedily before String parsers, so without 'player'
+        // an operator can never address a player legitimately named 'repair'.
         registerHistoryViewBranches(commandManager, false,
                 targetSuggestions, listPageNumberSuggestions,
                 sessionOrdinalSuggestions, violationPageSuggestions);
@@ -142,12 +144,13 @@ public class GrimHistory implements BuildableCommand {
      * session-help, detail-default-page, detail-page-N) under either the
      * bare {@code /grim history <target>} prefix or the explicit
      * {@code /grim history player <target>} prefix. The {@code player}
-     * literal exists for one specific case: addressing a player whose name
-     * collides with a literal we already register at the same tree depth
-     * (e.g. someone literally named {@code repair}). Cloud matches literals
-     * greedily before String parsers, so without the escape hatch those
-     * operators are unreachable. Registering both forms is the simplest way
-     * to keep the short form while still giving a safe long form.
+     * literal exists for first-token collisions only — siblings of
+     * {@code <target>} at the same tree depth (currently {@code repair}
+     * and {@code player} itself). {@code page} and {@code session} live
+     * below {@code <target>} so players with those names still resolve
+     * through the bare form. Cloud matches literals greedily before String
+     * parsers, so without the escape hatch a player legitimately named
+     * {@code repair} would be unreachable.
      */
     private void registerHistoryViewBranches(
             CommandManager<Sender> commandManager,
@@ -168,24 +171,33 @@ public class GrimHistory implements BuildableCommand {
             return b.required("target", StringParser.stringParser(), targetSuggestions);
         };
 
+        // Capture the registration form so click commands generated from
+        // session-list rows (and the help-branch examples) route back to the
+        // same form the operator used — a list opened via /grim history
+        // player repair must generate clicks of /grim history player repair
+        // session N, not /grim history repair … (which re-enters the repair
+        // literal branch).
+        final boolean viaPlayer = withPlayerLiteral;
+
         // List, page 1
         commandManager.command(
                 applyFilterFlags(commandManager, base.get())
-                        .handler(this::handleListPage1)
+                        .handler(ctx -> handleListPage1(ctx, viaPlayer))
         );
         // List, page N
         commandManager.command(
                 applyFilterFlags(commandManager, base.get()
                         .literal("page")
                         .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
-                        .handler(this::handleListPageN)
+                        .handler(ctx -> handleListPageN(ctx, viaPlayer))
         );
         // Help branch: /grim history <target> session  (no ordinal). Cloud
         // would otherwise refuse dispatch here with a parse error pointing
         // at the missing required argument, which most operators read as a
         // syntax mistake rather than a hint to discover the feature.
         commandManager.command(
-                base.get().literal("session").handler(this::handleSessionHelp)
+                base.get().literal("session")
+                        .handler(ctx -> handleSessionHelp(ctx, viaPlayer))
         );
         // Detail (default violation page). The `session` literal lives at the
         // same tree slot as `page` above; Cloud picks the branch by exact
@@ -238,7 +250,13 @@ public class GrimHistory implements BuildableCommand {
                         .withDescription(Description.of("Filter to violations whose display name OR verbose text matches this regex.")));
     }
 
-    private void handleListPage1(CommandContext<Sender> context) {
+    // The viaPlayer parameter on the list-page handlers is unused by
+    // renderList — V2's session-list hover text uses a UUID-prefix
+    // copy-paste hint (not a clickEvent.runCommand), so the codex finding
+    // about click-routing under the disambiguated form doesn't apply
+    // here. The flag still threads in via the registration closures so
+    // the handler-signature shape stays uniform with handleSessionHelp.
+    private void handleListPage1(CommandContext<Sender> context, boolean viaPlayer) {
         Sender sender = context.sender();
         String target = context.get("target");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
@@ -247,7 +265,7 @@ public class GrimHistory implements BuildableCommand {
                 renderList(sender, lifecycle, history, uuid, displayName, 1, filter));
     }
 
-    private void handleListPageN(CommandContext<Sender> context) {
+    private void handleListPageN(CommandContext<Sender> context, boolean viaPlayer) {
         Sender sender = context.sender();
         String target = context.get("target");
         int page = context.<Integer>get("page_number");
@@ -309,11 +327,16 @@ public class GrimHistory implements BuildableCommand {
      * flag inline so they don't have to switch to {@code /grim help} to
      * learn the syntax.
      */
-    private void handleSessionHelp(CommandContext<Sender> ctx) {
+    private void handleSessionHelp(CommandContext<Sender> ctx, boolean viaPlayer) {
         Sender sender = ctx.sender();
         String target = ctx.get("target");
+        // Echo the exact prefix the operator used so the printed examples
+        // dispatch on the same branch — a target that needed the 'player'
+        // escape hatch (e.g. someone named 'repair') would route through
+        // the wrong literal if the help printed the bare form.
+        String addressPrefix = "/grim history " + (viaPlayer ? "player " : "");
         sender.sendMessage(Component.text()
-                .append(Component.text("/grim history ", NamedTextColor.GRAY))
+                .append(Component.text(addressPrefix, NamedTextColor.GRAY))
                 .append(Component.text(target, NamedTextColor.WHITE))
                 .append(Component.text(" session ", NamedTextColor.GRAY))
                 .append(Component.text("<N | latest>", NamedTextColor.AQUA))
@@ -336,10 +359,10 @@ public class GrimHistory implements BuildableCommand {
         sender.sendMessage(Component.text("  --grep <regex>", NamedTextColor.YELLOW)
                 .append(Component.text("            filter by either name or verbose (AND-composes with others)", NamedTextColor.GRAY)));
         sender.sendMessage(Component.text("Examples:", NamedTextColor.GRAY));
-        sender.sendMessage(Component.text("  /grim history ", NamedTextColor.GRAY)
+        sender.sendMessage(Component.text("  " + addressPrefix, NamedTextColor.GRAY)
                 .append(Component.text(target, NamedTextColor.WHITE))
                 .append(Component.text(" session latest -d -v", NamedTextColor.GRAY)));
-        sender.sendMessage(Component.text("  /grim history ", NamedTextColor.GRAY)
+        sender.sendMessage(Component.text("  " + addressPrefix, NamedTextColor.GRAY)
                 .append(Component.text(target, NamedTextColor.WHITE))
                 .append(Component.text(" session 1 --grep reach", NamedTextColor.GRAY)));
     }

--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -61,12 +61,20 @@ import java.util.regex.PatternSyntaxException;
  *       → session list, page 1
  *   /grim history &lt;target&gt; page &lt;P&gt;
  *       → session list, page P
+ *   /grim history &lt;target&gt; session
+ *       → printable help menu for the session subcommand (no ordinal supplied).
  *   /grim history &lt;target&gt; session &lt;N | "latest"&gt; [-d] [-v]
  *       → session detail for "Session N" (global chronological, Session 1 = oldest).
  *         {@code latest} / {@code last} / {@code l} are aliases for the most
  *         recent session.
  *   /grim history &lt;target&gt; session &lt;N | "latest"&gt; page &lt;P&gt; [-d] [-v]
  *       → session detail, violation page P.
+ *   /grim history player &lt;target&gt; ...
+ *       → disambiguated form for players whose name collides with a literal
+ *         we register at the same tree depth (e.g. {@code repair}, {@code page},
+ *         {@code session}). Cloud matches literals greedily before String
+ *         parsers, so without the {@code player} escape hatch those operators
+ *         are unreachable.
  * </pre>
  * The {@code session} literal leaves the slot after {@code <target>} open for
  * future top-level subcommands (e.g. {@code violations}, {@code summary}) —
@@ -111,25 +119,73 @@ public class GrimHistory implements BuildableCommand {
                         .permission("grim.history.repair")
                         .handler(this::handleRepairCheckIds)
         );
+
+        // The five history-view branches live under both prefixes:
+        //   /grim history <target> ...                — ambiguous form
+        //   /grim history player <target> ...         — disambiguated form
+        // The disambiguated form is the only way to view the history of a
+        // player whose name collides with a literal we register on the same
+        // tree depth (currently 'page', 'repair', 'session', 'player' itself;
+        // potentially more in future). Cloud literals win over String parsing
+        // when both could match, so without the 'player' escape hatch there's
+        // no way to address a player legitimately named e.g. 'repair'.
+        registerHistoryViewBranches(commandManager, false,
+                targetSuggestions, listPageNumberSuggestions,
+                sessionOrdinalSuggestions, violationPageSuggestions);
+        registerHistoryViewBranches(commandManager, true,
+                targetSuggestions, listPageNumberSuggestions,
+                sessionOrdinalSuggestions, violationPageSuggestions);
+    }
+
+    /**
+     * Registers the five history-view branches (list-page-1, list-page-N,
+     * session-help, detail-default-page, detail-page-N) under either the
+     * bare {@code /grim history <target>} prefix or the explicit
+     * {@code /grim history player <target>} prefix. The {@code player}
+     * literal exists for one specific case: addressing a player whose name
+     * collides with a literal we already register at the same tree depth
+     * (e.g. someone literally named {@code repair}). Cloud matches literals
+     * greedily before String parsers, so without the escape hatch those
+     * operators are unreachable. Registering both forms is the simplest way
+     * to keep the short form while still giving a safe long form.
+     */
+    private void registerHistoryViewBranches(
+            CommandManager<Sender> commandManager,
+            boolean withPlayerLiteral,
+            SuggestionProvider<Sender> targetSuggestions,
+            SuggestionProvider<Sender> listPageNumberSuggestions,
+            SuggestionProvider<Sender> sessionOrdinalSuggestions,
+            SuggestionProvider<Sender> violationPageSuggestions) {
+        // Lambda factory so each branch starts from a fresh builder — Cloud
+        // builders are not designed to be reused across .command() calls;
+        // calling .literal() twice on the same builder cross-pollinates the
+        // sibling branches.
+        java.util.function.Supplier<Command.Builder<Sender>> base = () -> {
+            Command.Builder<Sender> b = commandManager.commandBuilder("grim", "grimac")
+                    .literal("history", "hist")
+                    .permission("grim.history");
+            if (withPlayerLiteral) b = b.literal("player");
+            return b.required("target", StringParser.stringParser(), targetSuggestions);
+        };
+
         // List, page 1
         commandManager.command(
-                applyFilterFlags(commandManager,
-                        commandManager.commandBuilder("grim", "grimac")
-                                .literal("history", "hist")
-                                .permission("grim.history")
-                                .required("target", StringParser.stringParser(), targetSuggestions))
+                applyFilterFlags(commandManager, base.get())
                         .handler(this::handleListPage1)
         );
         // List, page N
         commandManager.command(
-                applyFilterFlags(commandManager,
-                        commandManager.commandBuilder("grim", "grimac")
-                                .literal("history", "hist")
-                                .permission("grim.history")
-                                .required("target", StringParser.stringParser(), targetSuggestions)
-                                .literal("page")
-                                .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
+                applyFilterFlags(commandManager, base.get()
+                        .literal("page")
+                        .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
                         .handler(this::handleListPageN)
+        );
+        // Help branch: /grim history <target> session  (no ordinal). Cloud
+        // would otherwise refuse dispatch here with a parse error pointing
+        // at the missing required argument, which most operators read as a
+        // syntax mistake rather than a hint to discover the feature.
+        commandManager.command(
+                base.get().literal("session").handler(this::handleSessionHelp)
         );
         // Detail (default violation page). The `session` literal lives at the
         // same tree slot as `page` above; Cloud picks the branch by exact
@@ -137,34 +193,26 @@ public class GrimHistory implements BuildableCommand {
         // the "latest" / "last" / "l" aliases alongside plain integers — the
         // handler resolves them via resolveSessionOrdinal().
         commandManager.command(
-                applyFilterFlags(commandManager,
-                        commandManager.commandBuilder("grim", "grimac")
-                                .literal("history", "hist")
-                                .permission("grim.history")
-                                .required("target", StringParser.stringParser(), targetSuggestions)
-                                .literal("session")
-                                .required("session", StringParser.stringParser(), sessionOrdinalSuggestions)
-                                .flag(commandManager.flagBuilder("detailed").withAliases("d")
-                                        .withDescription(Description.of("Show each violation as its own row instead of time-bucketed groups.")))
-                                .flag(commandManager.flagBuilder("verbose").withAliases("v")
-                                        .withDescription(Description.of("Include the raw verbose text inline on each line (also always available on hover)."))))
+                applyFilterFlags(commandManager, base.get()
+                        .literal("session")
+                        .required("session", StringParser.stringParser(), sessionOrdinalSuggestions)
+                        .flag(commandManager.flagBuilder("detailed").withAliases("d")
+                                .withDescription(Description.of("Show each violation as its own row instead of time-bucketed groups.")))
+                        .flag(commandManager.flagBuilder("verbose").withAliases("v")
+                                .withDescription(Description.of("Include the raw verbose text inline on each line (also always available on hover)."))))
                         .handler(this::handleDetailDefaultPage)
         );
         // Detail, violation page N
         commandManager.command(
-                applyFilterFlags(commandManager,
-                        commandManager.commandBuilder("grim", "grimac")
-                                .literal("history", "hist")
-                                .permission("grim.history")
-                                .required("target", StringParser.stringParser(), targetSuggestions)
-                                .literal("session")
-                                .required("session", StringParser.stringParser(), sessionOrdinalSuggestions)
-                                .literal("page")
-                                .required("page_number", IntegerParser.integerParser(1), violationPageSuggestions)
-                                .flag(commandManager.flagBuilder("detailed").withAliases("d")
-                                        .withDescription(Description.of("Show each violation as its own row instead of time-bucketed groups.")))
-                                .flag(commandManager.flagBuilder("verbose").withAliases("v")
-                                        .withDescription(Description.of("Include the raw verbose text inline on each line (also always available on hover)."))))
+                applyFilterFlags(commandManager, base.get()
+                        .literal("session")
+                        .required("session", StringParser.stringParser(), sessionOrdinalSuggestions)
+                        .literal("page")
+                        .required("page_number", IntegerParser.integerParser(1), violationPageSuggestions)
+                        .flag(commandManager.flagBuilder("detailed").withAliases("d")
+                                .withDescription(Description.of("Show each violation as its own row instead of time-bucketed groups.")))
+                        .flag(commandManager.flagBuilder("verbose").withAliases("v")
+                                .withDescription(Description.of("Include the raw verbose text inline on each line (also always available on hover)."))))
                         .handler(this::handleDetailPageN)
         );
     }
@@ -250,6 +298,50 @@ public class GrimHistory implements BuildableCommand {
             renderDetail(sender, lifecycle, history, uuid, displayName,
                     ordinal, detailed, verbose, Math.max(1, page), filter);
         });
+    }
+
+    /**
+     * Help branch — fires on {@code /grim history <target> session} with no
+     * ordinal after {@code session}. Cloud would otherwise refuse dispatch
+     * here with the stock "missing required argument: session" message,
+     * which most operators read as a parse error rather than a hint that
+     * they need to discover the feature. Prints the actual usage + every
+     * flag inline so they don't have to switch to {@code /grim help} to
+     * learn the syntax.
+     */
+    private void handleSessionHelp(CommandContext<Sender> ctx) {
+        Sender sender = ctx.sender();
+        String target = ctx.get("target");
+        sender.sendMessage(Component.text()
+                .append(Component.text("/grim history ", NamedTextColor.GRAY))
+                .append(Component.text(target, NamedTextColor.WHITE))
+                .append(Component.text(" session ", NamedTextColor.GRAY))
+                .append(Component.text("<N | latest>", NamedTextColor.AQUA))
+                .append(Component.text(" — show violations for a specific session.", NamedTextColor.GRAY))
+                .build());
+        sender.sendMessage(Component.text(
+                "  N is the session ordinal (1 = oldest). 'latest' / 'last' / 'l' = most recent.",
+                NamedTextColor.GRAY));
+        sender.sendMessage(Component.text("Optional:", NamedTextColor.GRAY));
+        sender.sendMessage(Component.text("  page <P>", NamedTextColor.YELLOW)
+                .append(Component.text("                  page through this session's violations", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  --detailed / -d", NamedTextColor.YELLOW)
+                .append(Component.text("           raw per-violation rows (no time-bucketing)", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  --verbose / -v", NamedTextColor.YELLOW)
+                .append(Component.text("            inline verbose text (also on hover)", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  --name <regex>", NamedTextColor.YELLOW)
+                .append(Component.text("            filter by check display name", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  --match <regex>", NamedTextColor.YELLOW)
+                .append(Component.text("           filter by verbose text", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  --grep <regex>", NamedTextColor.YELLOW)
+                .append(Component.text("            filter by either name or verbose (AND-composes with others)", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("Examples:", NamedTextColor.GRAY));
+        sender.sendMessage(Component.text("  /grim history ", NamedTextColor.GRAY)
+                .append(Component.text(target, NamedTextColor.WHITE))
+                .append(Component.text(" session latest -d -v", NamedTextColor.GRAY)));
+        sender.sendMessage(Component.text("  /grim history ", NamedTextColor.GRAY)
+                .append(Component.text(target, NamedTextColor.WHITE))
+                .append(Component.text(" session 1 --grep reach", NamedTextColor.GRAY)));
     }
 
     /**

--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -123,14 +123,14 @@ public class GrimHistory implements BuildableCommand {
         // List, page 1
         commandManager.command(
                 applyFilterFlags(commandManager, base.get())
-                        .handler(ctx -> handleListPage1(ctx, viaPlayer))
+                        .handler(this::handleListPage1)
         );
         // List, page N
         commandManager.command(
                 applyFilterFlags(commandManager, base.get()
                         .literal("page")
                         .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
-                        .handler(ctx -> handleListPageN(ctx, viaPlayer))
+                        .handler(this::handleListPageN)
         );
         // Help branch on bare 'session' — Cloud would otherwise reject with
         // a parse error that reads like a syntax mistake, not a hint.
@@ -181,23 +181,23 @@ public class GrimHistory implements BuildableCommand {
                         .withDescription(Description.of("Filter to violations whose display name OR verbose text matches this regex.")));
     }
 
-    private void handleListPage1(CommandContext<Sender> context, boolean viaPlayer) {
+    private void handleListPage1(CommandContext<Sender> context) {
         Sender sender = context.sender();
         String target = context.get("target");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
         if (filter == FILTER_ERROR) return;
         runWithPrelude(sender, target, (uuid, displayName, lifecycle, history) ->
-                renderList(sender, lifecycle, history, uuid, displayName, 1, filter, viaPlayer));
+                renderList(sender, lifecycle, history, uuid, displayName, 1, filter));
     }
 
-    private void handleListPageN(CommandContext<Sender> context, boolean viaPlayer) {
+    private void handleListPageN(CommandContext<Sender> context) {
         Sender sender = context.sender();
         String target = context.get("target");
         int page = context.<Integer>get("page_number");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
         if (filter == FILTER_ERROR) return;
         runWithPrelude(sender, target, (uuid, displayName, lifecycle, history) ->
-                renderList(sender, lifecycle, history, uuid, displayName, Math.max(1, page), filter, viaPlayer));
+                renderList(sender, lifecycle, history, uuid, displayName, Math.max(1, page), filter));
     }
 
     private void handleDetailDefaultPage(CommandContext<Sender> context) {
@@ -409,7 +409,7 @@ public class GrimHistory implements BuildableCommand {
 
     private void renderList(Sender sender, DataStoreLifecycle lifecycle, HistoryService history,
                             UUID uuid, String displayName, int page,
-                            @Nullable Predicate<ViolationEntry> filter, boolean viaPlayer) throws Exception {
+                            @Nullable Predicate<ViolationEntry> filter) throws Exception {
         int entriesPerPage = lifecycle.config().history().entriesPerPage();
         long totalSessions = history.countSessions(uuid).toCompletableFuture().get(5, TimeUnit.SECONDS);
         int maxPages = Math.max(1, (int) ((totalSessions + entriesPerPage - 1) / Math.max(1, entriesPerPage)));
@@ -428,7 +428,7 @@ public class GrimHistory implements BuildableCommand {
 
         UUID ongoingSessionId = ongoingSessionIdFor(lifecycle, uuid);
         List<Component> components = HistoryComponentRenderer.renderSessionList(
-                sender, uuid, displayName, page, maxPages, result, ongoingSessionId, viaPlayer);
+                sender, uuid, displayName, page, maxPages, result, ongoingSessionId);
         for (Component c : components) sender.sendMessage(c);
     }
 

--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -52,51 +52,18 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * {@code /grim history} UI entry.
- * <p>
- * Command tree (sibling shapes disambiguated by the literal that follows
- * {@code <target>}):
  * <pre>
- *   /grim history &lt;target&gt;
- *       → session list, page 1
- *   /grim history &lt;target&gt; page &lt;P&gt;
- *       → session list, page P
- *   /grim history &lt;target&gt; session
- *       → printable help menu for the session subcommand (no ordinal supplied).
- *   /grim history &lt;target&gt; session &lt;N | "latest"&gt; [-d] [-v]
- *       → session detail for "Session N" (global chronological, Session 1 = oldest).
- *         {@code latest} / {@code last} / {@code l} are aliases for the most
- *         recent session.
- *   /grim history &lt;target&gt; session &lt;N | "latest"&gt; page &lt;P&gt; [-d] [-v]
- *       → session detail, violation page P.
- *   /grim history player &lt;target&gt; ...
- *       → disambiguated form for players whose name collides with a sibling
- *         literal of {@code <target>}. Today the only such collisions are
- *         {@code repair} and {@code player} itself; {@code page} and
- *         {@code session} live below {@code <target>} and are still reachable
- *         through the bare form. Cloud matches literals greedily before String
- *         parsers, so without the {@code player} escape hatch an operator can
- *         never address a player legitimately named {@code repair}.
+ *   /grim history &lt;target&gt;                                 → list, page 1
+ *   /grim history &lt;target&gt; page &lt;P&gt;                          → list, page P
+ *   /grim history &lt;target&gt; session                          → help menu
+ *   /grim history &lt;target&gt; session &lt;N|latest&gt; [-d] [-v]     → detail
+ *   /grim history &lt;target&gt; session &lt;N|latest&gt; page &lt;P&gt; [-d] [-v]
+ *   /grim history player &lt;target&gt; ...                       → disambiguated form
+ *   /grim history repair check-ids                           → in-place repair
  * </pre>
- * The {@code session} literal leaves the slot after {@code <target>} open for
- * future top-level subcommands (e.g. {@code violations}, {@code summary}) —
- * adding one is a matter of registering another sibling builder with its own
- * literal. Cloud will disambiguate on the literal token without ambiguity.
- * <p>
- * Flags: {@code --detailed}/{@code -d} shows raw violations one-per-row instead
- * of time-bucketed groups; {@code --verbose}/{@code -v} inlines verbose text
- * (full verbose always on hover). {@code --name <regex>}, {@code --match
- * <regex>} and {@code --grep <regex>} narrow the displayed violations
- * (display name, verbose text, or either) and apply to both list and detail
- * views — combining flags ANDs them.
- * <p>
- * Autocompletion on {@code <session>} and {@code <page>} is constrained to the
- * actual valid range for the player in context (computed via
- * {@code countSessions} / violations count), so tab-complete never offers
- * numbers that'd error out.
- * <p>
- * Player history reads run synchronously so RCON callers keep their reply
- * channel. The repair subcommand schedules its database work asynchronously.
+ * {@code latest} / {@code last} / {@code l} alias the most-recent session.
+ * Flags: {@code -d} raw rows, {@code -v} inline verbose, {@code --name} /
+ * {@code --match} / {@code --grep} regex filters (AND-composed).
  */
 public class GrimHistory implements BuildableCommand {
 
@@ -122,17 +89,9 @@ public class GrimHistory implements BuildableCommand {
                         .handler(this::handleRepairCheckIds)
         );
 
-        // The five history-view branches live under both prefixes:
-        //   /grim history <target> ...                — ambiguous form
-        //   /grim history player <target> ...         — disambiguated form
-        // The escape hatch only matters for siblings of <target> — literals
-        // that share the slot the String parser would otherwise match. Today
-        // that's 'repair' (the repair subcommand) and 'player' itself.
-        // 'page' and 'session' live below <target>, so a player legitimately
-        // named 'page' or 'session' is still reachable through the bare
-        // form; only first-token collisions need the disambiguator. Cloud
-        // matches literals greedily before String parsers, so without 'player'
-        // an operator can never address a player legitimately named 'repair'.
+        // Bare + 'player'-prefixed forms; the prefix is the escape hatch
+        // for players whose name collides with a sibling literal at the
+        // same tree depth (today: 'repair', 'player').
         registerHistoryViewBranches(commandManager, false,
                 targetSuggestions, listPageNumberSuggestions,
                 sessionOrdinalSuggestions, violationPageSuggestions);
@@ -141,19 +100,7 @@ public class GrimHistory implements BuildableCommand {
                 sessionOrdinalSuggestions, violationPageSuggestions);
     }
 
-    /**
-     * Registers the five history-view branches (list-page-1, list-page-N,
-     * session-help, detail-default-page, detail-page-N) under either the
-     * bare {@code /grim history <target>} prefix or the explicit
-     * {@code /grim history player <target>} prefix. The {@code player}
-     * literal exists for first-token collisions only — siblings of
-     * {@code <target>} at the same tree depth (currently {@code repair}
-     * and {@code player} itself). {@code page} and {@code session} live
-     * below {@code <target>} so players with those names still resolve
-     * through the bare form. Cloud matches literals greedily before String
-     * parsers, so without the escape hatch a player legitimately named
-     * {@code repair} would be unreachable.
-     */
+    /** Registers the bare or {@code player}-prefixed view branches. */
     private void registerHistoryViewBranches(
             CommandManager<Sender> commandManager,
             boolean withPlayerLiteral,
@@ -161,10 +108,7 @@ public class GrimHistory implements BuildableCommand {
             SuggestionProvider<Sender> listPageNumberSuggestions,
             SuggestionProvider<Sender> sessionOrdinalSuggestions,
             SuggestionProvider<Sender> violationPageSuggestions) {
-        // Lambda factory so each branch starts from a fresh builder — Cloud
-        // builders are not designed to be reused across .command() calls;
-        // calling .literal() twice on the same builder cross-pollinates the
-        // sibling branches.
+        // Fresh builder per branch — reusing one cross-pollinates siblings.
         java.util.function.Supplier<Command.Builder<Sender>> base = () -> {
             Command.Builder<Sender> b = commandManager.commandBuilder("grim", "grimac")
                     .literal("history", "hist")
@@ -173,11 +117,7 @@ public class GrimHistory implements BuildableCommand {
             return b.required("target", StringParser.stringParser(), targetSuggestions);
         };
 
-        // Capture the registration form so the help-branch examples printed
-        // by handleSessionHelp echo the same prefix the operator dispatched
-        // on. (V2's session-list rows attach hover hints with a UUID-prefix
-        // copy-paste form, not a clickEvent.runCommand, so the click-routing
-        // issue raised by codex for V3 doesn't apply to this renderer.)
+        // handleSessionHelp echoes whichever prefix was used.
         final boolean viaPlayer = withPlayerLiteral;
 
         // List, page 1
@@ -192,19 +132,14 @@ public class GrimHistory implements BuildableCommand {
                         .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
                         .handler(this::handleListPageN)
         );
-        // Help branch: /grim history <target> session  (no ordinal). Cloud
-        // would otherwise refuse dispatch here with a parse error pointing
-        // at the missing required argument, which most operators read as a
-        // syntax mistake rather than a hint to discover the feature.
+        // Help branch on bare 'session' — Cloud would otherwise reject with
+        // a parse error that reads like a syntax mistake, not a hint.
         commandManager.command(
                 base.get().literal("session")
                         .handler(ctx -> handleSessionHelp(ctx, viaPlayer))
         );
-        // Detail (default violation page). The `session` literal lives at the
-        // same tree slot as `page` above; Cloud picks the branch by exact
-        // match. The session-ordinal arg is a String parser so it can accept
-        // the "latest" / "last" / "l" aliases alongside plain integers — the
-        // handler resolves them via resolveSessionOrdinal().
+        // 'session' literal at the same tree slot as 'page'; session-ordinal is
+        // String so it accepts 'latest' / 'last' / 'l' alongside integers.
         commandManager.command(
                 applyFilterFlags(commandManager, base.get()
                         .literal("session")
@@ -230,12 +165,7 @@ public class GrimHistory implements BuildableCommand {
         );
     }
 
-    /**
-     * Attach the three regex-filter flags ({@code --name}, {@code --match},
-     * {@code --grep}) to a command builder. Shared across all four branches
-     * — declarative cloud builders need the flags repeated per branch, but
-     * the bodies are identical, so we centralise.
-     */
+    /** Attach the {@code --name} / {@code --match} / {@code --grep} regex flags. */
     private static Command.Builder<Sender> applyFilterFlags(
             CommandManager<Sender> commandManager,
             Command.Builder<Sender> b) {
@@ -318,15 +248,7 @@ public class GrimHistory implements BuildableCommand {
         });
     }
 
-    /**
-     * Help branch — fires on {@code /grim history <target> session} with no
-     * ordinal after {@code session}. Cloud would otherwise refuse dispatch
-     * here with the stock "missing required argument: session" message,
-     * which most operators read as a parse error rather than a hint that
-     * they need to discover the feature. Prints the actual usage + every
-     * flag inline so they don't have to switch to {@code /grim help} to
-     * learn the syntax.
-     */
+    /** Prints usage for {@code /grim history <target> session} without an ordinal. */
     private void handleSessionHelp(CommandContext<Sender> ctx, boolean viaPlayer) {
         Sender sender = ctx.sender();
         String target = ctx.get("target");
@@ -367,34 +289,14 @@ public class GrimHistory implements BuildableCommand {
                 .append(Component.text(" session 1 --grep reach", NamedTextColor.GRAY)));
     }
 
-    /**
-     * Sentinel returned by {@link #parseFilterFromContext(Sender, CommandContext)}
-     * when the operator supplied an invalid regex. Handlers compare the
-     * return value against this with {@code ==} to distinguish "no filter"
-     * (null) from "user error already messaged" (this sentinel) before
-     * dispatching to {@code runWithPrelude} — saves a separate boolean
-     * field on each handler.
-     */
+    /** Sentinel: invalid regex, sender already messaged. Distinguished from null ("no filter") with {@code ==}. */
     private static final Predicate<ViolationEntry> FILTER_ERROR = v -> false;
 
     /**
-     * Build a {@link ViolationEntry} predicate from the three filter flags.
-     *
-     * <ul>
-     *   <li>{@code --name <regex>} — matches the violation's display name.</li>
-     *   <li>{@code --match <regex>} — matches the verbose string. Rows with
-     *       {@code null} verbose drop when this flag is set.</li>
-     *   <li>{@code --grep <regex>} — grep-style: matches if EITHER display
-     *       name OR verbose hits.</li>
-     * </ul>
-     *
-     * <p>Combining flags ANDs them — each flag is an independent narrowing
-     * step. All three use {@link Pattern#CASE_INSENSITIVE} so the operator
-     * doesn't have to think about casing.
-     *
-     * <p>Returns {@code null} when no filter flag is set so callers can
-     * short-circuit; returns {@link #FILTER_ERROR} after sending an error
-     * message to the sender if a regex fails to compile.
+     * Build the violation predicate from {@code --name} (display name),
+     * {@code --match} (verbose), {@code --grep} (either). Case-insensitive,
+     * AND-composed. Null = no filter; {@link #FILTER_ERROR} = bad regex,
+     * sender already messaged.
      */
     private static @Nullable Predicate<ViolationEntry> parseFilterFromContext(Sender sender, CommandContext<Sender> ctx) {
         Pattern namePat;
@@ -448,12 +350,7 @@ public class GrimHistory implements BuildableCommand {
         }
     }
 
-    /**
-     * Translates the {@code session} argument — either a positive integer, the
-     * literal "latest" / "last" / "l", or {@code null}-ish — into a global session
-     * ordinal. Returns {@code null} when the target has no sessions or the input
-     * is unparseable.
-     */
+    /** Resolves a positive integer, {@code latest}/{@code last}/{@code l}, or null. */
     private static @Nullable Integer resolveSessionOrdinal(String raw, UUID uuid, HistoryService history)
             throws Exception {
         if (raw == null) return null;
@@ -765,17 +662,9 @@ public class GrimHistory implements BuildableCommand {
     // ---- suggestion providers ----
 
     /**
-     * Merged online + offline player suggestions for the {@code <target>} argument.
-     * <p>
-     * Empty prefix: online players only (skips the datastore to avoid
-     * enumerating every historical player). Non-empty prefix: online players
-     * first, then offline matches from the datastore sorted by {@code last_seen}
-     * descending, merged case-insensitively. Combined result is capped at
-     * {@link #MAX_PLAYER_SUGGESTIONS}.
-     * <p>
-     * Permission-gated by the surrounding {@code grim.history} permission on
-     * the command itself; Cloud never invokes suggestions for a sender that
-     * can't execute the command.
+     * Online players + offline name-prefix matches from the datastore
+     * (sorted by {@code last_seen} desc). Empty prefix skips the offline
+     * lookup. Capped at {@link #MAX_PLAYER_SUGGESTIONS}.
      */
     private static SuggestionProvider<Sender> targetSuggestions(CloudCommandAdapter adapter) {
         SuggestionProvider<Sender> onlineProvider = adapter.onlinePlayerSuggestions();

--- a/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
+++ b/common/src/main/java/ac/grim/grimac/command/commands/GrimHistory.java
@@ -123,14 +123,14 @@ public class GrimHistory implements BuildableCommand {
         // List, page 1
         commandManager.command(
                 applyFilterFlags(commandManager, base.get())
-                        .handler(this::handleListPage1)
+                        .handler(ctx -> handleListPage1(ctx, viaPlayer))
         );
         // List, page N
         commandManager.command(
                 applyFilterFlags(commandManager, base.get()
                         .literal("page")
                         .required("page_number", IntegerParser.integerParser(1), listPageNumberSuggestions))
-                        .handler(this::handleListPageN)
+                        .handler(ctx -> handleListPageN(ctx, viaPlayer))
         );
         // Help branch on bare 'session' — Cloud would otherwise reject with
         // a parse error that reads like a syntax mistake, not a hint.
@@ -181,28 +181,23 @@ public class GrimHistory implements BuildableCommand {
                         .withDescription(Description.of("Filter to violations whose display name OR verbose text matches this regex.")));
     }
 
-    // List handlers don't need the viaPlayer flag — V2's renderSummaryLine
-    // attaches a hover hint with a UUID-prefix copy-paste form (not a
-    // clickEvent.runCommand), so the V3 click-routing issue with the
-    // disambiguated form doesn't apply here. Only handleSessionHelp needs
-    // to know which prefix the operator dispatched on.
-    private void handleListPage1(CommandContext<Sender> context) {
+    private void handleListPage1(CommandContext<Sender> context, boolean viaPlayer) {
         Sender sender = context.sender();
         String target = context.get("target");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
         if (filter == FILTER_ERROR) return;
         runWithPrelude(sender, target, (uuid, displayName, lifecycle, history) ->
-                renderList(sender, lifecycle, history, uuid, displayName, 1, filter));
+                renderList(sender, lifecycle, history, uuid, displayName, 1, filter, viaPlayer));
     }
 
-    private void handleListPageN(CommandContext<Sender> context) {
+    private void handleListPageN(CommandContext<Sender> context, boolean viaPlayer) {
         Sender sender = context.sender();
         String target = context.get("target");
         int page = context.<Integer>get("page_number");
         Predicate<ViolationEntry> filter = parseFilterFromContext(sender, context);
         if (filter == FILTER_ERROR) return;
         runWithPrelude(sender, target, (uuid, displayName, lifecycle, history) ->
-                renderList(sender, lifecycle, history, uuid, displayName, Math.max(1, page), filter));
+                renderList(sender, lifecycle, history, uuid, displayName, Math.max(1, page), filter, viaPlayer));
     }
 
     private void handleDetailDefaultPage(CommandContext<Sender> context) {
@@ -414,7 +409,7 @@ public class GrimHistory implements BuildableCommand {
 
     private void renderList(Sender sender, DataStoreLifecycle lifecycle, HistoryService history,
                             UUID uuid, String displayName, int page,
-                            @Nullable Predicate<ViolationEntry> filter) throws Exception {
+                            @Nullable Predicate<ViolationEntry> filter, boolean viaPlayer) throws Exception {
         int entriesPerPage = lifecycle.config().history().entriesPerPage();
         long totalSessions = history.countSessions(uuid).toCompletableFuture().get(5, TimeUnit.SECONDS);
         int maxPages = Math.max(1, (int) ((totalSessions + entriesPerPage - 1) / Math.max(1, entriesPerPage)));
@@ -433,7 +428,7 @@ public class GrimHistory implements BuildableCommand {
 
         UUID ongoingSessionId = ongoingSessionIdFor(lifecycle, uuid);
         List<Component> components = HistoryComponentRenderer.renderSessionList(
-                sender, uuid, displayName, page, maxPages, result, ongoingSessionId);
+                sender, uuid, displayName, page, maxPages, result, ongoingSessionId, viaPlayer);
         for (Component c : components) sender.sendMessage(c);
     }
 

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -407,17 +407,22 @@ public final class HistoryComponentRenderer {
      */
     private static String mmSafe(@Nullable String raw) {
         if (raw == null || raw.isEmpty()) return "";
-        String stripped = LEGACY_FORMAT_PATTERN.matcher(raw).replaceAll("");
-        // Kill '%' so values can't reintroduce trusted text by riding
-        // through MessageUtil.replacePlaceholders' or MessageUtil
-        // .miniMessage's variable replacement pass — both expand
-        // %prefix% and other registered names after substitution.
+        // Order matters: strip '%' BEFORE legacy markers. A payload like
+        // "&%c" otherwise sneaks past — LEGACY_FORMAT_PATTERN doesn't
+        // match "&%" (% is not a colour code), then a subsequent %-strip
+        // would re-fuse "&c" which MessageUtil.miniMessage's downstream
+        // legacy → MM conversion would then interpret as red. Killing
+        // '%' first also nukes the %prefix% / %grim_version% /
+        // operator-registered variable expansion bypass (those names
+        // run through MessageUtil.replacePlaceholders and
+        // MessageUtil.miniMessage's own prefix pass after substitution).
+        String stripped = LEGACY_FORMAT_PATTERN.matcher(
+                raw.replace("%", "")).replaceAll("");
         // Backslash and '<' are escaped (MM treats '\<' as a literal
         // '<' and '\\' as a literal '\'); the backslash escape must
         // run first so we don't double-process the backslash we add
         // for '<'.
         return stripped
-                .replace("%", "")
                 .replace("\\", "\\\\")
                 .replace("<", "\\<");
     }

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -12,6 +12,7 @@ import ac.grim.grimac.platform.api.sender.Sender;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +38,9 @@ public final class HistoryComponentRenderer {
      * Session-list view. {@code page} is 1-indexed; {@code maxPages} ≥ 1.
      * {@code ongoingSessionId} (optional) is the player's currently-active
      * sessionId from SessionTracker; the matching row shows "current" as its
-     * duration.
+     * duration. {@code viaPlayerLiteral} routes the per-row click /
+     * copy-paste detail command through {@code /grim history player <target>}
+     * so a list opened via the disambiguator stays on that branch.
      */
     public static @NotNull List<Component> renderSessionList(
             @NotNull Sender sender,
@@ -46,7 +49,8 @@ public final class HistoryComponentRenderer {
             int page,
             int maxPages,
             @NotNull Page<SessionSummary> result,
-            @Nullable UUID ongoingSessionId) {
+            @Nullable UUID ongoingSessionId,
+            boolean viaPlayerLiteral) {
         ConfigManager cfg = GrimAPI.INSTANCE.getConfigManager().getConfig();
         String safePlayer = mmSafe(playerDisplayName);
         if (result.items().isEmpty()) {
@@ -68,12 +72,13 @@ public final class HistoryComponentRenderer {
                         "maxPages", maxPagesStr)));
         for (SessionSummary s : result.items()) {
             boolean ongoing = ongoingSessionId != null && ongoingSessionId.equals(s.sessionId());
-            out.add(renderSummaryLine(sender, cfg, s, ongoing));
+            out.add(renderSummaryLine(sender, cfg, s, ongoing, playerDisplayName, viaPlayerLiteral));
         }
         return out;
     }
 
-    private static Component renderSummaryLine(Sender sender, ConfigManager cfg, SessionSummary s, boolean ongoing) {
+    private static Component renderSummaryLine(Sender sender, ConfigManager cfg, SessionSummary s, boolean ongoing,
+                                               String playerDisplayName, boolean viaPlayerLiteral) {
         long elapsedNow = Math.max(0, System.currentTimeMillis() - s.startedEpochMs());
         String durationText = ongoing
                 ? "current"
@@ -103,18 +108,19 @@ public final class HistoryComponentRenderer {
                         Map.entry("unique_checks", Integer.toString(s.uniqueCheckCount())),
                         Map.entry("crashed_marker", crashedMarker),
                         Map.entry("timeago", formatDuration(elapsedNow))));
-        // Hover tooltip — click-hint plus raw session metadata that doesn't fit on the line.
+        String detailCommand = "/grim history " + (viaPlayerLiteral ? "player " : "")
+                + playerDisplayName + " session " + s.sessionOrdinal();
         Component tooltip = Component.text()
                 .append(Component.text("Session ", NamedTextColor.AQUA))
                 .append(Component.text(s.sessionId().toString(), NamedTextColor.GRAY))
                 .append(Component.newline())
-                .append(Component.text("Click (when supported) or run ", NamedTextColor.GRAY))
-                .append(Component.text("/grim history " + shortName(s.playerUuid()) + " session " + s.sessionOrdinal(),
-                        NamedTextColor.YELLOW))
+                .append(Component.text("Click or run ", NamedTextColor.GRAY))
+                .append(Component.text(detailCommand, NamedTextColor.YELLOW))
                 .append(Component.newline())
                 .append(Component.text("to view session details.", NamedTextColor.GRAY))
                 .build();
-        return line.hoverEvent(HoverEvent.showText(tooltip));
+        return line.hoverEvent(HoverEvent.showText(tooltip))
+                .clickEvent(ClickEvent.runCommand(detailCommand));
     }
 
     /**
@@ -391,7 +397,4 @@ public final class HistoryComponentRenderer {
         }
     }
 
-    private static String shortName(UUID u) {
-        return u.toString().substring(0, 8);
-    }
 }

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -11,9 +11,11 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.platform.api.sender.Sender;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import io.github.retrooper.packetevents.adventure.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -338,14 +340,41 @@ public final class HistoryComponentRenderer {
 
     // ---- helpers ----
 
+    /**
+     * Substitute {@code %key%} placeholders, then run through
+     * {@link MessageUtil#miniMessage(String)} (which converts {@code §}-style
+     * legacy codes to MM tags before MM.deserialize).
+     *
+     * <p>Every value is passed through {@link #sanitizeForMiniMessage(String)}
+     * before substitution. MessageUtil already neutralises {@code §} codes
+     * sitting in the template body, but stored field values can still
+     * contain MiniMessage syntax characters ({@code <}, {@code >}) — most
+     * notably the client brand, which is whatever the client sent on the
+     * {@code minecraft:brand} channel. Without sanitisation a brand of e.g.
+     * {@code "Vape<rainbow>"} would let the client inject MM tags into
+     * operator-facing /grim history output.
+     */
     private static Component parse(Sender sender, ConfigManager cfg, String key, String fallback,
                                    Map<String, String> vars) {
         String raw = cfg.getStringElse(key, fallback);
         for (Map.Entry<String, String> e : vars.entrySet()) {
-            raw = raw.replace("%" + e.getKey() + "%", e.getValue());
+            raw = raw.replace("%" + e.getKey() + "%", sanitizeForMiniMessage(e.getValue()));
         }
         raw = MessageUtil.replacePlaceholders(sender, raw);
         return MessageUtil.miniMessage(raw);
+    }
+
+    /**
+     * Normalise an untrusted string into a MiniMessage-safe substitute by
+     * round-tripping through legacy-section deserialise → MM serialise. §
+     * runs become equivalent MM tag pairs; literal {@code <} / {@code >}
+     * survive as MM-escaped text rather than being interpreted as tags.
+     * {@code null} / empty input short-circuits to {@code ""}.
+     */
+    private static String sanitizeForMiniMessage(@Nullable String raw) {
+        if (raw == null || raw.isEmpty()) return "";
+        return MiniMessage.miniMessage().serialize(
+                LegacyComponentSerializer.legacySection().deserialize(raw));
     }
 
     public static @NotNull String formatDuration(long ms) {

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -224,9 +224,14 @@ public final class HistoryComponentRenderer {
         for (CheckCount c : bucket.checks()) {
             if (!first) checksList.append("&7, ");
             first = false;
+            // Check display names come from CheckCount rows in the DB —
+            // most originate from internal Grim checks, but the
+            // AbstractCheck extension API + the v1-catalog repair path
+            // make plugin-authored names plausible. Defence-in-depth
+            // wrap so a hostile plugin can't paint formatting into rows.
             checksList.append(cfg.getStringElse("grim-history-check-count",
                             "&f%check_name%&7 x&c%count%")
-                    .replace("%check_name%", c.displayName())
+                    .replace("%check_name%", mmSafe(c.displayName()))
                     .replace("%count%", Integer.toString(c.count())));
         }
         Component line = parse(sender, cfg, "grim-history-detail-group",
@@ -275,11 +280,15 @@ public final class HistoryComponentRenderer {
         // legacy format code (§, &, hex variants) and escapes the MM tag
         // opener so a crafted verbose can't inject formatting into the
         // rendered row. Suppressed when -v isn't set.
+        // Check display names + descriptions come from CheckCount rows —
+        // built-ins are trusted but plugin-authored AbstractCheck
+        // metadata can flow through here. mmSafe-defend so a hostile
+        // check can't paint formatting into the per-violation row.
         Component line = parse(sender, cfg, "grim-history-detail-entry",
                 "&7- &f%check% &8(&b%offset%&8)&7 %verbose%",
                 Map.of(
-                        "check", v.displayName(),
-                        "description", v.description(),
+                        "check", mmSafe(v.displayName()),
+                        "description", mmSafe(v.description()),
                         "offset", formatDuration(v.offsetFromSessionStartMs()),
                         "vl", Double.toString(v.vl()),
                         "verbose", verbose ? mmSafe(verboseText) : ""));
@@ -399,20 +408,32 @@ public final class HistoryComponentRenderer {
     private static String mmSafe(@Nullable String raw) {
         if (raw == null || raw.isEmpty()) return "";
         String stripped = LEGACY_FORMAT_PATTERN.matcher(raw).replaceAll("");
-        // Escape backslash first so we don't double-process the backslash
-        // we add for '<'. MM treats '\<' as a literal '<' and '\\' as '\'.
-        return stripped.replace("\\", "\\\\").replace("<", "\\<");
+        // Kill '%' so values can't reintroduce trusted text by riding
+        // through MessageUtil.replacePlaceholders' or MessageUtil
+        // .miniMessage's variable replacement pass — both expand
+        // %prefix% and other registered names after substitution.
+        // Backslash and '<' are escaped (MM treats '\<' as a literal
+        // '<' and '\\' as a literal '\'); the backslash escape must
+        // run first so we don't double-process the backslash we add
+        // for '<'.
+        return stripped
+                .replace("%", "")
+                .replace("\\", "\\\\")
+                .replace("<", "\\<");
     }
 
     /**
-     * Matches any legacy format marker that V2's downstream
+     * Matches any legacy Minecraft format marker that V2's downstream
      * {@link MessageUtil#miniMessage} pipeline would otherwise interpret as
-     * a colour / decoration run. Covers both {@code §} and {@code &} sigils,
-     * plain {@code [0-9A-Za-z]} format codes, and the two hex forms
-     * ({@code &#RRGGBB} and the Bedrock-style {@code &x&R&R&G&G&B&B}).
+     * a colour / decoration run. Restricted to the canonical legacy
+     * alphabet (digits, {@code a-f} colours, {@code k-o} decorations,
+     * {@code r} reset, {@code x} hex marker) so innocent text like
+     * {@code AT&T} or {@code R&D} survives untouched. Covers both sigils
+     * and both hex forms (the {@code &#RRGGBB} literal form and the
+     * Bedrock-style {@code &x&R&R&G&G&B&B} interleave).
      */
     private static final Pattern LEGACY_FORMAT_PATTERN = Pattern.compile(
-            "[§&](?:[0-9A-Za-z]|#[A-Fa-f0-9]{6}|x(?:[§&][A-Fa-f0-9]){6})");
+            "[§&](?:[0-9a-fk-orxA-FK-ORX]|#[A-Fa-f0-9]{6}|x(?:[§&][A-Fa-f0-9]){6})");
 
     public static @NotNull String formatDuration(long ms) {
         if (ms < 0) ms = 0;

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -100,7 +100,7 @@ public final class HistoryComponentRenderer {
                 ? cfg.getStringElse("grim-history-crashed-marker", " &8(&ccrashed&8)")
                 : "";
         Component line = parse(sender, cfg, "grim-history-session",
-                "%prefix% &8[&b%grim_version%&8] &8[&b%server_name%&8] &8[&b%client_version%&8]"
+                "&8[&b%grim_version%&8] &8[&b%server_name%&8] &8[&b%client_version%&8]"
                         + " &bSession &f%ordinal%&b duration &f%duration%&b with &c%violations%&b"
                         + " violations &8[&c%unique_checks%&8]%crashed_marker% &8(&7%timeago% ago&8)",
                 Map.ofEntries(
@@ -180,17 +180,17 @@ public final class HistoryComponentRenderer {
         out.add(parse(sender, cfg, "grim-history-detail-header",
                 "%prefix% &bShowing &f%player%&b's session &f%ordinal%&b details:", metaVars));
         out.add(parse(sender, cfg, "grim-history-detail-meta1",
-                "%prefix% &bGrim: &f%grim_version%&b, Server: &f%server_name%&b, Duration: &f%duration%&b, Date: &7%timeago% ago",
+                "&bGrim: &f%grim_version%&b, Server: &f%server_name%&b, Duration: &f%duration%&b, Date: &7%timeago% ago",
                 metaVars));
         out.add(parse(sender, cfg, "grim-history-detail-meta2",
-                "%prefix% &bClient: &f%client_version%&b, Brand: &f%client_brand%",
+                "&bClient: &f%client_version%&b, Brand: &f%client_brand%",
                 metaVars));
         out.add(parse(sender, cfg, "grim-history-detail-violations-header",
-                "%prefix% &bViolations: &8(%violations% total, %unique_checks% unique) &8[&f%page%&7/&f%max_pages%&8]",
+                "&bViolations: &8(%violations% total, %unique_checks% unique) &8[&f%page%&7/&f%max_pages%&8]",
                 metaVars));
 
         if (d.violations().isEmpty()) {
-            out.add(parse(sender, cfg, "grim-history-detail-empty", "%prefix% &7- (none)", Map.of()));
+            out.add(parse(sender, cfg, "grim-history-detail-empty", "&7- (none)", Map.of()));
             return out;
         }
 
@@ -218,7 +218,7 @@ public final class HistoryComponentRenderer {
                     .replace("%count%", Integer.toString(c.count())));
         }
         Component line = parse(sender, cfg, "grim-history-detail-group",
-                "%prefix% &7- %checks_list% &8(&b%offset%&8)",
+                "&7- %checks_list% &8(&b%offset%&8)",
                 Map.of(
                         "checks_list", checksList.toString(),
                         "offset", formatDuration(bucket.bucketStartOffsetMs())));
@@ -257,7 +257,7 @@ public final class HistoryComponentRenderer {
     private static Component renderViolationLine(Sender sender, ConfigManager cfg, ViolationEntry v, boolean verbose) {
         String verboseText = v.verbose() == null ? "" : v.verbose();
         Component line = parse(sender, cfg, "grim-history-detail-entry",
-                "%prefix% &7- &f%check% &8(&b%offset%&8)&7 %verbose%",
+                "&7- &f%check% &8(&b%offset%&8)&7 %verbose%",
                 Map.of(
                         "check", v.displayName(),
                         "description", v.description(),

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -106,10 +106,13 @@ public final class HistoryComponentRenderer {
                         + " &bSession &f%ordinal%&b duration &f%duration%&b with &c%violations%&b"
                         + " violations &8[&c%unique_checks%&8]%crashed_marker% &8(&7%timeago% ago&8)",
                 Map.ofEntries(
-                        Map.entry("grim_version", nullToUnknown(s.grimVersion())),
-                        Map.entry("server_name", nullToUnknown(s.serverName())),
+                        // mmSafe wraps the externally-sourced fields. crashed_marker
+                        // is a config-keyed MM/legacy fragment built by the renderer
+                        // above and must NOT round-trip — it would lose its formatting.
+                        Map.entry("grim_version", mmSafe(nullToUnknown(s.grimVersion()))),
+                        Map.entry("server_name", mmSafe(nullToUnknown(s.serverName()))),
                         Map.entry("client_version", clientVersionDisplay(s.clientVersion())),
-                        Map.entry("client_brand", nullToUnknown(s.clientBrand())),
+                        Map.entry("client_brand", mmSafe(nullToUnknown(s.clientBrand()))),
                         Map.entry("ordinal", Integer.toString(s.sessionOrdinal())),
                         Map.entry("duration", durationText),
                         Map.entry("violations", Long.toString(s.violationCount())),
@@ -166,12 +169,15 @@ public final class HistoryComponentRenderer {
         int page = pageArg == null ? maxPages : Math.max(1, Math.min(pageArg, maxPages));
 
         Map<String, String> metaVars = Map.ofEntries(
+                // mmSafe wraps the externally-sourced fields. Player display
+                // names are Minecraft-constrained (letters/digits/underscore),
+                // so they don't need sanitisation.
                 Map.entry("player", playerDisplayName),
                 Map.entry("ordinal", Integer.toString(d.sessionOrdinal())),
-                Map.entry("grim_version", nullToUnknown(d.grimVersion())),
-                Map.entry("server_name", nullToUnknown(d.serverName())),
+                Map.entry("grim_version", mmSafe(nullToUnknown(d.grimVersion()))),
+                Map.entry("server_name", mmSafe(nullToUnknown(d.serverName()))),
                 Map.entry("client_version", clientVersionDisplay(d.clientVersion())),
-                Map.entry("client_brand", nullToUnknown(d.clientBrand())),
+                Map.entry("client_brand", mmSafe(nullToUnknown(d.clientBrand()))),
                 Map.entry("duration", durationText),
                 Map.entry("timeago", formatDuration(elapsedNow)),
                 Map.entry("violations", Integer.toString(d.violations().size())),
@@ -258,6 +264,13 @@ public final class HistoryComponentRenderer {
 
     private static Component renderViolationLine(Sender sender, ConfigManager cfg, ViolationEntry v, boolean verbose) {
         String verboseText = v.verbose() == null ? "" : v.verbose();
+        // verbose carries whatever the check wrote into the column — often a
+        // component fragment serialised via LegacyComponentSerializer, so §
+        // (or `&`) codes are common, as are values derived from user-supplied
+        // strings (chat content, brand fragments). mmSafe converts both
+        // legacy syntaxes to MM tag pairs and escapes literal '<' / '>' so a
+        // crafted verbose can't inject MM tags into the rendered row.
+        // Suppressed when -v isn't set.
         Component line = parse(sender, cfg, "grim-history-detail-entry",
                 "&7- &f%check% &8(&b%offset%&8)&7 %verbose%",
                 Map.of(
@@ -265,7 +278,7 @@ public final class HistoryComponentRenderer {
                         "description", v.description(),
                         "offset", formatDuration(v.offsetFromSessionStartMs()),
                         "vl", Double.toString(v.vl()),
-                        "verbose", verbose ? verboseText : ""));
+                        "verbose", verbose ? mmSafe(verboseText) : ""));
         // Hover carries the richer disambiguation — description on its own
         // line, then the raw verbose below. Shown regardless of the -v
         // flag, because operators scanning a dense list still want the
@@ -340,41 +353,43 @@ public final class HistoryComponentRenderer {
 
     // ---- helpers ----
 
-    /**
-     * Substitute {@code %key%} placeholders, then run through
-     * {@link MessageUtil#miniMessage(String)} (which converts {@code §}-style
-     * legacy codes to MM tags before MM.deserialize).
-     *
-     * <p>Every value is passed through {@link #sanitizeForMiniMessage(String)}
-     * before substitution. MessageUtil already neutralises {@code §} codes
-     * sitting in the template body, but stored field values can still
-     * contain MiniMessage syntax characters ({@code <}, {@code >}) — most
-     * notably the client brand, which is whatever the client sent on the
-     * {@code minecraft:brand} channel. Without sanitisation a brand of e.g.
-     * {@code "Vape<rainbow>"} would let the client inject MM tags into
-     * operator-facing /grim history output.
-     */
     private static Component parse(Sender sender, ConfigManager cfg, String key, String fallback,
                                    Map<String, String> vars) {
         String raw = cfg.getStringElse(key, fallback);
         for (Map.Entry<String, String> e : vars.entrySet()) {
-            raw = raw.replace("%" + e.getKey() + "%", sanitizeForMiniMessage(e.getValue()));
+            raw = raw.replace("%" + e.getKey() + "%", e.getValue());
         }
         raw = MessageUtil.replacePlaceholders(sender, raw);
         return MessageUtil.miniMessage(raw);
     }
 
     /**
-     * Normalise an untrusted string into a MiniMessage-safe substitute by
-     * round-tripping through legacy-section deserialise → MM serialise. §
-     * runs become equivalent MM tag pairs; literal {@code <} / {@code >}
-     * survive as MM-escaped text rather than being interpreted as tags.
-     * {@code null} / empty input short-circuits to {@code ""}.
+     * Normalise an untrusted leaf string into a MiniMessage-safe substitute.
+     * Callers must wrap stored values that originate outside the renderer
+     * (client brand, server name) before stuffing them into the var map for
+     * {@link #parse}. Trusted renderer-built MM fragments — {@code
+     * checks_list} composed from a config-keyed template, {@code
+     * crashed_marker} sourced from messages.yml — must NOT be passed through
+     * this helper, since the round-trip strips their MM tags as literal text.
+     *
+     * <p>The pre-normalisation step translates legacy {@code &amp;}-codes to
+     * {@code §}-codes via {@link MessageUtil#translateAlternateColorCodes(char, String)}.
+     * V2's {@code MessageUtil.miniMessage} otherwise globally rewrites
+     * {@code &c} runs into MM tags AFTER var substitution, so an untrusted
+     * value containing {@code &c} would still inject formatting if the
+     * round-trip below saw only the {@code §}-form. Pre-translating brings
+     * both syntaxes through {@code LegacyComponentSerializer.legacySection}
+     * (which only recognises {@code §}). MM.serialize then re-emits the
+     * runs as MM tag pairs and escapes any literal {@code <} / {@code >}
+     * in the input.
+     *
+     * <p>{@code null} / empty input short-circuits to {@code ""}.
      */
-    private static String sanitizeForMiniMessage(@Nullable String raw) {
+    private static String mmSafe(@Nullable String raw) {
         if (raw == null || raw.isEmpty()) return "";
+        String translated = MessageUtil.translateAlternateColorCodes('&', raw);
         return MiniMessage.miniMessage().serialize(
-                LegacyComponentSerializer.legacySection().deserialize(raw));
+                LegacyComponentSerializer.legacySection().deserialize(translated));
     }
 
     public static @NotNull String formatDuration(long ms) {

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -28,21 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-/**
- * Converts {@link SessionSummary} / {@link SessionDetail} records returned by
- * {@link ac.grim.grimac.api.storage.history.HistoryService} into Adventure
- * {@link Component} trees for the plugin's command output. All presentation
- * text lives in {@code messages.yml} (see the {@code grim-history-*} keys),
- * so operators can recolour / reword the whole UI without touching code.
- * Hover tooltips are attached here directly from the raw data (verbose
- * strings, description one-liners, grouped check breakdowns).
- * <p>
- * The {@code grim-history-detail-entry} template accepts an optional
- * {@code %description%} variable — include it in your messages.yml when
- * you want the check's short description inlined in detailed-mode rows.
- * The default template omits it (to keep rows narrow); hover always
- * carries the description when the check has one declared.
- */
+/** Renders history service records into command output components. */
 public final class HistoryComponentRenderer {
 
     private HistoryComponentRenderer() {}
@@ -106,11 +92,7 @@ public final class HistoryComponentRenderer {
                         + " &bSession &f%ordinal%&b duration &f%duration%&b with &c%violations%&b"
                         + " violations &8[&c%unique_checks%&8]%crashed_marker% &8(&7%timeago% ago&8)",
                 Map.ofEntries(
-                        // mmSafe wraps the truly-untrusted fields. server_name and
-                        // grim_version are operator-/server-configured (operators may
-                        // legitimately want colours), so they pass verbatim.
-                        // crashed_marker is a config-keyed legacy/MM fragment built
-                        // above and must NOT round-trip.
+                        // Only sanitize untrusted leaves; keep operator-configured fragments intact.
                         Map.entry("grim_version", nullToUnknown(s.grimVersion())),
                         Map.entry("server_name", nullToUnknown(s.serverName())),
                         Map.entry("client_version", clientVersionDisplay(s.clientVersion())),
@@ -171,11 +153,7 @@ public final class HistoryComponentRenderer {
         int page = pageArg == null ? maxPages : Math.max(1, Math.min(pageArg, maxPages));
 
         Map<String, String> metaVars = Map.ofEntries(
-                // mmSafe wraps the truly-untrusted leaves: %player% is
-                // operator-typed on the command line (defence in depth),
-                // %client_brand% is whatever the client sent on the
-                // minecraft:brand channel. server_name / grim_version are
-                // server/operator config and may legitimately contain colours.
+                // Only sanitize untrusted leaves; keep operator-configured fragments intact.
                 Map.entry("player", mmSafe(playerDisplayName)),
                 Map.entry("ordinal", Integer.toString(d.sessionOrdinal())),
                 Map.entry("grim_version", nullToUnknown(d.grimVersion())),
@@ -224,11 +202,7 @@ public final class HistoryComponentRenderer {
         for (CheckCount c : bucket.checks()) {
             if (!first) checksList.append("&7, ");
             first = false;
-            // Check display names come from CheckCount rows in the DB —
-            // most originate from internal Grim checks, but the
-            // AbstractCheck extension API + the v1-catalog repair path
-            // make plugin-authored names plausible. Defence-in-depth
-            // wrap so a hostile plugin can't paint formatting into rows.
+            // Check names can be plugin-authored; render them as plain text.
             checksList.append(cfg.getStringElse("grim-history-check-count",
                             "&f%check_name%&7 x&c%count%")
                     .replace("%check_name%", mmSafe(c.displayName()))
@@ -273,17 +247,7 @@ public final class HistoryComponentRenderer {
 
     private static Component renderViolationLine(Sender sender, ConfigManager cfg, ViolationEntry v, boolean verbose) {
         String verboseText = v.verbose() == null ? "" : v.verbose();
-        // verbose carries whatever the check wrote into the column — often a
-        // component fragment serialised via LegacyComponentSerializer (so §
-        // / & codes are common), occasionally derived from user-supplied
-        // strings (chat content, brand fragments). mmSafe strips every
-        // legacy format code (§, &, hex variants) and escapes the MM tag
-        // opener so a crafted verbose can't inject formatting into the
-        // rendered row. Suppressed when -v isn't set.
-        // Check display names + descriptions come from CheckCount rows —
-        // built-ins are trusted but plugin-authored AbstractCheck
-        // metadata can flow through here. mmSafe-defend so a hostile
-        // check can't paint formatting into the per-violation row.
+        // Verbose/check metadata can include user or plugin text; render substitutions as plain text.
         Component line = parse(sender, cfg, "grim-history-detail-entry",
                 "&7- &f%check% &8(&b%offset%&8)&7 %verbose%",
                 Map.of(
@@ -376,67 +340,20 @@ public final class HistoryComponentRenderer {
         return MessageUtil.miniMessage(raw);
     }
 
-    /**
-     * Render an untrusted leaf string as plain text, MiniMessage-escaped.
-     * Strips every form of formatting (legacy {@code §}-codes, ampersand
-     * {@code &}-codes, hex {@code &#RRGGBB} and Bedrock {@code &x&R&R…}
-     * forms) and escapes the MM tag-opener so the result cannot inject
-     * formatting downstream regardless of {@link MessageUtil#miniMessage}'s
-     * legacy + hex prepass.
-     *
-     * <p>Used on values that originate outside the renderer's trust
-     * boundary:
-     * <ul>
-     *   <li>{@code client_brand} — whatever the client sent on the
-     *       {@code minecraft:brand} plugin channel.</li>
-     *   <li>{@code verbose} — whatever a check wrote into the column.
-     *       Checks sometimes embed user-supplied text inside verbose
-     *       without sanitising.</li>
-     *   <li>{@code playerDisplayName} / {@code target} — operator-typed
-     *       on the command line; defence-in-depth so a hostile MM tag
-     *       in the typed target name can't poison header rendering.</li>
-     * </ul>
-     *
-     * <p>NOT used on trusted leaves: {@code server_name} and
-     * {@code grim_version} are operator-/server-configured and may
-     * legitimately contain operator-authored colours, so they pass
-     * through verbatim. Renderer-built fragments
-     * ({@code crashed_marker}, {@code checks_list}) also pass through.
-     *
-     * <p>{@code null} / empty input short-circuits to {@code ""}.
-     */
+    /** Renders untrusted template values as plain text before MiniMessage parsing. */
     private static String mmSafe(@Nullable String raw) {
         if (raw == null || raw.isEmpty()) return "";
-        // Order matters: strip '%' BEFORE legacy markers. A payload like
-        // "&%c" otherwise sneaks past — LEGACY_FORMAT_PATTERN doesn't
-        // match "&%" (% is not a colour code), then a subsequent %-strip
-        // would re-fuse "&c" which MessageUtil.miniMessage's downstream
-        // legacy → MM conversion would then interpret as red. Killing
-        // '%' first also nukes the %prefix% / %grim_version% /
-        // operator-registered variable expansion bypass (those names
-        // run through MessageUtil.replacePlaceholders and
-        // MessageUtil.miniMessage's own prefix pass after substitution).
+        // Strip '%' first so '&%c' cannot become '&c' after placeholder removal.
         String stripped = LEGACY_FORMAT_PATTERN.matcher(
                 raw.replace("%", "")).replaceAll("");
-        // Backslash and '<' are escaped (MM treats '\<' as a literal
-        // '<' and '\\' as a literal '\'); the backslash escape must
-        // run first so we don't double-process the backslash we add
-        // for '<'.
+        // Escape backslash before '<' so the added escape isn't itself escaped.
         return stripped
                 .replace("\\", "\\\\")
                 .replace("<", "\\<");
     }
 
-    /**
-     * Matches any legacy Minecraft format marker that V2's downstream
-     * {@link MessageUtil#miniMessage} pipeline would otherwise interpret as
-     * a colour / decoration run. Restricted to the canonical legacy
-     * alphabet (digits, {@code a-f} colours, {@code k-o} decorations,
-     * {@code r} reset, {@code x} hex marker) so innocent text like
-     * {@code AT&T} or {@code R&D} survives untouched. Covers both sigils
-     * and both hex forms (the {@code &#RRGGBB} literal form and the
-     * Bedrock-style {@code &x&R&R&G&G&B&B} interleave).
-     */
+    // Canonical legacy alphabet only — leaves AT&T / R&D alone.
+    // Covers §/& sigils, &#RRGGBB hex, and the Bedrock &x&R&R… interleave.
     private static final Pattern LEGACY_FORMAT_PATTERN = Pattern.compile(
             "[§&](?:[0-9a-fk-orxA-FK-ORX]|#[A-Fa-f0-9]{6}|x(?:[§&][A-Fa-f0-9]){6})");
 

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -11,11 +11,9 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.platform.api.sender.Sender;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
-import io.github.retrooper.packetevents.adventure.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -63,10 +62,11 @@ public final class HistoryComponentRenderer {
             @NotNull Page<SessionSummary> result,
             @Nullable UUID ongoingSessionId) {
         ConfigManager cfg = GrimAPI.INSTANCE.getConfigManager().getConfig();
+        String safePlayer = mmSafe(playerDisplayName);
         if (result.items().isEmpty()) {
             return List.of(parse(sender, cfg, "grim-history-no-sessions",
                     "%prefix% &7No session history for &f%player%&7.",
-                    Map.of("player", playerDisplayName)));
+                    Map.of("player", safePlayer)));
         }
         List<Component> out = new ArrayList<>(result.items().size() + 1);
         // Emit both %max_pages% (new) and %maxPages% (pre-cutover spelling) so
@@ -76,7 +76,7 @@ public final class HistoryComponentRenderer {
         out.add(parse(sender, cfg, "grim-history-header",
                 "%prefix% &bShowing session history for &f%player% &8[&f%page%&7/&f%max_pages%&8]",
                 Map.of(
-                        "player", playerDisplayName,
+                        "player", safePlayer,
                         "page", Integer.toString(page),
                         "max_pages", maxPagesStr,
                         "maxPages", maxPagesStr)));
@@ -106,11 +106,13 @@ public final class HistoryComponentRenderer {
                         + " &bSession &f%ordinal%&b duration &f%duration%&b with &c%violations%&b"
                         + " violations &8[&c%unique_checks%&8]%crashed_marker% &8(&7%timeago% ago&8)",
                 Map.ofEntries(
-                        // mmSafe wraps the externally-sourced fields. crashed_marker
-                        // is a config-keyed MM/legacy fragment built by the renderer
-                        // above and must NOT round-trip — it would lose its formatting.
-                        Map.entry("grim_version", mmSafe(nullToUnknown(s.grimVersion()))),
-                        Map.entry("server_name", mmSafe(nullToUnknown(s.serverName()))),
+                        // mmSafe wraps the truly-untrusted fields. server_name and
+                        // grim_version are operator-/server-configured (operators may
+                        // legitimately want colours), so they pass verbatim.
+                        // crashed_marker is a config-keyed legacy/MM fragment built
+                        // above and must NOT round-trip.
+                        Map.entry("grim_version", nullToUnknown(s.grimVersion())),
+                        Map.entry("server_name", nullToUnknown(s.serverName())),
                         Map.entry("client_version", clientVersionDisplay(s.clientVersion())),
                         Map.entry("client_brand", mmSafe(nullToUnknown(s.clientBrand()))),
                         Map.entry("ordinal", Integer.toString(s.sessionOrdinal())),
@@ -169,13 +171,15 @@ public final class HistoryComponentRenderer {
         int page = pageArg == null ? maxPages : Math.max(1, Math.min(pageArg, maxPages));
 
         Map<String, String> metaVars = Map.ofEntries(
-                // mmSafe wraps the externally-sourced fields. Player display
-                // names are Minecraft-constrained (letters/digits/underscore),
-                // so they don't need sanitisation.
-                Map.entry("player", playerDisplayName),
+                // mmSafe wraps the truly-untrusted leaves: %player% is
+                // operator-typed on the command line (defence in depth),
+                // %client_brand% is whatever the client sent on the
+                // minecraft:brand channel. server_name / grim_version are
+                // server/operator config and may legitimately contain colours.
+                Map.entry("player", mmSafe(playerDisplayName)),
                 Map.entry("ordinal", Integer.toString(d.sessionOrdinal())),
-                Map.entry("grim_version", mmSafe(nullToUnknown(d.grimVersion()))),
-                Map.entry("server_name", mmSafe(nullToUnknown(d.serverName()))),
+                Map.entry("grim_version", nullToUnknown(d.grimVersion())),
+                Map.entry("server_name", nullToUnknown(d.serverName())),
                 Map.entry("client_version", clientVersionDisplay(d.clientVersion())),
                 Map.entry("client_brand", mmSafe(nullToUnknown(d.clientBrand()))),
                 Map.entry("duration", durationText),
@@ -265,12 +269,12 @@ public final class HistoryComponentRenderer {
     private static Component renderViolationLine(Sender sender, ConfigManager cfg, ViolationEntry v, boolean verbose) {
         String verboseText = v.verbose() == null ? "" : v.verbose();
         // verbose carries whatever the check wrote into the column — often a
-        // component fragment serialised via LegacyComponentSerializer, so §
-        // (or `&`) codes are common, as are values derived from user-supplied
-        // strings (chat content, brand fragments). mmSafe converts both
-        // legacy syntaxes to MM tag pairs and escapes literal '<' / '>' so a
-        // crafted verbose can't inject MM tags into the rendered row.
-        // Suppressed when -v isn't set.
+        // component fragment serialised via LegacyComponentSerializer (so §
+        // / & codes are common), occasionally derived from user-supplied
+        // strings (chat content, brand fragments). mmSafe strips every
+        // legacy format code (§, &, hex variants) and escapes the MM tag
+        // opener so a crafted verbose can't inject formatting into the
+        // rendered row. Suppressed when -v isn't set.
         Component line = parse(sender, cfg, "grim-history-detail-entry",
                 "&7- &f%check% &8(&b%offset%&8)&7 %verbose%",
                 Map.of(
@@ -364,33 +368,51 @@ public final class HistoryComponentRenderer {
     }
 
     /**
-     * Normalise an untrusted leaf string into a MiniMessage-safe substitute.
-     * Callers must wrap stored values that originate outside the renderer
-     * (client brand, server name) before stuffing them into the var map for
-     * {@link #parse}. Trusted renderer-built MM fragments — {@code
-     * checks_list} composed from a config-keyed template, {@code
-     * crashed_marker} sourced from messages.yml — must NOT be passed through
-     * this helper, since the round-trip strips their MM tags as literal text.
+     * Render an untrusted leaf string as plain text, MiniMessage-escaped.
+     * Strips every form of formatting (legacy {@code §}-codes, ampersand
+     * {@code &}-codes, hex {@code &#RRGGBB} and Bedrock {@code &x&R&R…}
+     * forms) and escapes the MM tag-opener so the result cannot inject
+     * formatting downstream regardless of {@link MessageUtil#miniMessage}'s
+     * legacy + hex prepass.
      *
-     * <p>The pre-normalisation step translates legacy {@code &amp;}-codes to
-     * {@code §}-codes via {@link MessageUtil#translateAlternateColorCodes(char, String)}.
-     * V2's {@code MessageUtil.miniMessage} otherwise globally rewrites
-     * {@code &c} runs into MM tags AFTER var substitution, so an untrusted
-     * value containing {@code &c} would still inject formatting if the
-     * round-trip below saw only the {@code §}-form. Pre-translating brings
-     * both syntaxes through {@code LegacyComponentSerializer.legacySection}
-     * (which only recognises {@code §}). MM.serialize then re-emits the
-     * runs as MM tag pairs and escapes any literal {@code <} / {@code >}
-     * in the input.
+     * <p>Used on values that originate outside the renderer's trust
+     * boundary:
+     * <ul>
+     *   <li>{@code client_brand} — whatever the client sent on the
+     *       {@code minecraft:brand} plugin channel.</li>
+     *   <li>{@code verbose} — whatever a check wrote into the column.
+     *       Checks sometimes embed user-supplied text inside verbose
+     *       without sanitising.</li>
+     *   <li>{@code playerDisplayName} / {@code target} — operator-typed
+     *       on the command line; defence-in-depth so a hostile MM tag
+     *       in the typed target name can't poison header rendering.</li>
+     * </ul>
+     *
+     * <p>NOT used on trusted leaves: {@code server_name} and
+     * {@code grim_version} are operator-/server-configured and may
+     * legitimately contain operator-authored colours, so they pass
+     * through verbatim. Renderer-built fragments
+     * ({@code crashed_marker}, {@code checks_list}) also pass through.
      *
      * <p>{@code null} / empty input short-circuits to {@code ""}.
      */
     private static String mmSafe(@Nullable String raw) {
         if (raw == null || raw.isEmpty()) return "";
-        String translated = MessageUtil.translateAlternateColorCodes('&', raw);
-        return MiniMessage.miniMessage().serialize(
-                LegacyComponentSerializer.legacySection().deserialize(translated));
+        String stripped = LEGACY_FORMAT_PATTERN.matcher(raw).replaceAll("");
+        // Escape backslash first so we don't double-process the backslash
+        // we add for '<'. MM treats '\<' as a literal '<' and '\\' as '\'.
+        return stripped.replace("\\", "\\\\").replace("<", "\\<");
     }
+
+    /**
+     * Matches any legacy format marker that V2's downstream
+     * {@link MessageUtil#miniMessage} pipeline would otherwise interpret as
+     * a colour / decoration run. Covers both {@code §} and {@code &} sigils,
+     * plain {@code [0-9A-Za-z]} format codes, and the two hex forms
+     * ({@code &#RRGGBB} and the Bedrock-style {@code &x&R&R&G&G&B&B}).
+     */
+    private static final Pattern LEGACY_FORMAT_PATTERN = Pattern.compile(
+            "[§&](?:[0-9A-Za-z]|#[A-Fa-f0-9]{6}|x(?:[§&][A-Fa-f0-9]){6})");
 
     public static @NotNull String formatDuration(long ms) {
         if (ms < 0) ms = 0;

--- a/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
+++ b/common/src/main/java/ac/grim/grimac/command/render/HistoryComponentRenderer.java
@@ -38,9 +38,9 @@ public final class HistoryComponentRenderer {
      * Session-list view. {@code page} is 1-indexed; {@code maxPages} ≥ 1.
      * {@code ongoingSessionId} (optional) is the player's currently-active
      * sessionId from SessionTracker; the matching row shows "current" as its
-     * duration. {@code viaPlayerLiteral} routes the per-row click /
-     * copy-paste detail command through {@code /grim history player <target>}
-     * so a list opened via the disambiguator stays on that branch.
+     * duration. Per-row click / copy-paste detail commands always use the
+     * disambiguated {@code /grim history player <target>} form so a shared
+     * or re-run command can't dead-end on a literal-collision player name.
      */
     public static @NotNull List<Component> renderSessionList(
             @NotNull Sender sender,
@@ -49,8 +49,7 @@ public final class HistoryComponentRenderer {
             int page,
             int maxPages,
             @NotNull Page<SessionSummary> result,
-            @Nullable UUID ongoingSessionId,
-            boolean viaPlayerLiteral) {
+            @Nullable UUID ongoingSessionId) {
         ConfigManager cfg = GrimAPI.INSTANCE.getConfigManager().getConfig();
         String safePlayer = mmSafe(playerDisplayName);
         if (result.items().isEmpty()) {
@@ -72,13 +71,13 @@ public final class HistoryComponentRenderer {
                         "maxPages", maxPagesStr)));
         for (SessionSummary s : result.items()) {
             boolean ongoing = ongoingSessionId != null && ongoingSessionId.equals(s.sessionId());
-            out.add(renderSummaryLine(sender, cfg, s, ongoing, playerDisplayName, viaPlayerLiteral));
+            out.add(renderSummaryLine(sender, cfg, s, ongoing, playerDisplayName));
         }
         return out;
     }
 
     private static Component renderSummaryLine(Sender sender, ConfigManager cfg, SessionSummary s, boolean ongoing,
-                                               String playerDisplayName, boolean viaPlayerLiteral) {
+                                               String playerDisplayName) {
         long elapsedNow = Math.max(0, System.currentTimeMillis() - s.startedEpochMs());
         String durationText = ongoing
                 ? "current"
@@ -108,8 +107,7 @@ public final class HistoryComponentRenderer {
                         Map.entry("unique_checks", Integer.toString(s.uniqueCheckCount())),
                         Map.entry("crashed_marker", crashedMarker),
                         Map.entry("timeago", formatDuration(elapsedNow))));
-        String detailCommand = "/grim history " + (viaPlayerLiteral ? "player " : "")
-                + playerDisplayName + " session " + s.sessionOrdinal();
+        String detailCommand = "/grim history player " + playerDisplayName + " session " + s.sessionOrdinal();
         Component tooltip = Component.text()
                 .append(Component.text("Session ", NamedTextColor.AQUA))
                 .append(Component.text(s.sessionId().toString(), NamedTextColor.GRAY))


### PR DESCRIPTION
Four operator-facing changes to `/grim history`:

- `/grim history <target> session` (no ordinal) prints the help menu instead of Cloud's stock `missing required argument: session` parse error.
- `/grim history player <target> …` disambiguates player names that collide with a sibling literal at the same tree depth (today: `repair`, `player` itself).
- Fallback history templates render `%prefix%` on header lines only; mid-render rows render unprefixed. Operators' existing `messages.yml` overrides are unaffected — only the hard-coded defaults change.
- Session-row hover now attaches `ClickEvent.runCommand` and uses the real player name + ordinal. Previously it suggested `/grim history <8-char-uuid-prefix> session <N>` which couldn't resolve (the target parser takes a name, not a UUID prefix) and carried a "Click (when supported)" hedge with no click event wired. The click command always uses the disambiguated `/grim history player <name> session <N>` form so a shared or re-run command can't dead-end on a literal-collision player name.

## How it works

`HistoryComponentRenderer.mmSafe()` is the sanitization layer for untrusted leaves — client brand, inline verbose text, player display, check display/description. Strips `%` before legacy `§`/`&` markers (so `&%c` cannot become `&c` after the percent drops out), strips hex variants (`&#RRGGBB` and the Bedrock `&x&R&R…` interleave), and escapes the MiniMessage tag opener. The legacy regex is narrowed to the canonical Minecraft alphabet (`0-9 a-f k-o r x`) so innocent text like `R&D` or `AT&T` survives untouched.

Server name, Grim version, the renderer-built `crashed_marker` and `checks_list`, and templates loaded from `messages.yml` pass through verbatim so operator-authored formatting still works.

## What this prevents

- A crafted client brand or check name painting MiniMessage into operator-facing rows.
- A leaf value expanding `%prefix%` / `%grim_version%` to lift trusted text through the downstream placeholder replacer.
- A `<click:run_command:/op …>` slipping past the renderer via any untrusted field.

## Test plan

- [ ] `/grim history <target> session` prints the session help menu.
- [ ] `/grim history player <colliding-name>` resolves a player named e.g. `repair`.
- [ ] Bare forms still work for list, paged list, session detail, paged session detail.
- [ ] Fallback history output only carries the bot prefix on header lines; existing `messages.yml` overrides remain unchanged.
- [ ] Untrusted client brand (e.g. `§cVape` or `<click:run_command:/op …>vape</click>`) renders as plain text in `/grim history` output.
