### PR TITLE
config: expose SQL Hikari pool settings

### DIFF
--- a/common/src/main/java/ac/grim/grimac/manager/config/update/GrimConfigSpecs.java
+++ b/common/src/main/java/ac/grim/grimac/manager/config/update/GrimConfigSpecs.java
@@ -138,8 +138,40 @@ public final class GrimConfigSpecs {
      * key collisions across backends.
      */
     public static @NotNull ConfigUpdater.Spec backend(@NotNull String backendId) {
-        return ConfigUpdater.Spec.builder("/databases/" + backendId + "/", 1,
-                        ConfigUpdater.ConfigFlavor.V2)
-                .build();
+        ConfigUpdater.Spec.Builder builder = ConfigUpdater.Spec.builder(
+                "/databases/" + backendId + "/",
+                backendVersion(backendId),
+                ConfigUpdater.ConfigFlavor.V2);
+        if (backendSupportsHikariPoolSettings(backendId)) {
+            builder.migration(2, ctx -> preservePoolSettingOverrides(ctx, backendId));
+        }
+        return builder.build();
+    }
+
+    private static int backendVersion(@NotNull String backendId) {
+        return backendSupportsHikariPoolSettings(backendId) ? 2 : 1;
+    }
+
+    private static boolean backendSupportsHikariPoolSettings(@NotNull String backendId) {
+        return backendId.equals("mysql") || backendId.equals("postgres");
+    }
+
+    private static void preservePoolSettingOverrides(
+            @NotNull MigrationContext ctx,
+            @NotNull String backendId) {
+        // v1 did not ship these keys, but preserve values if an operator
+        // already added them by hand before the bundled defaults caught up.
+        String prefix = backendId + ".pool-settings.";
+        for (String key : new String[]{
+                "maximum-pool-size",
+                "minimum-idle",
+                "maximum-lifetime-ms",
+                "keepalive-time-ms",
+                "connection-timeout-ms"}) {
+            Object value = ctx.input().get(prefix + key);
+            if (value != null) {
+                ctx.output().put(prefix + key, value);
+            }
+        }
     }
 }

--- a/common/src/main/resources/databases/mysql/de.yml
+++ b/common/src/main/resources/databases/mysql/de.yml
@@ -20,6 +20,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Zusätzliche URL-Parameter, die nach dem festen Set angehängt werden
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Leer lassen, falls du nichts Spezifisches brauchst — die Defaults
@@ -46,4 +62,4 @@ mysql:
 
 # Schema-Marker — siehe Kopf-Kommentar in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/en.yml
+++ b/common/src/main/resources/databases/mysql/en.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Extra URL parameters appended after the canned set
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Leave empty unless you know you need something specific — the defaults
@@ -44,4 +60,4 @@ mysql:
 
 # Schema markers — see header comment in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/es.yml
+++ b/common/src/main/resources/databases/mysql/es.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parámetros de URL extra que se añaden tras el conjunto fijo
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Déjalo vacío salvo que sepas que necesitas algo específico — los
@@ -44,4 +60,4 @@ mysql:
 
 # Marcadores de esquema — ver el comentario de cabecera en config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/fr.yml
+++ b/common/src/main/resources/databases/mysql/fr.yml
@@ -20,6 +20,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Paramètres d'URL supplémentaires ajoutés après le jeu fixe
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Laissez vide sauf besoin spécifique — les défauts conviennent à une
@@ -46,4 +62,4 @@ mysql:
 
 # Marqueurs de schéma — voir le commentaire d'en-tête dans config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/it.yml
+++ b/common/src/main/resources/databases/mysql/it.yml
@@ -18,6 +18,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parametri URL extra appesi dopo il set fisso
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Lascia vuoto se non hai bisogno di qualcosa di specifico — i default
@@ -44,4 +60,4 @@ mysql:
 
 # Marcatori di schema — vedi il commento di intestazione in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/ja.yml
+++ b/common/src/main/resources/databases/mysql/ja.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # 既定パラメータ
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true)
   # の後ろに追加される URL パラメータです。特に必要が無ければ空のまま
@@ -44,4 +60,4 @@ mysql:
 
 # スキーマ用マーカー — config.yml のヘッダーコメントを参照。
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/nl.yml
+++ b/common/src/main/resources/databases/mysql/nl.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Extra URL-parameters die na de vaste set worden toegevoegd
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Laat leeg tenzij je iets specifieks nodig hebt — de defaults passen
@@ -45,4 +61,4 @@ mysql:
 
 # Schemamarkers — zie de header-comment in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/pt.yml
+++ b/common/src/main/resources/databases/mysql/pt.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parâmetros de URL extras anexados após o conjunto fixo
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Deixe vazio salvo se precisar de algo específico — os defaults batem
@@ -45,4 +61,4 @@ mysql:
 
 # Marcadores de esquema — ver o comentário do cabeçalho em config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/ru.yml
+++ b/common/src/main/resources/databases/mysql/ru.yml
@@ -19,6 +19,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Дополнительные URL-параметры, дописываемые после фиксированного набора
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true).
   # Оставьте пустым, если нет специфической необходимости — значения по
@@ -45,4 +61,4 @@ mysql:
 
 # Маркеры схемы — см. шапку config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/tr.yml
+++ b/common/src/main/resources/databases/mysql/tr.yml
@@ -20,6 +20,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Sabit setin (useSSL=false&allowPublicKeyRetrieval=true&
   # rewriteBatchedStatements=true) sonrasına eklenen ek URL parametreleri.
   # Belirli bir gereksinim yoksa boş bırak — varsayılanlar yerel bir dev
@@ -46,4 +62,4 @@ mysql:
 
 # Şema işaretçileri — bkz. config.yml'deki başlık yorumu.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/mysql/zh.yml
+++ b/common/src/main/resources/databases/mysql/zh.yml
@@ -17,6 +17,22 @@ mysql:
   user: "root"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 10
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 10
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # 在固定参数集
   # (useSSL=false&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true)
   # 之后追加的额外 URL 参数。除非确有特殊需要，否则保持为空 — 默认值已
@@ -40,4 +56,4 @@ mysql:
 
 # 模式标记 — 参见 config.yml 顶部的注释。
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/de.yml
+++ b/common/src/main/resources/databases/postgres/de.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Zusätzliche URL-Parameter, die nach `?` angehängt werden. Leer lassen,
   # falls du nichts Spezifisches brauchst.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Schema-Marker — siehe Kopf-Kommentar in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/en.yml
+++ b/common/src/main/resources/databases/postgres/en.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Extra URL parameters appended after `?`. Leave empty unless you know
   # you need something specific.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Schema markers — see header comment in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/es.yml
+++ b/common/src/main/resources/databases/postgres/es.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parámetros de URL extra que se añaden tras `?`. Déjalo vacío salvo que
   # sepas que necesitas algo específico.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Marcadores de esquema — ver el comentario de cabecera en config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/fr.yml
+++ b/common/src/main/resources/databases/postgres/fr.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Paramètres d'URL supplémentaires ajoutés après `?`. Laissez vide sauf
   # besoin spécifique.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Marqueurs de schéma — voir le commentaire d'en-tête dans config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/it.yml
+++ b/common/src/main/resources/databases/postgres/it.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parametri URL extra appesi dopo `?`. Lascia vuoto se non hai bisogno
   # di qualcosa di specifico.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Marcatori di schema — vedi il commento di intestazione in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/ja.yml
+++ b/common/src/main/resources/databases/postgres/ja.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # `?` の後ろに追加される URL パラメータです。特に必要が無ければ空の
   # まま。
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # スキーマ用マーカー — config.yml のヘッダーコメントを参照。
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/nl.yml
+++ b/common/src/main/resources/databases/postgres/nl.yml
@@ -18,6 +18,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Extra URL-parameters die na `?` worden toegevoegd. Laat leeg tenzij je
   # iets specifieks nodig hebt.
   extra-jdbc-params: ""
@@ -35,4 +51,4 @@ postgres:
 
 # Schemamarkers — zie de header-comment in config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/pt.yml
+++ b/common/src/main/resources/databases/postgres/pt.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Parâmetros de URL extras anexados após `?`. Deixe vazio salvo se
   # precisar de algo específico.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Marcadores de esquema — ver o comentário do cabeçalho em config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/ru.yml
+++ b/common/src/main/resources/databases/postgres/ru.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # Дополнительные URL-параметры, дописываемые после `?`. Оставьте
   # пустым, если нет специфической необходимости.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Маркеры схемы — см. шапку config.yml.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/tr.yml
+++ b/common/src/main/resources/databases/postgres/tr.yml
@@ -17,6 +17,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # `?` sonrasına eklenen ek URL parametreleri. Belirli bir gereksinim
   # yoksa boş bırak.
   extra-jdbc-params: ""
@@ -34,4 +50,4 @@ postgres:
 
 # Şema işaretçileri — bkz. config.yml'deki başlık yorumu.
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/common/src/main/resources/databases/postgres/zh.yml
+++ b/common/src/main/resources/databases/postgres/zh.yml
@@ -15,6 +15,22 @@ postgres:
   user: "postgres"
   password: ""
 
+  # HikariCP connection pool settings. These only apply to SQL backends
+  # that use Hikari internally.
+  pool-settings:
+    # Maximum physical database connections this Grim instance can keep open.
+    maximum-pool-size: 5
+    # Minimum idle connections kept warm. Keep equal to maximum-pool-size
+    # for a fixed-size pool, or lower it if your database has tight limits.
+    minimum-idle: 5
+    # Retire connections after this many milliseconds. 1800000 is Hikari's
+    # default 30 minutes; use 0 only if your database/proxy handles lifetime.
+    maximum-lifetime-ms: 1800000
+    # Periodically ping idle connections. 0 disables keepalive.
+    keepalive-time-ms: 0
+    # Maximum time to wait for a connection from the pool before failing.
+    connection-timeout-ms: 5000
+
   # 在 `?` 之后追加的额外 URL 参数。除非确有特殊需要，否则保持为空。
   extra-jdbc-params: ""
 
@@ -31,4 +47,4 @@ postgres:
 
 # 模式标记 — 参见 config.yml 顶部的注释。
 config-flavor: V2
-config-version: 1
+config-version: 2

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -12,7 +12,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.7"
+grim-api = "1.6.0.8"
 packetevents = "2.13.1+8187e23-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
## Summary
- add commented Hikari pool-settings blocks to MySQL and Postgres backend configs
- bump only those backend config specs to version 2
- add a migration step that preserves preseeded operator pool-setting overrides
- update GrimAPI dependency to the published 1.6.0.8 release

Runtime support is in GrimAnticheat/GrimAPI#32 and released as GrimAPI 1.6.0.8.

## Testing
- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --offline :common:compileJava
- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --offline :common:compileJava :bukkit:compileJava
- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew --refresh-dependencies -PmavenLocalOverride=false :common:compileJava :bukkit:compileJava