### PR TITLE
storage: use GrimAPI 1.6.0.3

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.2"
+grim-api = "1.6.0.3"
 packetevents = "2.12.3+e18eca8-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
Fixes #2718.

Pulls in GrimAPI 1.6.0.3, which fixes JDBC check catalog insertion against the v2 SQL grim_checks table by allocating check_id explicitly instead of expecting a generated key.

Verification:
- GrimAPI PR #27 merged and release workflow completed for 1.6.0.3.
- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :grim-internal:test --tests ac.grim.grimac.internal.storage.checks.JdbcCheckCatalogPersistenceTest --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqlite --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqliteLegacy
- JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew --no-daemon :bukkit:shadowJar -PmavenLocalOverride=false
- Deployed to paper-1.20.1 test profile and verified Grim loaded as 2.3.74-codex_check-catalog-v2-sql-2.0-dc3ac4c.
- Server log shows datastore startup clean with no v1 datastore recordFlag/failed grim_checks signature after smoke attempt.