### PR TITLE
Backport storage ownership leases

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     api(libs.adventure.text.minimessage)
     api(libs.jetbrains.annotations)
     api(libs.hikaricp)
-
     api(libs.grim.api)
     api(libs.grim.internal)
     compileOnly(libs.grim.internal.shims)

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreConfigBuilder.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreConfigBuilder.java
@@ -8,8 +8,10 @@ import ac.grim.grimac.api.storage.backend.BackendRegistry;
 import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.config.DataStoreConfig;
+import ac.grim.grimac.api.storage.config.DuplicatePersistentUuidAction;
 import ac.grim.grimac.api.storage.config.HistoryConfig;
 import ac.grim.grimac.api.storage.config.MigrationConfig;
+import ac.grim.grimac.api.storage.config.OwnershipConfig;
 import ac.grim.grimac.api.storage.config.RetentionRule;
 import ac.grim.grimac.api.storage.config.SessionConfig;
 import ac.grim.grimac.api.storage.config.WaitStrategyType;
@@ -64,6 +66,8 @@ public final class DataStoreConfigBuilder {
                 config.getBooleanElse(NS + "session.scope-per-server", true),
                 config.getLongElse(NS + "session.heartbeat-interval-ms", 30_000L));
 
+        OwnershipConfig ownership = readOwnership();
+
         WritePathConfig writePath = readWritePath();
         Map<Category<?>, RetentionRule> retention = readRetention();
 
@@ -81,7 +85,31 @@ public final class DataStoreConfigBuilder {
         String serverName = config.getStringElse(NS + "server-name", "Unknown");
 
         return new DataStoreConfig(
-                routing, backends, session, writePath, retention, migration, chain, history, serverName);
+                routing, backends, session, ownership, writePath, retention, migration, chain, history, serverName);
+    }
+
+    private @NotNull OwnershipConfig readOwnership() {
+        String actionRaw = config.getStringElse(
+                NS + "ownership.duplicate-persistent-uuid-action", "disable-storage");
+        DuplicatePersistentUuidAction action;
+        try {
+            action = DuplicatePersistentUuidAction.valueOf(
+                    actionRaw.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "database.ownership.duplicate-persistent-uuid-action must be one of "
+                            + "disable-storage, fail-startup, allow-unsafe (got '" + actionRaw + "')");
+        }
+        return new OwnershipConfig(
+                config.getBooleanElse(NS + "ownership.enforce-persistent-uuid-ownership", true),
+                action,
+                config.getLongElse(NS + "ownership.lease-ttl-ms", 20_000L),
+                config.getLongElse(NS + "ownership.renew-interval-ms", 10_000L),
+                config.getLongElse(NS + "ownership.startup-wait-ms", 20_000L),
+                config.getLongElse(NS + "ownership.safety-margin-ms", 5_000L),
+                config.getLongElse(NS + "ownership.stale-startup-ttl-ms", 30_000L),
+                config.getLongElse(NS + "ownership.recovery-sweep-interval-ms", 10_000L),
+                config.getBooleanElse(NS + "ownership.cleanup-other-servers", true));
     }
 
     private Map<Category<?>, String> readRouting() {

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
@@ -3,8 +3,6 @@ package ac.grim.grimac.manager.datastore;
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.plugin.GrimPlugin;
 import ac.grim.grimac.checks.impl.verbose.VerboseCodecs;
-import ac.grim.grimac.manager.init.start.StartableInitable;
-import ac.grim.grimac.manager.init.stop.StoppableInitable;
 import ac.grim.grimac.api.storage.DataStore;
 import ac.grim.grimac.api.storage.backend.Backend;
 import ac.grim.grimac.api.storage.backend.BackendConfig;
@@ -17,9 +15,15 @@ import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.check.CheckCatalogPersistence;
 import ac.grim.grimac.api.storage.check.CheckCatalogRow;
 import ac.grim.grimac.api.storage.config.DataStoreConfig;
+import ac.grim.grimac.api.storage.config.DuplicatePersistentUuidAction;
 import ac.grim.grimac.api.storage.history.HistoryService;
 import ac.grim.grimac.api.storage.identity.NameResolver;
 import ac.grim.grimac.api.storage.identity.NameResolverLink;
+import ac.grim.grimac.api.storage.instance.OwnershipClaimResult;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipAdapter;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipGate;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipMetadata;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipSnapshot;
 import ac.grim.grimac.api.storage.registry.MigrationContext;
 import ac.grim.grimac.api.storage.registry.StoreId;
 import ac.grim.grimac.api.storage.submit.ViolationSink;
@@ -57,6 +61,8 @@ import ac.grim.grimac.internal.storage.submit.ViolationSinkImpl;
 import ac.grim.grimac.internal.storage.verbose.VerboseManifest;
 import ac.grim.grimac.internal.storage.verbose.VerboseRegistry;
 import ac.grim.grimac.internal.storage.verbose.VerboseRegistryImpl;
+import ac.grim.grimac.manager.init.start.StartableInitable;
+import ac.grim.grimac.manager.init.stop.StoppableInitable;
 import com.mongodb.client.MongoDatabase;
 import org.bson.BsonBinarySubType;
 import org.bson.Document;
@@ -65,6 +71,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.sql.DataSource;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -85,18 +92,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.sql.DataSource;
 
 /**
- * Wires the shared DataStore + associated services to the plugin's
- * start/stop lifecycle. Owns the construction order: build backends → init →
- * capability-validate routing → migrate any legacy store → start writer
- * loops → register services. Accepting players happens in
- * {@link GrimAPI#start()} after this.
+ * Wires the shared DataStore and services to the plugin lifecycle. This path
+ * uses the v2 backend primitives so persistent UUID ownership, startup rows,
+ * and crash recovery all share the same backend under the session route.
  */
 public final class DataStoreLifecycle implements StartableInitable, StoppableInitable {
 
     private static final String CHECKS_STORE = "grim_checks";
+    private static final StoreId OWNERSHIP_STORE = StoreId.grim("server_ownership");
 
     private final GrimPlugin plugin;
     private final Logger logger;
@@ -116,10 +121,15 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     private PlayerToggleStore playerToggleStore = PlayerToggleStore.NOOP;
     private V2InstanceRegistry instanceRegistry;
     private HeartbeatScheduler heartbeatScheduler;
+    private OwnershipHeartbeatScheduler ownershipHeartbeatScheduler;
+    private ServerOwnershipAdapter ownershipAdapter;
+    private ServerOwnershipGate ownershipGate = ServerOwnershipGate.disabled();
     private UUID instanceId;
     private UUID startupId;
+    private UUID ownershipFence;
     private long startupStartedEpochMs;
     private ScheduledExecutorService duplicateWarningExecutor;
+    private ScheduledExecutorService recoverySweepExecutor;
 
     private boolean enabled = true;
     private boolean loaded;
@@ -135,27 +145,22 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     @Override
     public void start() {
         Path dataFolder = plugin.getDataFolder().toPath();
-        // database.yml + per-backend files load through the shared
-        // ConfigManager (see ConfigManagerFileImpl). Their key paths are
-        // namespaced under `database:` / `<id>:` wrappers so Configuralize's
-        // flat-merge doesn't collide them with config.yml / discord.yml.
-        // The cross-version updater also runs there before this method is
-        // called, so the on-disk files are already migrated.
         DataStoreConfigBuilder builder = new DataStoreConfigBuilder(
                 backendRegistry,
                 dataFolder,
                 GrimAPI.INSTANCE.getConfigManager().getConfig());
 
         if (!builder.enabled()) {
-            logger.info("[grim-datastore] disabled in database.yml — skipping storage init");
+            logger.info("[grim-datastore] disabled in database.yml - skipping storage init");
             this.enabled = false;
             installLocalVerboseRegistry();
             return;
         }
+        this.enabled = true;
         try {
             this.config = builder.build();
         } catch (RuntimeException e) {
-            logger.log(Level.SEVERE, "[grim-datastore] database.yml rejected — storage disabled", e);
+            logger.log(Level.SEVERE, "[grim-datastore] database.yml rejected - storage disabled", e);
             this.enabled = false;
             installLocalVerboseRegistry();
             return;
@@ -163,10 +168,15 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
 
         try {
             this.loaded = buildAndStart(dataFolder);
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "[grim-datastore] failed to initialise storage — falling back to disabled", e);
+        } catch (FatalStorageStartupException e) {
+            logger.log(Level.SEVERE, "[grim-datastore] fatal storage startup failure - shutting down server", e);
+            try { close(); } catch (Exception ignore) {}
             this.enabled = false;
-            try { teardown(); } catch (Exception ignore) {}
+            shutdownServerAfterFatalStorageStartup();
+        } catch (Exception | LinkageError e) {
+            logger.log(Level.SEVERE, "[grim-datastore] failed to initialise storage - falling back to disabled", e);
+            try { close(); } catch (Exception ignore) {}
+            this.enabled = false;
             installLocalVerboseRegistry();
         }
     }
@@ -182,7 +192,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
             BackendV2 v2 = constructV2Direct(backendId, backendConfig);
             if (v2 == null) {
                 logger.warning("[grim-datastore] no v2 backend for id '" + backendId
-                        + "' — categories routed here will be unavailable");
+                        + "' - categories routed here will be unavailable");
                 continue;
             }
             try {
@@ -230,6 +240,17 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         if (sessionBackendId != null && !"none".equals(sessionBackendId)) {
             BackendV2 sessionBackend = v2ById.get(sessionBackendId);
             if (sessionBackend != null) {
+                this.ownershipAdapter = sessionBackend.ownershipAdapter().orElse(null);
+                if (ownershipAdapter != null) {
+                    try {
+                        ownershipAdapter.ensureStore(OWNERSHIP_STORE);
+                    } catch (Exception e) {
+                        allFailures++;
+                        logger.log(Level.WARNING,
+                                "[grim-datastore] failed to ensure server ownership store on '"
+                                        + sessionBackendId + "'", e);
+                    }
+                }
                 MigrationContext mctx = buildMigrationContext(sessionBackend);
                 if (mctx == null) mctx = NO_OP_MIGRATION_CONTEXT;
 
@@ -251,21 +272,24 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         }
 
         if (allFailures > 0) {
-            logger.severe("[grim-datastore] v2 cutover had " + allFailures
-                    + " failure(s) — aborting storage init");
-            closeV2Backends();
-            throw new RuntimeException("v2 cutover failed with " + allFailures + " error(s)");
+            logger.warning("[grim-datastore] v2 cutover skipped " + allFailures
+                    + " failed route(s); continuing with successfully installed routes");
         }
 
         V2Routes routes = routesBuilder.build();
         if (routes.isEmpty()) {
             throw new RuntimeException("no v2 routes installed");
         }
+
         CategoryRouter router = startupRouteInstalled
                 ? new CategoryRouter(Map.of(V2InstanceRegistry.STARTUPS, V2InstanceRegistry.ROUTER_SENTINEL_BACKEND))
                 : new CategoryRouter(Map.of());
+        boolean enforceOwnership = config.ownership().enforcePersistentUuidOwnership()
+                && config.ownership().duplicatePersistentUuidAction() != DuplicatePersistentUuidAction.ALLOW_UNSAFE;
+        this.ownershipGate = new ServerOwnershipGate(enforceOwnership);
         this.dataStore = new DataStoreImpl(router, config.writePath(), logger);
         this.dataStore.withV2Routes(routes);
+        this.dataStore.withOwnershipGate(ownershipGate);
         this.dataStore.start();
         this.checkRegistry = buildCheckRegistry(v2ById);
         this.verboseRegistry = buildVerboseRegistry();
@@ -280,239 +304,13 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         return true;
     }
 
-    private boolean buildServices(@NotNull V2Routes routes) {
-        V2InstanceRegistry.StartupClaim claim = startInstanceRegistry();
-        if (claim != null && claim.duplicate()) {
-            startDuplicateWarning(claim.warningMessage());
-            return false;
-        }
-
-        boolean sessionRouted = routes.contains(Categories.SESSION);
-        boolean violationRouted = routes.contains(Categories.VIOLATION);
-        boolean playerIdentityRouted = routes.contains(Categories.PLAYER_IDENTITY);
-        boolean settingRouted = routes.contains(Categories.SETTING);
-
-        if (sessionRouted && violationRouted) {
-            this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
-                    config.history().entriesPerPage(), config.history().groupIntervalMs())
-                    .withV2Startups(Categories.SERVER_STARTUP)
-                    .withVerboseRegistry(verboseRegistry);
-        } else {
-            logger.warning("[grim-datastore] history disabled; missing "
-                    + missingRoutes(sessionRouted, "session", violationRouted, "violation"));
-        }
-        this.playerIdentityService = new PlayerIdentityService(dataStore);
-        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain(), playerIdentityRouted);
-        this.violationSink = violationRouted ? new ViolationSinkImpl(dataStore) : null;
-        this.retentionSweeper = new RetentionSweeper(dataStore, config.retention(), logger);
-        if (sessionRouted) {
-            this.sessionTracker = new SessionTrackerImpl(
-                    dataStore, config.serverName(), config.session().heartbeatIntervalMs(), startupId);
-        } else {
-            this.sessionTracker = SessionTracker.NOOP;
-            logger.warning("[grim-datastore] session tracking disabled; missing session route");
-        }
-        if (sessionRouted && violationRouted) {
-            this.liveWriteHooks = new LiveWriteHooksImpl(
-                    dataStore, playerIdentityService, checkRegistry, sessionTracker);
-        } else if (playerIdentityRouted) {
-            this.liveWriteHooks = new IdentityLiveWriteHooks(playerIdentityService);
-        } else {
-            this.liveWriteHooks = LiveWriteHooks.NOOP;
-        }
-        if (settingRouted) {
-            this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
-        } else {
-            this.playerToggleStore = PlayerToggleStore.NOOP;
-            logger.warning("[grim-datastore] player toggle persistence disabled; missing setting route");
-        }
-        return true;
-    }
-
-    private static @NotNull String missingRoutes(
-            boolean firstPresent, @NotNull String first,
-            boolean secondPresent, @NotNull String second) {
-        if (!firstPresent && !secondPresent) return first + " and " + second + " routes";
-        if (!firstPresent) return first + " route";
-        return second + " route";
-    }
-
-    private @Nullable V2InstanceRegistry.StartupClaim startInstanceRegistry() {
-        long heartbeatMs = instanceHeartbeatIntervalMs();
-        this.instanceId = loadPersistentInstanceId(plugin.getDataFolder().toPath());
-        this.startupId = UUID.randomUUID();
-        this.startupStartedEpochMs = System.currentTimeMillis();
-
-        this.instanceRegistry = V2InstanceRegistry.create(dataStore, dataStore.v2Routes(), logger);
-        if (instanceRegistry == null) {
-            logger.warning("[grim-datastore] v2 server startup registry route missing; "
-                    + "startup ownership and instance heartbeats are disabled");
-            return null;
-        }
-
-        // Checks intern templates lazily on first flag, so the manifest is
-        // re-encoded per heartbeat and republished immediately whenever a
-        // new template registers — rows stay decodable from their startup.
-        VerboseRegistry manifestRegistry = this.verboseRegistry;
-        java.util.function.Supplier<byte[]> verboseManifest = () -> manifestRegistry == null
-                ? VerboseManifest.textOnly(VerboseManifest.FLAVOR_V2_PUBLIC)
-                : VerboseManifest.encode(
-                        VerboseManifest.FLAVOR_V2_PUBLIC,
-                        manifestRegistry.checkIdVersions(checkRegistry));
-        V2InstanceRegistry.StartupClaim claim = instanceRegistry.claimStartup(
-                config.serverName(),
-                instanceId,
-                startupId,
-                startupStartedEpochMs,
-                hostname(),
-                GrimAPI.INSTANCE.getExternalAPI().getGrimVersion(),
-                serverVersionString(),
-                verboseManifest.get(),
-                heartbeatMs);
-        if (!claim.storageEnabled()) return claim;
-
-        this.heartbeatScheduler = new HeartbeatScheduler(
-                startupId,
-                instanceId,
-                config.serverName(),
-                startupStartedEpochMs,
-                hostname(),
-                GrimAPI.INSTANCE.getExternalAPI().getGrimVersion(),
-                serverVersionString(),
-                verboseManifest,
-                Duration.ofMillis(heartbeatMs),
-                instanceRegistry::publish,
-                logger);
-        heartbeatScheduler.start();
-        HeartbeatScheduler scheduler = this.heartbeatScheduler;
-        if (manifestRegistry != null) {
-            manifestRegistry.onChange(scheduler::publishNowAndWait);
-        }
-        return claim;
-    }
-
-    private @NotNull VerboseRegistry buildVerboseRegistry() {
-        // Templates intern themselves on a check's first flag; the registry
-        // only needs Grim's tag set available before anything parses/renders.
-        VerboseCodecs.ensureRegistered();
-        return new VerboseRegistryImpl(
-                dataStore,
-                checkRegistry,
-                VerboseManifest.FLAVOR_V2_PUBLIC);
-    }
-
-    private void installLocalVerboseRegistry() {
-        try {
-            CheckRegistry localChecks = new CheckRegistry(new InMemoryCheckCatalogPersistence());
-            localChecks.reload();
-            this.checkRegistry = localChecks;
-            this.verboseRegistry = buildVerboseRegistry();
-        } catch (RuntimeException e) {
-            logger.log(Level.WARNING,
-                    "[grim-datastore] failed to initialise local verbose registry", e);
-        }
-    }
-
-    private long instanceHeartbeatIntervalMs() {
-        long configured = config.session().heartbeatIntervalMs();
-        return configured > 0L ? configured : 30_000L;
-    }
-
-    private @NotNull UUID loadPersistentInstanceId(@NotNull Path dataFolder) {
-        Path file = dataFolder.resolve("data").resolve("storage-instance.uuid");
-        try {
-            Files.createDirectories(file.getParent());
-            if (Files.exists(file)) {
-                String raw = Files.readString(file, StandardCharsets.UTF_8).trim();
-                try {
-                    return UUID.fromString(raw);
-                } catch (IllegalArgumentException e) {
-                    Path backup = file.resolveSibling(file.getFileName() + ".invalid-" + System.currentTimeMillis());
-                    Files.move(file, backup, StandardCopyOption.REPLACE_EXISTING);
-                    logger.warning("[grim-datastore] invalid storage instance UUID in " + file
-                            + "; moved it to " + backup + " and generated a new persistent id");
-                }
-            }
-
-            UUID generated = UUID.randomUUID();
-            Files.writeString(
-                    file,
-                    generated + System.lineSeparator(),
-                    StandardCharsets.UTF_8,
-                    StandardOpenOption.CREATE_NEW);
-            return generated;
-        } catch (IOException e) {
-            throw new IllegalStateException("failed to load persistent storage instance id from " + file, e);
-        }
-    }
-
-    private @Nullable String serverVersionString() {
-        return GrimAPI.INSTANCE.getPlatformServer().getPlatformImplementationString();
-    }
-
-    private void disableStorageAfterDuplicate() {
-        logger.warning("[grim-datastore] storage disabled for this boot because another live Grim startup "
-                + "is using this storage instance id. Runtime checks remain active.");
-        if (heartbeatScheduler != null) {
-            heartbeatScheduler.stop();
-            heartbeatScheduler = null;
-        }
-        if (dataStore != null) {
-            dataStore.flushAndClose(config.writePath().shutdownDrainTimeoutMs());
-        }
-        closeV2Backends();
-        dataStore = null;
-        historyService = null;
-        playerIdentityService = null;
-        nameResolver = null;
-        violationSink = null;
-        retentionSweeper = null;
-        sessionTracker = SessionTracker.NOOP;
-        liveWriteHooks = LiveWriteHooks.NOOP;
-        playerToggleStore = PlayerToggleStore.NOOP;
-        instanceRegistry = null;
-        verboseRegistry = null;
-        loaded = false;
-        enabled = false;
-    }
-
-    private void startDuplicateWarning(@NotNull String message) {
-        stopDuplicateWarning();
-        logger.warning(message);
-        duplicateWarningExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "grim-storage-duplicate-warning");
-            t.setDaemon(true);
-            return t;
-        });
-        duplicateWarningExecutor.scheduleAtFixedRate(
-                () -> logger.warning(message),
-                60L,
-                60L,
-                TimeUnit.SECONDS);
-    }
-
-    private void stopDuplicateWarning() {
-        if (duplicateWarningExecutor != null) {
-            duplicateWarningExecutor.shutdownNow();
-            duplicateWarningExecutor = null;
-        }
-    }
-
-    private @Nullable String hostname() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            return null;
-        }
-    }
-
     private @NotNull CheckRegistry buildCheckRegistry(@NotNull Map<String, BackendV2> v2ById) {
         String backendId = config.routing().get(Categories.VIOLATION);
         BackendConfig backendConfig = backendId == null ? null : config.backends().get(backendId);
         BackendV2 backend = backendId == null ? null : v2ById.get(backendId);
         if (backend == null || !dataStore.v2Routes().contains(Categories.CHECK_CATALOG)) {
             logger.warning("[grim-datastore] no routed check catalog available for v2 backend '"
-                    + backendId + "' — check names will be process-local only");
+                    + backendId + "' - check names will be process-local only");
             CheckRegistry fallback = new CheckRegistry(new InMemoryCheckCatalogPersistence());
             fallback.reload();
             return fallback;
@@ -524,7 +322,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         } catch (RuntimeException e) {
             logger.log(Level.WARNING,
                     "[grim-datastore] failed to load persisted check catalog for backend '"
-                            + backendId + "' — falling back to process-local check names", e);
+                            + backendId + "' - falling back to process-local check names", e);
             CheckRegistry fallback = new CheckRegistry(new InMemoryCheckCatalogPersistence());
             fallback.reload();
             return fallback;
@@ -561,7 +359,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         }
 
         logger.warning("[grim-datastore] no persisted check catalog loader available for v2 backend '"
-                + backend.id() + "' — starting with an empty routed catalog view");
+                + backend.id() + "' - starting with an empty routed catalog view");
         return List.of();
     }
 
@@ -680,8 +478,6 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
                     StoreId.grim("grim_violations"), V2BuiltinKinds.violations()));
             out.put(Categories.CHECK_CATALOG, new V2BackendBootstrap.Binding<>(
                     StoreId.grim(CHECKS_STORE), V2BuiltinKinds.checks()));
-            out.put(Categories.VERBOSE_SCHEMA, new V2BackendBootstrap.Binding<>(
-                    StoreId.grim("verbose_schemas"), V2BuiltinKinds.verboseSchemas()));
         } else if (cat == Categories.SESSION) {
             out.put(cat, new V2BackendBootstrap.Binding<>(
                     StoreId.grim("grim_sessions"), V2BuiltinKinds.sessions()));
@@ -693,6 +489,449 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
                     StoreId.grim("grim_settings"), V2BuiltinKinds.settings()));
         }
         return out;
+    }
+
+    private boolean buildServices(@NotNull V2Routes routes) {
+        V2InstanceRegistry.StartupClaim claim = startInstanceRegistry();
+        if (claim != null && claim.duplicate()) {
+            startDuplicateWarning(claim.warningMessage());
+            return false;
+        }
+
+        boolean sessionRouted = routes.contains(Categories.SESSION);
+        boolean violationRouted = routes.contains(Categories.VIOLATION);
+        boolean playerIdentityRouted = routes.contains(Categories.PLAYER_IDENTITY);
+        boolean settingRouted = routes.contains(Categories.SETTING);
+
+        if (sessionRouted && violationRouted) {
+            this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
+                    config.history().entriesPerPage(), config.history().groupIntervalMs())
+                    .withV2Startups(Categories.SERVER_STARTUP)
+                    .withVerboseRegistry(verboseRegistry);
+        } else {
+            logger.warning("[grim-datastore] history disabled; missing "
+                    + missingRoutes(sessionRouted, "session", violationRouted, "violation"));
+        }
+        this.playerIdentityService = new PlayerIdentityService(dataStore);
+        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain(), playerIdentityRouted);
+        this.violationSink = violationRouted ? new ViolationSinkImpl(dataStore) : null;
+        this.retentionSweeper = new RetentionSweeper(dataStore, config.retention(), logger);
+        if (sessionRouted) {
+            this.sessionTracker = new SessionTrackerImpl(
+                    dataStore, config.serverName(), config.session().heartbeatIntervalMs(), startupId);
+        } else {
+            this.sessionTracker = SessionTracker.NOOP;
+            logger.warning("[grim-datastore] session tracking disabled; missing session route");
+        }
+        if (sessionRouted && violationRouted) {
+            this.liveWriteHooks = new LiveWriteHooksImpl(
+                    dataStore, playerIdentityService, checkRegistry, sessionTracker);
+        } else if (playerIdentityRouted) {
+            this.liveWriteHooks = new IdentityLiveWriteHooks(playerIdentityService);
+        } else {
+            this.liveWriteHooks = LiveWriteHooks.NOOP;
+        }
+        if (settingRouted) {
+            this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
+        } else {
+            this.playerToggleStore = PlayerToggleStore.NOOP;
+            logger.warning("[grim-datastore] player toggle persistence disabled; missing setting route");
+        }
+        return true;
+    }
+
+    private static @NotNull String missingRoutes(
+            boolean firstPresent, @NotNull String first,
+            boolean secondPresent, @NotNull String second) {
+        if (!firstPresent && !secondPresent) return first + " and " + second + " routes";
+        if (!firstPresent) return first + " route";
+        return second + " route";
+    }
+
+    private @Nullable V2InstanceRegistry.StartupClaim startInstanceRegistry() {
+        long heartbeatMs = ownershipGate.enforced()
+                ? config.ownership().renewIntervalMs()
+                : instanceHeartbeatIntervalMs();
+        long leaseTtlMs = config.ownership().leaseTtlMs();
+        this.instanceId = loadPersistentInstanceId(plugin.getDataFolder().toPath());
+        this.startupId = UUID.randomUUID();
+        this.ownershipFence = UUID.randomUUID();
+        this.startupStartedEpochMs = System.currentTimeMillis();
+
+        this.instanceRegistry = V2InstanceRegistry.create(dataStore, dataStore.v2Routes(), logger);
+        if (instanceRegistry == null) {
+            String message = "[grim-datastore] v2 server startup registry route missing; "
+                    + "startup history and crash recovery are disabled";
+            logger.warning(message);
+            if (ownershipGate.enforced()) {
+                return ownershipDenied(message, null, -1L);
+            }
+            return null;
+        }
+
+        VerboseRegistry manifestRegistry = this.verboseRegistry;
+        java.util.function.Supplier<byte[]> verboseManifest = () -> manifestRegistry == null
+                ? VerboseManifest.textOnly(VerboseManifest.FLAVOR_V2_PUBLIC)
+                : VerboseManifest.encode(
+                        VerboseManifest.FLAVOR_V2_PUBLIC,
+                        manifestRegistry.checkIdVersions(checkRegistry));
+        ServerOwnershipMetadata metadata = new ServerOwnershipMetadata(
+                config.serverName(),
+                hostname(),
+                GrimAPI.INSTANCE.getExternalAPI().getGrimVersion(),
+                GrimAPI.INSTANCE.getPlatformServer().getPlatformImplementationString());
+
+        boolean enforceOwnership = ownershipGate.enforced();
+        OwnershipClaimResult ownershipClaim = null;
+        if (enforceOwnership) {
+            if (ownershipAdapter == null) {
+                String message = "[grim-datastore] STORAGE DISABLED: backend for sessions does not expose "
+                        + "a server ownership adapter, but persistent UUID ownership is enforced.";
+                return ownershipDenied(message, null, -1L);
+            }
+            ownershipClaim = claimOwnershipWithOptionalWait(metadata);
+            if (!ownershipClaim.claimed()) {
+                ServerOwnershipSnapshot owner = ownershipClaim.currentOwner();
+                long remaining = owner == null ? -1L
+                        : Math.max(0L, owner.leaseExpiresAtEpochMs() - ownershipClaim.dbNowEpochMs());
+                String message = "[grim-datastore] STORAGE DISABLED: live duplicate persistent storage UUID "
+                        + instanceId + " detected. Existing startupId="
+                        + (owner == null ? "unknown" : owner.ownerStartupId())
+                        + " serverName='" + (owner == null ? "unknown" : owner.serverName()) + "'"
+                        + " leaseRemainingMs=" + remaining
+                        + "; this startupId=" + startupId
+                        + ". A server data folder or storage-instance.uuid appears to be copied.";
+                return ownershipDenied(message, owner == null ? null : owner.ownerStartupId(), remaining);
+            }
+            ownershipGate.open(startupId, ownershipFence, leaseTtlMs, config.ownership().safetyMarginMs());
+        }
+
+        long dbNow = ownershipClaim != null
+                ? ownershipClaim.dbNowEpochMs()
+                : dbNowBestEffort();
+        V2InstanceRegistry.StartupClaim claim = instanceRegistry.openStartup(
+                config.serverName(),
+                instanceId,
+                startupId,
+                ownershipFence,
+                startupStartedEpochMs,
+                dbNow,
+                metadata.hostname(),
+                metadata.grimVersion(),
+                metadata.serverVersionString(),
+                verboseManifest.get());
+
+        long recovered = recoverAfterStartupClaim(ownershipClaim, dbNow);
+        if (recovered > 0) {
+            logger.warning("[grim-datastore] recovered " + recovered
+                    + " open session(s) after claiming storage startup");
+        }
+
+        if (enforceOwnership) {
+            this.ownershipHeartbeatScheduler = new OwnershipHeartbeatScheduler(
+                    ownershipAdapter,
+                    OWNERSHIP_STORE,
+                    startupId,
+                    instanceId,
+                    ownershipFence,
+                    config.serverName(),
+                    startupStartedEpochMs,
+                    metadata.hostname(),
+                    metadata.grimVersion(),
+                    metadata.serverVersionString(),
+                    verboseManifest,
+                    leaseTtlMs,
+                    config.ownership().safetyMarginMs(),
+                    Duration.ofMillis(heartbeatMs),
+                    ownershipGate,
+                    instanceRegistry::publish,
+                    this::disablePersistenceAfterLostOwnership,
+                    logger);
+            ownershipHeartbeatScheduler.start();
+        } else {
+            this.heartbeatScheduler = new HeartbeatScheduler(
+                    startupId,
+                    instanceId,
+                    config.serverName(),
+                    startupStartedEpochMs,
+                    metadata.hostname(),
+                    metadata.grimVersion(),
+                    metadata.serverVersionString(),
+                    verboseManifest,
+                    Duration.ofMillis(heartbeatMs),
+                    instanceRegistry::publish,
+                    logger);
+            heartbeatScheduler.start();
+        }
+        if (manifestRegistry != null) {
+            if (ownershipHeartbeatScheduler != null) {
+                manifestRegistry.onChange(ownershipHeartbeatScheduler::publishNowAndWait);
+            } else if (heartbeatScheduler != null) {
+                manifestRegistry.onChange(heartbeatScheduler::publishNowAndWait);
+            }
+        }
+        startRecoverySweep();
+        return claim;
+    }
+
+    private @NotNull OwnershipClaimResult claimOwnershipWithOptionalWait(
+            @NotNull ServerOwnershipMetadata metadata) {
+        long ttlMs = config.ownership().leaseTtlMs();
+        OwnershipClaimResult first = claimOwnership(metadata, ttlMs);
+        if (first.claimed()) return first;
+        ServerOwnershipSnapshot owner = first.currentOwner();
+        long remaining = owner == null ? 0L
+                : Math.max(0L, owner.leaseExpiresAtEpochMs() - first.dbNowEpochMs());
+        long waitMs = Math.min(config.ownership().startupWaitMs(), remaining + 50L);
+        if (waitMs <= 0L || owner == null) return first;
+        logger.warning("[grim-datastore] persistent storage UUID " + instanceId
+                + " is owned by startupId=" + owner.ownerStartupId()
+                + "; waiting " + waitMs + "ms for the ownership lease to expire before retrying");
+        try {
+            Thread.sleep(waitMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return first;
+        }
+        return claimOwnership(metadata, ttlMs);
+    }
+
+    private @NotNull OwnershipClaimResult claimOwnership(
+            @NotNull ServerOwnershipMetadata metadata,
+            long ttlMs) {
+        try {
+            return ownershipAdapter.claimOwnership(
+                    OWNERSHIP_STORE, instanceId, startupId, ownershipFence, ttlMs, metadata);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to claim server ownership", e);
+        }
+    }
+
+    private @Nullable V2InstanceRegistry.StartupClaim ownershipDenied(
+            @NotNull String message,
+            @Nullable UUID conflictingStartupId,
+            long leaseRemainingMs) {
+        if (config.ownership().duplicatePersistentUuidAction() == DuplicatePersistentUuidAction.FAIL_STARTUP) {
+            throw new FatalStorageStartupException(message);
+        }
+        logger.warning(message);
+        ownershipGate.close("duplicate-persistent-uuid");
+        return V2InstanceRegistry.StartupClaim.duplicate(
+                startupId, instanceId,
+                conflictingStartupId == null ? startupId : conflictingStartupId,
+                leaseRemainingMs,
+                message);
+    }
+
+    private void shutdownServerAfterFatalStorageStartup() {
+        Runnable stop = () -> GrimAPI.INSTANCE.getPlatformServer().dispatchCommand(
+                GrimAPI.INSTANCE.getPlatformServer().getConsoleSender(),
+                "stop");
+        try {
+            GrimAPI.INSTANCE.getScheduler().getGlobalRegionScheduler().run(plugin, stop);
+        } catch (RuntimeException e) {
+            logger.log(Level.SEVERE, "[grim-datastore] failed to schedule server shutdown after fatal storage startup", e);
+            try {
+                stop.run();
+            } catch (RuntimeException immediateFailure) {
+                logger.log(Level.SEVERE, "[grim-datastore] failed to dispatch stop command after fatal storage startup", immediateFailure);
+            }
+        }
+    }
+
+    private static final class FatalStorageStartupException extends RuntimeException {
+        FatalStorageStartupException(@NotNull String message) {
+            super(message);
+        }
+    }
+
+    private long recoverAfterStartupClaim(
+            @Nullable OwnershipClaimResult ownershipClaim,
+            long dbNow) {
+        long closed = 0L;
+        if (ownershipClaim != null && ownershipClaim.previousOwner() != null) {
+            ServerOwnershipSnapshot previous = ownershipClaim.previousOwner();
+            if (!startupId.equals(previous.ownerStartupId())
+                    && (previous.closedAtEpochMs() != ServerOwnershipSnapshot.OPEN
+                    || previous.leaseExpiresAtEpochMs() <= dbNow)) {
+                closed += instanceRegistry.recoverStartup(previous.ownerStartupId(), "expired-ownership");
+            }
+        }
+        if (config.ownership().cleanupOtherServers()) {
+            closed += instanceRegistry.recoverStaleStartups(
+                    startupId, dbNow, config.ownership().staleStartupTtlMs());
+        }
+        return closed;
+    }
+
+    private long dbNowBestEffort() {
+        if (ownershipAdapter != null) {
+            try {
+                return ownershipAdapter.dbNowEpochMs();
+            } catch (Exception e) {
+                logger.log(Level.FINE, "[grim-datastore] failed to read DB time; using local time", e);
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    private void startRecoverySweep() {
+        if (!config.ownership().cleanupOtherServers() || instanceRegistry == null || startupId == null) return;
+        stopRecoverySweep();
+        recoverySweepExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "grim-storage-recovery-sweep");
+            t.setDaemon(true);
+            return t;
+        });
+        long intervalMs = config.ownership().recoverySweepIntervalMs();
+        recoverySweepExecutor.scheduleAtFixedRate(
+                this::runRecoverySweep,
+                intervalMs,
+                intervalMs,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private void runRecoverySweep() {
+        V2InstanceRegistry registry = instanceRegistry;
+        UUID currentStartup = startupId;
+        if (registry == null || currentStartup == null) return;
+        if (ownershipGate.enforced() && !ownershipGate.allowWrites()) return;
+        try {
+            long closed = registry.recoverStaleStartups(
+                    currentStartup,
+                    dbNowBestEffort(),
+                    config.ownership().staleStartupTtlMs());
+            if (closed > 0) {
+                logger.warning("[grim-datastore] recovery sweep closed " + closed
+                        + " open session(s) from stale startup rows");
+            }
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING, "[grim-datastore] recovery sweep failed", e);
+        }
+    }
+
+    private void stopRecoverySweep() {
+        if (recoverySweepExecutor != null) {
+            recoverySweepExecutor.shutdownNow();
+            recoverySweepExecutor = null;
+        }
+    }
+
+    private long instanceHeartbeatIntervalMs() {
+        long configured = config.session().heartbeatIntervalMs();
+        return configured > 0L ? configured : 30_000L;
+    }
+
+    private @NotNull VerboseRegistry buildVerboseRegistry() {
+        VerboseCodecs.ensureRegistered();
+        return new VerboseRegistryImpl(
+                dataStore,
+                checkRegistry,
+                VerboseManifest.FLAVOR_V2_PUBLIC);
+    }
+
+    private void installLocalVerboseRegistry() {
+        try {
+            CheckRegistry localChecks = new CheckRegistry(new InMemoryCheckCatalogPersistence());
+            localChecks.reload();
+            this.checkRegistry = localChecks;
+            this.verboseRegistry = buildVerboseRegistry();
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING,
+                    "[grim-datastore] failed to initialise local verbose registry", e);
+        }
+    }
+
+    private @NotNull UUID loadPersistentInstanceId(@NotNull Path dataFolder) {
+        Path file = dataFolder.resolve("data").resolve("storage-instance.uuid");
+        try {
+            Files.createDirectories(file.getParent());
+            if (Files.exists(file)) {
+                String raw = Files.readString(file, StandardCharsets.UTF_8).trim();
+                try {
+                    return UUID.fromString(raw);
+                } catch (IllegalArgumentException e) {
+                    Path backup = file.resolveSibling(file.getFileName() + ".invalid-" + System.currentTimeMillis());
+                    Files.move(file, backup, StandardCopyOption.REPLACE_EXISTING);
+                    logger.warning("[grim-datastore] invalid storage instance UUID in " + file
+                            + "; moved it to " + backup + " and generated a new persistent id");
+                }
+            }
+
+            UUID generated = UUID.randomUUID();
+            Files.writeString(
+                    file,
+                    generated + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW);
+            return generated;
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to load persistent storage instance id from " + file, e);
+        }
+    }
+
+    private void disableStorageAfterDuplicate() {
+        logger.warning("[grim-datastore] storage disabled for this boot because another live Grim startup "
+                + "is using this storage instance id. Runtime checks remain active.");
+        if (heartbeatScheduler != null) {
+            heartbeatScheduler.stop();
+            heartbeatScheduler = null;
+        }
+        if (ownershipHeartbeatScheduler != null) {
+            ownershipHeartbeatScheduler.stop();
+            ownershipHeartbeatScheduler = null;
+        }
+        ownershipGate.close("duplicate-persistent-uuid");
+        if (dataStore != null) {
+            dataStore.flushAndClose(config.writePath().shutdownDrainTimeoutMs());
+        }
+        closeV2Backends();
+        dataStore = null;
+        historyService = null;
+        playerIdentityService = null;
+        nameResolver = null;
+        violationSink = null;
+        retentionSweeper = null;
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
+        instanceRegistry = null;
+        verboseRegistry = null;
+        ownershipAdapter = null;
+        ownershipFence = null;
+        ownershipGate = ServerOwnershipGate.disabled();
+        loaded = false;
+        enabled = false;
+    }
+
+    private void startDuplicateWarning(@NotNull String message) {
+        stopDuplicateWarning();
+        logger.warning(message);
+        duplicateWarningExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "grim-storage-duplicate-warning");
+            t.setDaemon(true);
+            return t;
+        });
+        duplicateWarningExecutor.scheduleAtFixedRate(
+                () -> logger.warning(message),
+                60L,
+                60L,
+                TimeUnit.SECONDS);
+    }
+
+    private void stopDuplicateWarning() {
+        if (duplicateWarningExecutor != null) {
+            duplicateWarningExecutor.shutdownNow();
+            duplicateWarningExecutor = null;
+        }
+    }
+
+    private @Nullable String hostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return null;
+        }
     }
 
     private @Nullable MigrationContext buildMigrationContext(@NotNull BackendV2 backend) {
@@ -727,7 +966,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
                         && b.getData().length == 16) continue;
                 String idClass = id == null ? "null" : id.getClass().getSimpleName();
                 logger.warning(() -> "[grim-datastore] " + coll + " first-doc _id is "
-                        + idClass + ", expected UUID-shaped binary —"
+                        + idClass + ", expected UUID-shaped binary -"
                         + " entity migration will not handle this row correctly."
                         + " Halt and inspect before proceeding if this is unexpected.");
             } catch (RuntimeException e) {
@@ -762,7 +1001,7 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
                     if (playerIdentityRouted) {
                         links.add(new LocalCacheLink(store));
                     } else {
-                        logger.warning("[grim-datastore] name resolver local-cache disabled; "
+                        logger.warning("[grim-datastore] local-cache name resolver disabled; "
                                 + "missing player-identity route");
                     }
                 }
@@ -774,9 +1013,6 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     }
 
     private void maybeMigrateLegacy(Path dataFolder, SqliteBackend sqliteBackend) {
-        // The V0 reader/import path is SQLite-only. Only run it when the
-        // violation route itself is SQLite; mixed routing should not import
-        // legacy violations into an unrelated local side database.
         if (sqliteBackend == null) return;
         if (config.migration().skip()) {
             logger.info("[grim-datastore] migration.skip=true; leaving legacy v0 un-migrated");
@@ -785,7 +1021,6 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         V0Sources.V0Source source = V0Sources.detect(
                 dataFolder,
                 GrimAPI.INSTANCE.getConfigManager().getConfig());
-        // No legacy store on disk — fresh install or migration already done.
         if (source == null) {
             logger.info("[grim-datastore] no legacy v0 store detected; nothing to migrate");
             return;
@@ -810,60 +1045,28 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         }
     }
 
-    // Source detection moved to V0Sources so the /grim history migrate command
-    // can reuse the same routing logic. See that class for per-type builders.
-
     @Override
     public void stop() {
-        teardown();
+        close();
     }
 
-    /**
-     * Hot-reload from a freshly-refreshed ConfigManager. Drains in-flight
-     * writes within the configured {@code shutdown-drain-timeout-ms},
-     * drops anything still pending, then rebuilds backends + routing
-     * from the new {@code database.yml} / {@code databases/&lt;id&gt;.yml}.
-     *
-     * <p>Operators can swap the backend (e.g. SQLite → MySQL after a
-     * {@code /grim history migrate}) without bouncing the server. Brief
-     * unavailability between the drain and the new backend's init —
-     * writes during that window get dropped on the floor; the user
-     * accepts that tradeoff.
-     *
-     * <p>Stale references held by callers (e.g. a check that cached
-     * {@link LiveWriteHooks} in a local variable mid-event) keep working
-     * against the old, closed dataStore — those writes drop too. New
-     * lookups via {@link #liveWriteHooks()} resolve to the new instance.
-     */
     public synchronized void reload() {
         logger.info("[grim-datastore] /grim reload: tearing down datastore...");
-        teardown();
+        close();
         start();
     }
 
-    /**
-     * Idempotent teardown — drains writers, closes backends, nulls every
-     * service field. Used by both {@link #stop()} and {@link #reload()}.
-     * Doesn't touch {@code enabled}; {@link #start()} re-evaluates that
-     * from the freshly-loaded ConfigManager.
-     */
-    private void teardown() {
+    private synchronized void close() {
         stopDuplicateWarning();
-        // violationSink drains in-flight writes; dataStore drains per-category
-        // rings and closes each backend. Both null-guarded because a failure
-        // during buildAndStart can tear down mid-initialisation — start()'s
-        // catch calls teardown() before any of these fields were assigned.
-        if (heartbeatScheduler != null) {
-            heartbeatScheduler.stop();
-            heartbeatScheduler = null;
-        }
-        shutdownInstanceRegistry();
+        stopRecoverySweep();
+        if (!enabled) return;
+        stopHeartbeatSchedulersForShutdown();
         playerToggleStore.shutdown();
         if (violationSink != null) violationSink.shutDown();
-        if (dataStore != null) {
-            long drainMs = config != null ? config.writePath().shutdownDrainTimeoutMs() : 5000L;
-            dataStore.flushAndClose(drainMs);
-        }
+        shutdownInstanceRegistry();
+        if (dataStore != null && config != null) dataStore.flushAndClose(config.writePath().shutdownDrainTimeoutMs());
+        closeOwnership("graceful");
+        ownershipGate.close("shutdown");
         closeV2Backends();
         dataStore = null;
         historyService = null;
@@ -875,7 +1078,9 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         liveWriteHooks = LiveWriteHooks.NOOP;
         playerToggleStore = PlayerToggleStore.NOOP;
         instanceRegistry = null;
-        verboseRegistry = null;
+        ownershipAdapter = null;
+        ownershipFence = null;
+        ownershipGate = ServerOwnershipGate.disabled();
         instanceId = null;
         startupId = null;
         startupStartedEpochMs = 0L;
@@ -884,9 +1089,26 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         loaded = false;
     }
 
+    private void stopHeartbeatSchedulersForShutdown() {
+        if (ownershipHeartbeatScheduler != null) {
+            ownershipHeartbeatScheduler.publishNowAndWait();
+            ownershipHeartbeatScheduler.stop();
+            ownershipHeartbeatScheduler = null;
+        }
+        if (heartbeatScheduler != null) {
+            heartbeatScheduler.publishNowAndWait();
+            heartbeatScheduler.stop();
+            heartbeatScheduler = null;
+        }
+    }
+
     private void shutdownInstanceRegistry() {
         if (instanceRegistry == null || startupId == null || config == null) return;
-        long now = System.currentTimeMillis();
+        if (ownershipGate.enforced() && !ownershipGate.allowWrites()) {
+            logger.warning("[grim-datastore] skipping startup/session shutdown writes because DB ownership is no longer held");
+            return;
+        }
+        long now = dbNowBestEffort();
         try {
             long closed = instanceRegistry.closeCurrentStartup(startupId, now);
             if (closed > 0) {
@@ -896,6 +1118,26 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         } catch (RuntimeException e) {
             logger.log(Level.WARNING,
                     "[grim-datastore] failed to close sessions for this server startup", e);
+        }
+    }
+
+    private void closeOwnership(@NotNull String reason) {
+        if (ownershipAdapter == null || instanceId == null || startupId == null || ownershipFence == null) return;
+        try {
+            ownershipAdapter.closeOwnership(OWNERSHIP_STORE, instanceId, startupId, ownershipFence, reason);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "[grim-datastore] failed to close server ownership row", e);
+        }
+    }
+
+    private synchronized void disablePersistenceAfterLostOwnership() {
+        stopRecoverySweep();
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
+        if (violationSink != null) {
+            violationSink.shutDown();
+            violationSink = null;
         }
     }
 
@@ -909,67 +1151,23 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     public @Nullable DataStoreConfig config() { return config; }
     public @Nullable VerboseRegistry verboseRegistry() { return verboseRegistry; }
 
-    /**
-     * The live-writes facade used by {@code PunishmentManager} and
-     * {@code PacketPlayerJoinQuit}. Returns {@link LiveWriteHooks#NOOP} when
-     * the datastore is disabled or its init failed — callers don't null-check.
-     */
     public @NotNull LiveWriteHooks liveWriteHooks() { return liveWriteHooks; }
-
-    /**
-     * The live session tracker. Returns {@link SessionTracker#NOOP} when the
-     * datastore is disabled or its init failed.
-     */
     public @NotNull SessionTracker sessionTracker() { return sessionTracker; }
-
-    /**
-     * Persistence layer for the per-player /grim alerts | verbose | brands
-     * toggles. Returns {@link PlayerToggleStore#NOOP} when the datastore is
-     * disabled or its init failed.
-     */
     public @NotNull PlayerToggleStore playerToggleStore() { return playerToggleStore; }
 
-    /**
-     * Admin-command escape hatch used by {@code /grim history migrate} to target
-     * SQLite directly. Scans the active router for a {@link SqliteBackend}
-     * instance; returns null when routing doesn't include one (e.g. pure-memory
-     * test setups, or a site that routes everything to a non-SQL backend). The
-     * migration command degrades gracefully in that case.
-     */
     @ApiStatus.Internal
     public @Nullable SqliteBackend sqliteBackendForCommands() {
-        if (dataStore == null) return null;
-        for (Backend b : dataStore.router().allBackends()) {
-            if (b instanceof SqliteBackend s) return s;
-        }
         return null;
     }
 
-    /**
-     * Admin-command escape hatch. Returns the shared {@code CheckRegistry}
-     * instance so {@code /grim history migrate} can intern stable keys through
-     * the same registry the migrator uses at startup.
-     */
     @ApiStatus.Internal
     public @Nullable CheckRegistry checkRegistryForCommands() {
         return checkRegistry;
     }
 
-    /**
-     * Admin-command escape hatch. Returns all backends currently wired into the
-     * router, keyed by backend id. {@code /grim history copy} uses this to
-     * resolve {@code <src>} / {@code <dst>} arguments against the same backend
-     * instances the write path uses.
-     */
     @ApiStatus.Internal
     public @NotNull Map<String, Backend> allBackendsForCommands() {
-        if (dataStore == null) return Map.of();
-        Map<String, Backend> out = new LinkedHashMap<>();
-        for (Backend b : dataStore.router().allBackends()) {
-            if (b == V2InstanceRegistry.ROUTER_SENTINEL_BACKEND) continue;
-            out.put(b.id(), b);
-        }
-        return out;
+        return Map.of();
     }
 
     private record SimpleContext(BackendConfig config, Logger logger, Path dataDirectory) implements BackendContext {}

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/OwnershipHeartbeatScheduler.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/OwnershipHeartbeatScheduler.java
@@ -1,0 +1,178 @@
+package ac.grim.grimac.manager.datastore;
+
+import ac.grim.grimac.api.storage.event.ServerStartupEvent;
+import ac.grim.grimac.api.storage.instance.OwnershipRenewResult;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipAdapter;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipGate;
+import ac.grim.grimac.api.storage.registry.StoreId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class OwnershipHeartbeatScheduler {
+
+    private final @NotNull ServerOwnershipAdapter ownership;
+    private final @NotNull StoreId ownershipStore;
+    private final @NotNull UUID startupId;
+    private final @NotNull UUID instanceId;
+    private final @NotNull UUID fence;
+    private final @NotNull String serverName;
+    private final long startedEpochMs;
+    private final @Nullable String hostname;
+    private final @Nullable String grimVersion;
+    private final @Nullable String serverVersionString;
+    private final @NotNull Supplier<byte @Nullable []> verboseManifest;
+    private final long leaseTtlMs;
+    private final long safetyMarginMs;
+    private final @NotNull Duration interval;
+    private final @NotNull ServerOwnershipGate gate;
+    private final @NotNull Consumer<ServerStartupEvent> publish;
+    private final @NotNull Runnable lostOwnership;
+    private final @NotNull Logger logger;
+    private final AtomicBoolean lost = new AtomicBoolean(false);
+
+    private final Object lifecycleLock = new Object();
+    private @Nullable ScheduledExecutorService executor;
+    private @Nullable ScheduledFuture<?> task;
+    private volatile @Nullable Thread schedulerThread;
+
+    OwnershipHeartbeatScheduler(
+            @NotNull ServerOwnershipAdapter ownership,
+            @NotNull StoreId ownershipStore,
+            @NotNull UUID startupId,
+            @NotNull UUID instanceId,
+            @NotNull UUID fence,
+            @NotNull String serverName,
+            long startedEpochMs,
+            @Nullable String hostname,
+            @Nullable String grimVersion,
+            @Nullable String serverVersionString,
+            @NotNull Supplier<byte @Nullable []> verboseManifest,
+            long leaseTtlMs,
+            long safetyMarginMs,
+            @NotNull Duration interval,
+            @NotNull ServerOwnershipGate gate,
+            @NotNull Consumer<ServerStartupEvent> publish,
+            @NotNull Runnable lostOwnership,
+            @NotNull Logger logger) {
+        this.ownership = ownership;
+        this.ownershipStore = ownershipStore;
+        this.startupId = startupId;
+        this.instanceId = instanceId;
+        this.fence = fence;
+        this.serverName = serverName;
+        this.startedEpochMs = startedEpochMs;
+        this.hostname = hostname;
+        this.grimVersion = grimVersion;
+        this.serverVersionString = serverVersionString;
+        this.verboseManifest = verboseManifest;
+        this.leaseTtlMs = leaseTtlMs;
+        this.safetyMarginMs = safetyMarginMs;
+        this.interval = interval;
+        this.gate = gate;
+        this.publish = publish;
+        this.lostOwnership = lostOwnership;
+        this.logger = logger;
+    }
+
+    void start() {
+        synchronized (lifecycleLock) {
+            if (executor != null) return;
+            executor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "grim-storage-ownership-" + serverName);
+                t.setDaemon(true);
+                schedulerThread = t;
+                return t;
+            });
+            long periodMs = Math.max(1L, interval.toMillis());
+            task = executor.scheduleAtFixedRate(this::tick, 0L, periodMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    void publishNowAndWait() {
+        ScheduledExecutorService current;
+        synchronized (lifecycleLock) {
+            current = executor;
+        }
+        if (current == null || lost.get()) return;
+        if (Thread.currentThread() == schedulerThread) {
+            tick();
+            return;
+        }
+        Future<?> future = current.submit(this::tick);
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e.getCause());
+        }
+    }
+
+    void stop() {
+        synchronized (lifecycleLock) {
+            if (task != null) {
+                task.cancel(false);
+                task = null;
+            }
+            if (executor != null) {
+                executor.shutdownNow();
+                executor = null;
+                schedulerThread = null;
+            }
+        }
+    }
+
+    private void tick() {
+        if (lost.get()) return;
+        try {
+            OwnershipRenewResult renewed = ownership.renewOwnership(
+                    ownershipStore, instanceId, startupId, fence, leaseTtlMs);
+            if (!renewed.renewed()) {
+                onLostOwnership();
+                return;
+            }
+            gate.extend(startupId, fence, leaseTtlMs, safetyMarginMs);
+            ServerStartupEvent event = new ServerStartupEvent()
+                    .startupId(startupId)
+                    .instanceId(instanceId)
+                    .serverName(serverName)
+                    .startedEpochMs(startedEpochMs)
+                    .lastHeartbeatEpochMs(renewed.dbNowEpochMs())
+                    .hostname(hostname)
+                    .grimVersion(grimVersion)
+                    .serverVersionString(serverVersionString)
+                    .verboseManifest(verboseManifest.get());
+            publish.accept(event);
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e);
+        }
+    }
+
+    private void onLostOwnership() {
+        if (!lost.compareAndSet(false, true)) return;
+        gate.close("lost-ownership");
+        logger.warning("[grim-datastore] lost DB ownership for instanceId=" + instanceId
+                + " startupId=" + startupId + "; disabling persistence for this boot");
+        try {
+            lostOwnership.run();
+        } finally {
+            stop();
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/SessionTrackerImpl.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/SessionTrackerImpl.java
@@ -48,7 +48,7 @@ public final class SessionTrackerImpl implements SessionTracker {
                 if (candidateSessionId == null) candidateSessionId = UUID.randomUUID();
                 State fresh = new State(candidateSessionId, now, now, now, meta);
                 if (states.putIfAbsent(playerUuid, fresh) == null) {
-                    emit(fresh, playerUuid, now, SessionRecord.OPEN);
+                    emit(fresh, playerUuid, now, null); // closed_at stays OPEN while alive
                     return fresh.sessionId;
                 }
                 // Lost the insert race — someone inserted between get and putIfAbsent. Retry as update.
@@ -57,7 +57,7 @@ public final class SessionTrackerImpl implements SessionTracker {
             State next = new State(current.sessionId, current.startedEpochMs, now, now,
                     mergeMeta(current.cachedMeta, meta));
             if (states.replace(playerUuid, current, next)) {
-                emit(next, playerUuid, now, SessionRecord.OPEN);
+                emit(next, playerUuid, now, null);
                 return next.sessionId;
             }
             // CAS lost — state changed (close removed it, or another observe replaced it). Retry.
@@ -74,7 +74,7 @@ public final class SessionTrackerImpl implements SessionTracker {
         // CAS the new state in. If another thread (rare — pollData runs on a
         // single tick scheduler per player) beat us, just skip — they'll emit.
         if (states.replace(playerUuid, current, next)) {
-            emit(next, playerUuid, now, SessionRecord.OPEN);
+            emit(next, playerUuid, now, null);
         }
     }
 
@@ -84,8 +84,7 @@ public final class SessionTrackerImpl implements SessionTracker {
         if (prev == null) return;
         // Emit last_activity from the prev state (the last actual observation),
         // closed_at = now (the disconnect timestamp). They diverge by design so
-        // SessionSummary.endedUnexpectedly (closed_at == last_activity) reads
-        // false on graceful close and true on crash sweep.
+        // crash recovery can stamp closed_at = last_activity for orphaned rows.
         State closed = new State(prev.sessionId, prev.startedEpochMs, prev.lastActivityEpochMs, now,
                 mergeMeta(prev.cachedMeta, meta));
         emit(closed, playerUuid, prev.lastActivityEpochMs, now);
@@ -97,7 +96,7 @@ public final class SessionTrackerImpl implements SessionTracker {
         return s == null ? null : s.sessionId;
     }
 
-    private void emit(State s, UUID playerUuid, long now, long closedAt) {
+    private void emit(State s, UUID playerUuid, long now, @Nullable Long closedAt) {
         final UUID sessionId = s.sessionId;
         final long started = s.startedEpochMs;
         final ClientMeta meta = s.cachedMeta;
@@ -106,7 +105,7 @@ public final class SessionTrackerImpl implements SessionTracker {
                 .playerUuid(playerUuid)
                 .startedEpochMs(started)
                 .lastActivityEpochMs(now)
-                .closedAtEpochMs(closedAt)
+                .closedAtEpochMs(closedAt == null ? SessionRecord.OPEN : closedAt)
                 .clientBrand(meta.clientBrand())
                 .clientVersion(meta.clientVersion())
                 .startupId(startupId));

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/V2InstanceRegistry.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/V2InstanceRegistry.java
@@ -7,8 +7,8 @@ import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.backend.KindAdapter;
 import ac.grim.grimac.api.storage.backend.StorageEventHandler;
-import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Capability;
+import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.check.CheckCatalogPersistence;
 import ac.grim.grimac.api.storage.check.CheckCatalogRepairResult;
@@ -26,12 +26,10 @@ import ac.grim.grimac.internal.storage.core.V2Routes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -45,7 +43,6 @@ final class V2InstanceRegistry {
     static final Backend ROUTER_SENTINEL_BACKEND = new RouterSentinelBackend();
 
     private static final int PAGE_SIZE = 512;
-    private static final long MIN_STALE_THRESHOLD_MS = 120_000L;
 
     private final DataStore store;
     private final StorageEventHandler<ServerStartupEvent> directStartupWriter;
@@ -77,20 +74,17 @@ final class V2InstanceRegistry {
         writeStartup(source);
     }
 
-    StartupClaim claimStartup(
+    StartupClaim openStartup(
             @NotNull String serverName,
             @NotNull UUID instanceId,
             @NotNull UUID startupId,
+            @NotNull UUID fence,
             long startedEpochMs,
+            long dbNowEpochMs,
             @Nullable String hostname,
             @Nullable String grimVersion,
             @Nullable String serverVersionString,
-            @Nullable byte[] verboseManifest,
-            long heartbeatIntervalMs) {
-        long staleThresholdMs = staleThresholdMs(heartbeatIntervalMs);
-        long observeMs = observeMs(heartbeatIntervalMs);
-        long now = System.currentTimeMillis();
-
+            @Nullable byte[] verboseManifest) {
         ServerStartupRecord current = new ServerStartupRecord(
                 startupId,
                 instanceId,
@@ -99,27 +93,17 @@ final class V2InstanceRegistry {
                 serverVersionString,
                 hostname,
                 startedEpochMs,
-                now,
+                dbNowEpochMs,
                 ServerStartupRecord.OPEN,
                 null,
                 verboseManifest);
         writeStartup(current);
-
-        RecoveryResult sameInstance = recoverPreviousStartupsForInstance(
-                current, now, staleThresholdMs, observeMs);
-        if (sameInstance.duplicate() != null) {
-            markStartupClosed(current, System.currentTimeMillis(), "duplicate");
-            return sameInstance.duplicate();
-        }
-
-        long staleClosed = recoverStaleStartups(current.startupId(), now, staleThresholdMs);
-        long closed = sameInstance.sessionsClosed() + staleClosed;
         String message = "[grim-datastore] storage startup claimed: serverName='" + serverName
                 + "' instanceId=" + instanceId
                 + " startupId=" + startupId
-                + "; recovered " + closed + " previous open session(s).";
-        logger.warning(message);
-        return StartupClaim.enabled(startupId, instanceId, closed, message);
+                + " fence=" + fence + ".";
+        logger.info(message);
+        return StartupClaim.enabled(startupId, instanceId, 0L, message);
     }
 
     long closeCurrentStartup(@NotNull UUID startupId, long closedAtEpochMs) {
@@ -129,47 +113,7 @@ final class V2InstanceRegistry {
         return closed;
     }
 
-    private @NotNull RecoveryResult recoverPreviousStartupsForInstance(
-            @NotNull ServerStartupRecord current,
-            long now,
-            long staleThresholdMs,
-            long observeMs) {
-        long closed = 0L;
-        for (ServerStartupRecord row : openStartupsForInstance(current.instanceId())) {
-            if (current.startupId().equals(row.startupId())) continue;
-            ServerStartupRecord recoverable = row;
-            if (!isStale(row, now, staleThresholdMs)) {
-                logger.warning("[grim-datastore] persistent storage instanceId=" + current.instanceId()
-                        + " has a fresh heartbeat from startupId=" + row.startupId()
-                        + " ageMs=" + heartbeatAgeMs(now, row)
-                        + "; observing for " + observeMs
-                        + "ms before deciding whether this is a live copied-data-folder duplicate.");
-                sleepObserve(observeMs);
-                long afterNow = System.currentTimeMillis();
-                Optional<ServerStartupRecord> after = startupById(row.startupId());
-                if (after.isEmpty() || after.get().isClosed()) continue;
-                recoverable = after.get();
-                if (heartbeatAdvanced(row, recoverable) && !isStale(recoverable, afterNow, staleThresholdMs)) {
-                    long conflictAge = heartbeatAgeMs(afterNow, recoverable);
-                    String message = "[grim-datastore] STORAGE DISABLED: live duplicate storage instanceId="
-                            + current.instanceId()
-                            + " detected. Existing startupId=" + recoverable.startupId()
-                            + " serverName='" + recoverable.serverName() + "'"
-                            + " heartbeatAgeMs=" + conflictAge
-                            + "; this startupId=" + current.startupId()
-                            + ". The data folder appears to be shared or copied between live servers.";
-                    logger.warning(message);
-                    return new RecoveryResult(closed,
-                            StartupClaim.duplicate(current.startupId(), current.instanceId(),
-                                    recoverable.startupId(), conflictAge, message));
-                }
-            }
-            closed += recoverStartup(recoverable, "crashed");
-        }
-        return new RecoveryResult(closed, null);
-    }
-
-    private long recoverStaleStartups(
+    long recoverStaleStartups(
             @NotNull UUID currentStartupId,
             long now,
             long staleThresholdMs) {
@@ -195,6 +139,11 @@ final class V2InstanceRegistry {
             cursor = stop ? null : page.nextCursor();
         } while (cursor != null);
         return closed;
+    }
+
+    long recoverStartup(@NotNull UUID startupId, @NotNull String reason) {
+        Optional<ServerStartupRecord> startup = startupById(startupId);
+        return startup.map(row -> recoverStartup(row, reason)).orElse(0L);
     }
 
     private long recoverStartup(@NotNull ServerStartupRecord startup, @NotNull String reason) {
@@ -306,61 +255,12 @@ final class V2InstanceRegistry {
                 STARTUPS, startupId)), "query server startup " + startupId);
     }
 
-    private @NotNull List<ServerStartupRecord> openStartupsForInstance(@NotNull UUID instanceId) {
-        List<ServerStartupRecord> out = new ArrayList<>();
-        Cursor cursor = null;
-        boolean reachedClosedRows;
-        do {
-            reachedClosedRows = false;
-            Page<ServerStartupRecord> page = await(store.execute(new EntityOps.FindByIndexOp<>(
-                    STARTUPS,
-                    "by_instance_open",
-                    instanceId,
-                    cursor,
-                    PAGE_SIZE)), "query server startups for instance " + instanceId);
-            for (ServerStartupRecord row : page.items()) {
-                if (!instanceId.equals(row.instanceId())) continue;
-                if (row.isClosed()) {
-                    reachedClosedRows = true;
-                    continue;
-                }
-                out.add(row);
-            }
-            cursor = reachedClosedRows ? null : page.nextCursor();
-        } while (cursor != null);
-        return out;
-    }
-
-    private static boolean heartbeatAdvanced(
-            @NotNull ServerStartupRecord before,
-            @NotNull ServerStartupRecord after) {
-        return Objects.equals(before.startupId(), after.startupId())
-                && after.lastHeartbeatEpochMs() > before.lastHeartbeatEpochMs();
-    }
-
     private static boolean isStale(@NotNull ServerStartupRecord row, long now, long staleThresholdMs) {
         return heartbeatAgeMs(now, row) > staleThresholdMs;
     }
 
     private static long heartbeatAgeMs(long now, @NotNull ServerStartupRecord row) {
         return Math.max(0L, now - row.lastHeartbeatEpochMs());
-    }
-
-    private static long staleThresholdMs(long heartbeatIntervalMs) {
-        return Math.max(MIN_STALE_THRESHOLD_MS, Math.max(1L, heartbeatIntervalMs) * 4L);
-    }
-
-    private static long observeMs(long heartbeatIntervalMs) {
-        return Math.max(1L, Math.max(1L, heartbeatIntervalMs) * 2L);
-    }
-
-    private void sleepObserve(long observeMs) {
-        try {
-            Thread.sleep(observeMs);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.warning("[grim-datastore] interrupted while observing storage heartbeat; treating holder as frozen");
-        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -414,8 +314,6 @@ final class V2InstanceRegistry {
                     heartbeatAgeMs, 0L, message);
         }
     }
-
-    private record RecoveryResult(long sessionsClosed, @Nullable StartupClaim duplicate) {}
 
     @SuppressWarnings("deprecation")
     private static final class RouterSentinelBackend implements Backend {

--- a/common/src/main/resources/database/en.yml
+++ b/common/src/main/resources/database/en.yml
@@ -46,6 +46,24 @@ database:
     # 0 disables.
     heartbeat-interval-ms: 30000
 
+  ownership:
+    # Prevent two live servers with the same persistent storage UUID from
+    # writing to the same DB. Turn this off only if you intentionally accept
+    # duplicate writers.
+    enforce-persistent-uuid-ownership: true
+    # Options:
+    # - disable-storage: keep checks running but disable DB writes for this boot.
+    # - fail-startup: fail Grim storage startup on a live duplicate UUID.
+    # - allow-unsafe: expert-only; bypasses ownership enforcement.
+    duplicate-persistent-uuid-action: disable-storage
+    renew-interval-ms: 10000
+    lease-ttl-ms: 20000
+    startup-wait-ms: 20000
+    safety-margin-ms: 5000
+    stale-startup-ttl-ms: 30000
+    recovery-sweep-interval-ms: 10000
+    cleanup-other-servers: true
+
   write-path:
     # queue-capacity must be a positive power of two (ring-buffer requirement).
     # Typical values: 4096, 8192, 16384, 32768, 65536.

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,7 +12,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.5"
+grim-api = "1.6.0.7"
 packetevents = "2.13.1+8187e23-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
Backports persistent storage ownership leases to public 2.0.\n\nVerification:\n- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --configure-on-demand -PmavenLocalOverride=false :common:compileJava --no-daemon --stacktrace\n- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --configure-on-demand -PmavenLocalOverride=false :bukkit:compileJava --no-daemon --stacktrace\n- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --configure-on-demand -PmavenLocalOverride=false :common:dependencyInsight --dependency GrimAPI --configuration compileClasspath :bukkit:shadowJar --no-daemon --stacktrace\n\nNotes:\n- Uses public GrimAPI 1.6.0.7.\n- Confirmed Bukkit jar does not include Redis/Jedis, commons-pool2, MySQL, Postgres, Mongo/BSON, or SQLite driver packages.