### PR TITLE
storage: use GrimAPI 1.6.0.2

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.1"
+grim-api = "1.6.0.2"
 packetevents = "2.12.3+e18eca8-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
Updates Grim 2.0 to the API release that restores legacy SQLite support for v2 datastore writes