### PR TITLE
storage: handle missing datastore routes

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
@@ -103,9 +103,9 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     private NameResolver nameResolver;
     private ViolationSinkImpl violationSink;
     private RetentionSweeper retentionSweeper;
-    private SessionTracker sessionTracker;
-    private LiveWriteHooks liveWriteHooks;
-    private PlayerToggleStore playerToggleStore;
+    private SessionTracker sessionTracker = SessionTracker.NOOP;
+    private LiveWriteHooks liveWriteHooks = LiveWriteHooks.NOOP;
+    private PlayerToggleStore playerToggleStore = PlayerToggleStore.NOOP;
     private V2InstanceRegistry instanceRegistry;
     private HeartbeatScheduler heartbeatScheduler;
     private UUID instanceId;
@@ -179,6 +179,12 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
             } catch (Exception e) {
                 logger.log(Level.SEVERE,
                         "[grim-datastore] v2 backend init failed for '" + backendId + "'", e);
+                try { v2.close(); }
+                catch (Exception closeFailure) {
+                    logger.log(Level.WARNING,
+                            "[grim-datastore] v2 backend close after failed init failed for '"
+                                    + backendId + "'", closeFailure);
+                }
                 continue;
             }
             this.v2Backends.add(v2);
@@ -244,6 +250,9 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         }
 
         V2Routes routes = routesBuilder.build();
+        if (routes.isEmpty()) {
+            throw new RuntimeException("no v2 routes installed");
+        }
         CategoryRouter router = startupRouteInstalled
                 ? new CategoryRouter(Map.of(V2InstanceRegistry.STARTUPS, V2InstanceRegistry.ROUTER_SENTINEL_BACKEND))
                 : new CategoryRouter(Map.of());
@@ -254,33 +263,67 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         logger.info("[grim-datastore] v2 cutover complete: " + v2ById.size()
                 + " v2 backend(s), " + routes + " routes installed, 0 legacy backends");
 
-        if (!buildServices()) {
+        if (!buildServices(routes)) {
             disableStorageAfterDuplicate();
             return false;
         }
         return true;
     }
 
-    private boolean buildServices() {
+    private boolean buildServices(@NotNull V2Routes routes) {
         V2InstanceRegistry.StartupClaim claim = startInstanceRegistry();
         if (claim != null && claim.duplicate()) {
             startDuplicateWarning(claim.warningMessage());
             return false;
         }
 
-        this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
-                config.history().entriesPerPage(), config.history().groupIntervalMs())
-                .withV2Startups(Categories.SERVER_STARTUP);
+        boolean sessionRouted = routes.contains(Categories.SESSION);
+        boolean violationRouted = routes.contains(Categories.VIOLATION);
+        boolean playerIdentityRouted = routes.contains(Categories.PLAYER_IDENTITY);
+        boolean settingRouted = routes.contains(Categories.SETTING);
+
+        if (sessionRouted && violationRouted) {
+            this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
+                    config.history().entriesPerPage(), config.history().groupIntervalMs())
+                    .withV2Startups(Categories.SERVER_STARTUP);
+        } else {
+            logger.warning("[grim-datastore] history disabled; missing "
+                    + missingRoutes(sessionRouted, "session", violationRouted, "violation"));
+        }
         this.playerIdentityService = new PlayerIdentityService(dataStore);
-        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain());
-        this.violationSink = new ViolationSinkImpl(dataStore);
+        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain(), playerIdentityRouted);
+        this.violationSink = violationRouted ? new ViolationSinkImpl(dataStore) : null;
         this.retentionSweeper = new RetentionSweeper(dataStore, config.retention(), logger);
-        this.sessionTracker = new SessionTrackerImpl(
-                dataStore, config.serverName(), config.session().heartbeatIntervalMs(), startupId);
-        this.liveWriteHooks = new LiveWriteHooksImpl(
-                dataStore, playerIdentityService, checkRegistry, sessionTracker);
-        this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
+        if (sessionRouted) {
+            this.sessionTracker = new SessionTrackerImpl(
+                    dataStore, config.serverName(), config.session().heartbeatIntervalMs(), startupId);
+        } else {
+            this.sessionTracker = SessionTracker.NOOP;
+            logger.warning("[grim-datastore] session tracking disabled; missing session route");
+        }
+        if (sessionRouted && violationRouted) {
+            this.liveWriteHooks = new LiveWriteHooksImpl(
+                    dataStore, playerIdentityService, checkRegistry, sessionTracker);
+        } else if (playerIdentityRouted) {
+            this.liveWriteHooks = new IdentityLiveWriteHooks(playerIdentityService);
+        } else {
+            this.liveWriteHooks = LiveWriteHooks.NOOP;
+        }
+        if (settingRouted) {
+            this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
+        } else {
+            this.playerToggleStore = PlayerToggleStore.NOOP;
+            logger.warning("[grim-datastore] player toggle persistence disabled; missing setting route");
+        }
         return true;
+    }
+
+    private static @NotNull String missingRoutes(
+            boolean firstPresent, @NotNull String first,
+            boolean secondPresent, @NotNull String second) {
+        if (!firstPresent && !secondPresent) return first + " and " + second + " routes";
+        if (!firstPresent) return first + " route";
+        return second + " route";
     }
 
     private @Nullable V2InstanceRegistry.StartupClaim startInstanceRegistry() {
@@ -379,9 +422,9 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         nameResolver = null;
         violationSink = null;
         retentionSweeper = null;
-        sessionTracker = null;
-        liveWriteHooks = null;
-        playerToggleStore = null;
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
         instanceRegistry = null;
         loaded = false;
         enabled = false;
@@ -577,11 +620,21 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         v2Backends.clear();
     }
 
-    private NameResolver buildNameResolver(DataStore store, List<String> chain) {
+    private NameResolver buildNameResolver(
+            DataStore store,
+            List<String> chain,
+            boolean playerIdentityRouted) {
         List<NameResolverLink> links = new ArrayList<>();
         for (String id : chain) {
             switch (id) {
-                case "local-cache" -> links.add(new LocalCacheLink(store));
+                case "local-cache" -> {
+                    if (playerIdentityRouted) {
+                        links.add(new LocalCacheLink(store));
+                    } else {
+                        logger.warning("[grim-datastore] name resolver local-cache disabled; "
+                                + "missing player-identity route");
+                    }
+                }
                 case "offline-mode-uuid" -> links.add(new OfflineModeUuidLink());
                 default -> logger.warning("[grim-datastore] unknown name-resolver link: " + id);
             }
@@ -674,7 +727,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
             heartbeatScheduler = null;
         }
         shutdownInstanceRegistry();
-        if (playerToggleStore != null) playerToggleStore.shutdown();
+        playerToggleStore.shutdown();
         if (violationSink != null) violationSink.shutDown();
         if (dataStore != null) {
             long drainMs = config != null ? config.writePath().shutdownDrainTimeoutMs() : 5000L;
@@ -687,9 +740,9 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         nameResolver = null;
         violationSink = null;
         retentionSweeper = null;
-        sessionTracker = null;
-        liveWriteHooks = null;
-        playerToggleStore = null;
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
         instanceRegistry = null;
         instanceId = null;
         startupId = null;
@@ -728,20 +781,20 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
      * {@code PacketPlayerJoinQuit}. Returns {@link LiveWriteHooks#NOOP} when
      * the datastore is disabled or its init failed — callers don't null-check.
      */
-    public @NotNull LiveWriteHooks liveWriteHooks() { return loaded ? liveWriteHooks : LiveWriteHooks.NOOP; }
+    public @NotNull LiveWriteHooks liveWriteHooks() { return liveWriteHooks; }
 
     /**
      * The live session tracker. Returns {@link SessionTracker#NOOP} when the
      * datastore is disabled or its init failed.
      */
-    public @NotNull SessionTracker sessionTracker() { return loaded ? sessionTracker : SessionTracker.NOOP; }
+    public @NotNull SessionTracker sessionTracker() { return sessionTracker; }
 
     /**
      * Persistence layer for the per-player /grim alerts | verbose | brands
      * toggles. Returns {@link PlayerToggleStore#NOOP} when the datastore is
      * disabled or its init failed.
      */
-    public @NotNull PlayerToggleStore playerToggleStore() { return loaded ? playerToggleStore : PlayerToggleStore.NOOP; }
+    public @NotNull PlayerToggleStore playerToggleStore() { return playerToggleStore; }
 
     /**
      * Admin-command escape hatch used by {@code /grim history migrate} to target

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/IdentityLiveWriteHooks.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/IdentityLiveWriteHooks.java
@@ -1,0 +1,62 @@
+package ac.grim.grimac.manager.datastore;
+
+import ac.grim.grimac.api.AbstractCheck;
+import ac.grim.grimac.internal.storage.identity.PlayerIdentityService;
+import ac.grim.grimac.platform.api.player.PlatformPlayer;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.protocol.player.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Live-write facade used when only the player-identity route is available.
+ * History/session writes remain no-op, but join identity caching still works.
+ */
+final class IdentityLiveWriteHooks implements LiveWriteHooks {
+
+    private final PlayerIdentityService identityService;
+
+    IdentityLiveWriteHooks(@NotNull PlayerIdentityService identityService) {
+        this.identityService = identityService;
+    }
+
+    @Override
+    public void onJoin(
+            @NotNull UUID uuid,
+            @Nullable String name,
+            long now,
+            @NotNull SessionTracker.ClientMeta meta) {
+        identityService.observe(uuid, name, now);
+    }
+
+    @Override public void onQuit(@NotNull UUID uuid, long now, @NotNull SessionTracker.ClientMeta meta) {}
+    @Override public void observeBrand(@NotNull UUID uuid, long now, @NotNull SessionTracker.ClientMeta meta) {}
+
+    @Override
+    public void recordFlag(
+            @NotNull UUID playerUuid,
+            @NotNull AbstractCheck check,
+            double vl,
+            @Nullable String verbose,
+            long now,
+            @NotNull SessionTracker.ClientMeta meta) {
+    }
+
+    @Override
+    public void onJoinFromUserLogin(@NotNull PlatformPlayer player, @NotNull User user, long now) {
+        onJoin(player.getUniqueId(), player.getName(), now, SessionTracker.ClientMeta.empty());
+    }
+
+    @Override public void onQuitFromUserDisconnect(@NotNull User user, @Nullable GrimPlayer grimPlayer, long now) {}
+    @Override public void observeBrandFromCheck(@NotNull GrimPlayer grimPlayer) {}
+
+    @Override
+    public void recordFlagFromCheck(
+            @NotNull GrimPlayer player,
+            @NotNull AbstractCheck check,
+            double vl,
+            @Nullable String verbose) {
+    }
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.0"
+grim-api = "1.6.0.1"
 packetevents = "2.12.3+e18eca8-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
## Summary
- Use the released GrimAPI 1.6.0.1 storage fixes.
- Keep datastore startup route-aware so one failed backend disables only the affected datastore features.
- Resolve no-op datastore facades at startup/reload instead of branching in hot paths.
- Preserve optional SQLite JDBC driver-holder behavior; Fabric does not shade SQLite.

## Fixes
Fixes #2707
Fixes #2710
Fixes #2711

## Verification
- JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew :bukkit:shadowJar :fabric:jar
- Confirmed final Bukkit/Fabric jars do not contain sqlite-jdbc/org.sqlite classes in prior review build.