### PR TITLE
exempt Bedrock players by username dot-prefix + %grim_isbedrock…

### DIFF
--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/utils/placeholder/PlaceholderAPIExpansion.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/utils/placeholder/PlaceholderAPIExpansion.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.platform.bukkit.utils.placeholder;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.GrimUser;
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.utils.reflection.GeyserUtil;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -46,11 +47,18 @@ public class PlaceholderAPIExpansion extends PlaceholderExpansion {
         for (String s : variableReplacements) {
             placeholders.add(s.equals("%player%") ? "%grim_player%" : "%grim_player_" + s.replace("%", "") + "%");
         }
+        placeholders.add("%grim_isbedrock%");
         return placeholders;
     }
 
     @Override
     public String onRequest(OfflinePlayer offlinePlayer, @NotNull String params) {
+        // Resolved straight from the username prefix so it still works for Bedrock
+        // players, who are exempted and therefore have no tracked GrimPlayer.
+        if (params.equalsIgnoreCase("isbedrock")) {
+            return String.valueOf(GeyserUtil.isBedrockName(offlinePlayer.getName()));
+        }
+
         for (Map.Entry<String, String> entry : GrimAPI.INSTANCE.getExternalAPI().getStaticReplacements().entrySet()) {
             String key = entry.getKey().equals("%grim_version%")
                     ? "version"

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/PlayerDataManager.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/PlayerDataManager.java
@@ -65,6 +65,13 @@ public class PlayerDataManager {
         if (isExemptUser(user)) return false;
         if (!ChannelHelper.isOpen(user.getChannel())) return false;
 
+        // Bedrock players (Geyser/Floodgate) are prefixed with "." by default and don't
+        // have Java movement, so exempt them based on their username prefix as well.
+        if (GeyserUtil.isBedrockName(user.getName())) {
+            exemptUser(user);
+            return false;
+        }
+
         if (user.getUUID() != null) {
             // Bedrock players don't have Java movement
             if (GeyserUtil.isBedrockPlayer(user.getUUID())) {

--- a/common/src/main/java/ac/grim/grimac/utils/reflection/GeyserUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/reflection/GeyserUtil.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.utils.reflection;
 import lombok.experimental.UtilityClass;
 import org.geysermc.api.Geyser;
 import org.geysermc.floodgate.api.FloodgateApi;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -15,5 +16,12 @@ public class GeyserUtil {
     public static boolean isBedrockPlayer(UUID uuid) {
         return floodgate && FloodgateApi.getInstance().isFloodgatePlayer(uuid)
                 || geyser && Geyser.api().isBedrockPlayer(uuid);
+    }
+
+    // Geyser/Floodgate prefixes Bedrock usernames (default prefix is ".") so they
+    // don't collide with Java usernames. Detecting that prefix lets us treat the
+    // player as Bedrock even when the Geyser/Floodgate API isn't reachable from here.
+    public static boolean isBedrockName(@Nullable String name) {
+        return name != null && name.startsWith(".");
     }
 }


### PR DESCRIPTION
…% placeholder

Geyser/Floodgate prefix Bedrock usernames with "." by default. Treat a leading-dot username as a Bedrock player and exempt them from checks, in addition to the existing Geyser/Floodgate API and Geyser-UUID detection. This covers setups where the Geyser/Floodgate API isn't reachable from the anticheat (e.g. proxy installs).

Adds GeyserUtil.isBedrockName() as the shared dot-prefix check used by both the exemption path and the new %grim_isbedrock% PlaceholderAPI placeholder. The placeholder resolves directly from the username so it still returns true for Bedrock players, who are exempted and therefore have no tracked GrimPlayer.