### PR TITLE
fix(fabric): refresh wrapped player entity on respawn

### DIFF
--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/entity/AbstractFabricGrimEntity.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/entity/AbstractFabricGrimEntity.java
@@ -11,7 +11,7 @@ import net.minecraft.world.entity.Entity;
 
 public abstract class AbstractFabricGrimEntity implements GrimEntity {
 
-    protected final Entity entity;
+    protected volatile Entity entity;
 
     public AbstractFabricGrimEntity(Entity entity) {
         this.entity = Objects.requireNonNull(entity);
@@ -34,6 +34,10 @@ public abstract class AbstractFabricGrimEntity implements GrimEntity {
     @Override
     public @NotNull Entity getNative() {
         return this.entity;
+    }
+
+    protected void replaceNativeEntity(@NotNull Entity entity) {
+        this.entity = Objects.requireNonNull(entity);
     }
 
     @Override

--- a/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformPlayer.java
+++ b/fabric/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformPlayer.java
@@ -149,7 +149,9 @@ public abstract class AbstractFabricPlatformPlayer extends AbstractFabricGrimEnt
 
     @Override
     public void replaceNativePlayer(Object nativePlayerObject) {
-        this.fabricPlayer = (ServerPlayer) nativePlayerObject;
+        ServerPlayer player = (ServerPlayer) nativePlayerObject;
+        this.fabricPlayer = player;
+        replaceNativeEntity(player);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Keep Fabric GrimEntity's native entity reference in sync when a cached PlatformPlayer is rebound after Minecraft replaces the ServerPlayer.
- Prevent inherited PlatformPlayer location/world/distance reads from using the old pre-respawn or pre-dimension-change entity.
- Fix Fabric `/grim spectate <player>` teleporting to stale target coordinates after the target respawns or changes dimensions.

## Notes
- This is Fabric-only. Bukkit wrappers do not use this Fabric entity/player split.
- Fixes https://github.com/GrimAnticheat/Grim/issues/2691.

## Testing
- `./gradlew :fabric:compileJava :fabric:mc12111:compileJava`