### PR TITLE
fix(fabric): bind PacketContext around item encoding for Polymer 0.16+ (#2701)

### DIFF
--- a/fabric/official/mc261/src/main/java/ac/grim/grimac/platform/fabric/mc261/Fabric261ConversionUtil.java
+++ b/fabric/official/mc261/src/main/java/ac/grim/grimac/platform/fabric/mc261/Fabric261ConversionUtil.java
@@ -36,7 +36,7 @@ public class Fabric261ConversionUtil implements IFabricConversionUtil {
             PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buffer);
             return wrapper.readItemStack();
         } catch (Exception e) {
-            LogUtil.error("Failed to encode ItemStack: {}" + fabricStack, e);
+            LogUtil.error("Failed to encode ItemStack: " + fabricStack, e);
             return ItemStack.EMPTY;
         } finally {
             ByteBufHelper.release(buffer);

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
@@ -4,6 +4,7 @@ import ac.grim.grimac.platform.api.player.PlatformInventory;
 import ac.grim.grimac.platform.api.player.PlatformPlayer;
 import ac.grim.grimac.platform.fabric.FabricPlatformServices;
 import ac.grim.grimac.platform.fabric.inject.FabricServerPlayerHandle;
+import ac.grim.grimac.platform.fabric.utils.FabricItemContextHook;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 
 public abstract class AbstractFabricPlatformInventory implements PlatformInventory {
@@ -18,48 +19,61 @@ public abstract class AbstractFabricPlatformInventory implements PlatformInvento
         return (FabricServerPlayerHandle) fabricPlatformPlayer.getNative();
     }
 
+    /**
+     * Converts a native item into a PacketEvents {@link ItemStack} while a {@code PacketContext} for the
+     * inventory owner is bound, so Polymer can encode the item instead of crashing (GrimAnticheat/Grim#2701).
+     */
+    private ItemStack convert(Object nativeItemStack) {
+        return FabricItemContextHook.supply(
+                fabricPlatformPlayer.getNative(),
+                () -> FabricPlatformServices.conversionUtil().fromFabricItemStack(nativeItemStack));
+    }
+
     @Override
     public ItemStack getItemInHand() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().heldItemStack());
+        return convert(handle().heldItemStack());
     }
 
     @Override
     public ItemStack getItemInOffHand() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(40));
+        return convert(handle().inventoryItemAt(40));
     }
 
     @Override
     public ItemStack getStack(int bukkitSlot, int vanillaSlot) {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(bukkitSlot));
+        return convert(handle().inventoryItemAt(bukkitSlot));
     }
 
     @Override
     public ItemStack getHelmet() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(39));
+        return convert(handle().inventoryItemAt(39));
     }
 
     @Override
     public ItemStack getChestplate() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(38));
+        return convert(handle().inventoryItemAt(38));
     }
 
     @Override
     public ItemStack getLeggings() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(37));
+        return convert(handle().inventoryItemAt(37));
     }
 
     @Override
     public ItemStack getBoots() {
-        return FabricPlatformServices.conversionUtil().fromFabricItemStack(handle().inventoryItemAt(36));
+        return convert(handle().inventoryItemAt(36));
     }
 
     @Override
     public ItemStack[] getContents() {
-        FabricServerPlayerHandle handle = handle();
-        ItemStack[] items = new ItemStack[handle.inventorySlotCount()];
-        for (int i = 0; i < items.length; i++) {
-            items[i] = FabricPlatformServices.conversionUtil().fromFabricItemStack(handle.inventoryItemAt(i));
-        }
-        return items;
+        // Bind the context once for the whole inventory sweep rather than per slot.
+        return FabricItemContextHook.supply(fabricPlatformPlayer.getNative(), () -> {
+            FabricServerPlayerHandle handle = handle();
+            ItemStack[] items = new ItemStack[handle.inventorySlotCount()];
+            for (int i = 0; i < items.length; i++) {
+                items[i] = FabricPlatformServices.conversionUtil().fromFabricItemStack(handle.inventoryItemAt(i));
+            }
+            return items;
+        });
     }
 }

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/player/AbstractFabricPlatformInventory.java
@@ -20,10 +20,16 @@ public abstract class AbstractFabricPlatformInventory implements PlatformInvento
     }
 
     /**
-     * Converts a native item into a PacketEvents {@link ItemStack} while a {@code PacketContext} for the
-     * inventory owner is bound, so Polymer can encode the item instead of crashing (GrimAnticheat/Grim#2701).
+     * Converts a native item into a PacketEvents {@link ItemStack}. When Polymer's item codec needs it
+     * (see {@link FabricItemContextHook#ACTIVE}), the encode runs with a {@code PacketContext} for the
+     * inventory owner bound so Polymer can encode the item instead of crashing (GrimAnticheat/Grim#2701).
+     * Otherwise it is the original direct read: the {@code ACTIVE} check folds away and no capturing
+     * lambda is allocated, keeping this hot path (held item / armour reads during predictions) allocation-free.
      */
     private ItemStack convert(Object nativeItemStack) {
+        if (!FabricItemContextHook.ACTIVE) {
+            return FabricPlatformServices.conversionUtil().fromFabricItemStack(nativeItemStack);
+        }
         return FabricItemContextHook.supply(
                 fabricPlatformPlayer.getNative(),
                 () -> FabricPlatformServices.conversionUtil().fromFabricItemStack(nativeItemStack));
@@ -66,14 +72,19 @@ public abstract class AbstractFabricPlatformInventory implements PlatformInvento
 
     @Override
     public ItemStack[] getContents() {
+        if (!FabricItemContextHook.ACTIVE) {
+            return readContents();
+        }
         // Bind the context once for the whole inventory sweep rather than per slot.
-        return FabricItemContextHook.supply(fabricPlatformPlayer.getNative(), () -> {
-            FabricServerPlayerHandle handle = handle();
-            ItemStack[] items = new ItemStack[handle.inventorySlotCount()];
-            for (int i = 0; i < items.length; i++) {
-                items[i] = FabricPlatformServices.conversionUtil().fromFabricItemStack(handle.inventoryItemAt(i));
-            }
-            return items;
-        });
+        return FabricItemContextHook.supply(fabricPlatformPlayer.getNative(), this::readContents);
+    }
+
+    private ItemStack[] readContents() {
+        FabricServerPlayerHandle handle = handle();
+        ItemStack[] items = new ItemStack[handle.inventorySlotCount()];
+        for (int i = 0; i < items.length; i++) {
+            items[i] = FabricPlatformServices.conversionUtil().fromFabricItemStack(handle.inventoryItemAt(i));
+        }
+        return items;
     }
 }

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
@@ -1,0 +1,88 @@
+package ac.grim.grimac.platform.fabric.utils;
+
+import ac.grim.grimac.utils.anticheat.LogUtil;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.Supplier;
+
+/**
+ * Binds a Polymer/fabric-api {@code PacketContext} around Grim's out-of-pipeline {@code ItemStack}
+ * encoding so that Polymer can encode items without crashing. See GrimAnticheat/Grim#2701.
+ *
+ * <p>Polymer 0.16+ (Minecraft 26.x) routes vanilla {@code ItemStack} stream-codec encoding through
+ * fabric-api's {@code net.fabricmc.fabric.api.networking.v1.context.PacketContext}. Its
+ * {@code ItemStackPacketCodecMixin} calls {@code PacketContext.orElseThrow()} at the head of every
+ * encode, which throws {@code "PacketContext is required, but it wasn't set up!"} whenever no context
+ * is bound to the current thread.
+ *
+ * <p>Grim encodes {@code ItemStack}s outside of the Netty pipeline when it reads a player's inventory
+ * to convert it into a PacketEvents {@code ItemStack} ({@code IFabricConversionUtil#fromFabricItemStack}).
+ * No context is bound there, so under Polymer every read threw, was caught, and returned
+ * {@code ItemStack.EMPTY} while spamming the log.
+ *
+ * <p>This hook reflectively wraps such reads in {@code PacketContext.supplyWithContext(provider, supplier)}
+ * using the inventory owner as the provider, so Polymer resolves that player's view of the item — the same
+ * representation the client received, which is what an anticheat simulating the client wants, and is
+ * consistent with the per-player block translation done by the {@code Fabric*PolymerHook}s.
+ *
+ * <p>It is a no-op pass-through when Polymer is absent or the fabric-api context API is unavailable
+ * (e.g. on pre-26.x where Polymer used PacketTweaker, whose codec mixin degrades gracefully on a missing
+ * context). Resolution is done by reflection because the parent fabric module compiles against MC 1.16.1,
+ * which predates this API; keying off the API's runtime presence means this transparently covers mc261
+ * and any later 26.x module without per-variant wiring.
+ */
+public final class FabricItemContextHook {
+    private static final MethodHandle SUPPLY_WITH_CONTEXT;
+
+    static {
+        MethodHandle supplyWithContext = null;
+
+        if (FabricLoader.getInstance().isModLoaded("polymer-core")) {
+            try {
+                MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+                Class<?> contextClass = Class.forName("net.fabricmc.fabric.api.networking.v1.context.PacketContext");
+                Class<?> providerClass = Class.forName("net.fabricmc.fabric.api.networking.v1.context.PacketContextProvider");
+
+                MethodHandle raw = lookup.findStatic(contextClass, "supplyWithContext",
+                        MethodType.methodType(Object.class, providerClass, Supplier.class));
+                // ServerPlayer implements PacketContextProvider via Polymer's mixin; accept it as a plain
+                // Object and let the handle's runtime checkcast validate it.
+                supplyWithContext = raw.asType(MethodType.methodType(Object.class, Object.class, Supplier.class));
+            } catch (Throwable t) {
+                // Older fabric-api/Polymer (PacketTweaker-based) tolerates a missing context, so failing to
+                // resolve the new API here is not fatal — degrade to a no-op pass-through.
+                LogUtil.info("[GrimAC] Polymer is present but fabric-api's PacketContext API is unavailable; "
+                        + "leaving item encoding to Polymer's own context handling.");
+            }
+        }
+
+        SUPPLY_WITH_CONTEXT = supplyWithContext;
+    }
+
+    private FabricItemContextHook() {
+    }
+
+    /**
+     * Runs {@code supplier} with {@code player}'s Polymer/fabric-api {@code PacketContext} bound to the
+     * current thread, so any {@code ItemStack} encoding inside it can be transformed by Polymer for that
+     * player. Falls back to running the supplier directly when the hook is inactive, the player is
+     * unavailable, or the context cannot be bound.
+     */
+    public static <T> T supply(Object player, Supplier<T> supplier) {
+        if (SUPPLY_WITH_CONTEXT == null || player == null) {
+            return supplier.get();
+        }
+        try {
+            Object result = SUPPLY_WITH_CONTEXT.invoke(player, supplier);
+            //noinspection unchecked
+            return (T) result;
+        } catch (Throwable t) {
+            // Binding failed (e.g. the player is not yet a context provider). Run without it; the encode's
+            // own try/catch handles any downstream Polymer failure.
+            return supplier.get();
+        }
+    }
+}

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
@@ -37,6 +37,16 @@ import java.util.function.Supplier;
 public final class FabricItemContextHook {
     private static final MethodHandle SUPPLY_WITH_CONTEXT;
 
+    /**
+     * True only when Polymer is present and the fabric-api context API resolved, i.e. when binding is
+     * actually needed. It is a {@code static final} primitive so the JIT folds it to a constant and
+     * dead-code-eliminates the binding path on the (overwhelmingly common) servers without Polymer —
+     * letting callers keep their original allocation-free direct read on hot paths. Check this at the
+     * call site <em>before</em> building the {@link Supplier} so the lambda is never allocated when
+     * inactive.
+     */
+    public static final boolean ACTIVE;
+
     static {
         MethodHandle supplyWithContext = null;
 
@@ -60,6 +70,7 @@ public final class FabricItemContextHook {
         }
 
         SUPPLY_WITH_CONTEXT = supplyWithContext;
+        ACTIVE = supplyWithContext != null;
     }
 
     private FabricItemContextHook() {

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
@@ -58,8 +58,11 @@ public final class FabricItemContextHook {
 
                 MethodHandle raw = lookup.findStatic(contextClass, "supplyWithContext",
                         MethodType.methodType(Object.class, providerClass, Supplier.class));
-                // ServerPlayer implements PacketContextProvider via Polymer's mixin; accept it as a plain
-                // Object and let the handle's runtime checkcast validate it.
+                // The inventory owner (ServerPlayer) implements PacketContextProvider at runtime via
+                // fabric-api's own net.fabricmc.fabric.mixin.networking.ServerPlayerMixin (it delegates
+                // getPacketContext() to player.connection). We accept it as a plain Object here and let
+                // the handle's runtime checkcast validate it, so the parent module needn't compile against
+                // the API. Verified live: the bind resolves "via net.minecraft.server.level.ServerPlayer".
                 supplyWithContext = raw.asType(MethodType.methodType(Object.class, Object.class, Supplier.class));
             } catch (Throwable t) {
                 // Older fabric-api/Polymer (PacketTweaker-based) tolerates a missing context, so failing to

--- a/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
+++ b/fabric/shared/src/main/java/ac/grim/grimac/platform/fabric/utils/FabricItemContextHook.java
@@ -82,14 +82,15 @@ public final class FabricItemContextHook {
      * player. Falls back to running the supplier directly when the hook is inactive, the player is
      * unavailable, or the context cannot be bound.
      */
+    @SuppressWarnings("unchecked")
     public static <T> T supply(Object player, Supplier<T> supplier) {
         if (SUPPLY_WITH_CONTEXT == null || player == null) {
             return supplier.get();
         }
         try {
-            Object result = SUPPLY_WITH_CONTEXT.invoke(player, supplier);
-            //noinspection unchecked
-            return (T) result;
+            // The handle is pre-shaped to (Object, Supplier)Object in <clinit>, so invokeExact matches the
+            // call-site descriptor exactly and skips the per-call argument adaptation plain invoke() does.
+            return (T) (Object) SUPPLY_WITH_CONTEXT.invokeExact(player, (Supplier<Object>) supplier);
         } catch (Throwable t) {
             // Binding failed (e.g. the player is not yet a context provider). Run without it; the encode's
             // own try/catch handles any downstream Polymer failure.


### PR DESCRIPTION
## Fixes #2701 — Fabric 26.x + Polymer item-encode crash

### Symptom
On Fabric MC 26.x with Polymer installed, holding/receiving any item spams:
```
Failed to encode ItemStack: {}64 minecraft:stripped_oak_log: java.lang.RuntimeException: PacketContext is required, but it wasn't set up!
    at net.fabricmc.fabric.api.networking.v1.context.PacketContext.orElseThrow(PacketContext.java:148)
```
Every affected read returns `ItemStack.EMPTY`, so Grim sees players holding nothing.

### Root cause
Grim encodes `ItemStack`s outside the Netty pipeline when reading a player's inventory (`fromFabricItemStack` → `ItemStack.STREAM_CODEC.encode`). Polymer 0.16+ (26.x) mixes into that codec and calls fabric-api `PacketContext.orElseThrow()` for **every** item, which throws when no context is bound to the thread. Polymer ≤1.21.x used PacketTweaker, which tolerated a missing context — so the item path was never protected; the 26.x switch to fabric-api's strict context surfaced it. (Prior Polymer work only covered block translation.)

### Fix
- `FabricItemContextHook` (new, `fabric/shared`): reflectively binds the inventory owner's `PacketContext` via `PacketContext.supplyWithContext(provider, supplier)` around the encode. Gated by a `static final ACTIVE` flag (JIT-folds to a no-op when Polymer / the fabric-api context API is absent, so non-Polymer servers and the intermediary/≤1.21.11 variant keep the original allocation-free path). Uses `invokeExact`.
- `AbstractFabricPlatformInventory`: routes reads through the gate (one bind per `getContents` sweep).
- `Fabric261ConversionUtil`: fix a malformed `"…: {}" + stack` log line.

### Verification (live, `fabric-26.1.2` + Polymer 0.16.5)
- Pre-fix: **32** `PacketContext is required` errors (incl. exact `{}64 minecraft:stripped_oak_log`).
- This PR: **0** errors; instrumented the bind path and observed `bind SUCCESS via net.minecraft.server.level.ServerPlayer` (fabric-api's `ServerPlayerMixin` makes `ServerPlayer` a `PacketContextProvider`). No regressions; both variants compile.
