### PR TITLE
Fix nether portal sweep for teleport-sized movement

### DIFF
--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -47,6 +47,7 @@ import ac.grim.grimac.utils.nmsutil.BlockProperties;
 import ac.grim.grimac.utils.nmsutil.Collisions;
 import ac.grim.grimac.utils.nmsutil.GetBoundingBox;
 import ac.grim.grimac.utils.nmsutil.Materials;
+import ac.grim.grimac.utils.nmsutil.NetherPortalMovement;
 import ac.grim.grimac.utils.nmsutil.StuckSpeed;
 import ac.grim.grimac.utils.viaversion.ViaVersionUtil;
 import com.github.retrooper.packetevents.PacketEvents;
@@ -865,7 +866,16 @@ public class GrimPlayer implements GrimUser {
     public void updateNetherPortalState() {
         // Like the client (Entity#checkInsideBlocks), test the whole tick's movement, not just the
         // resolved position, so a fast run-through through a portal is still detected.
-        SimpleCollisionBox movementThisTick = GetBoundingBox.getCollisionBoxForPlayer(this, x, y, z).expandToCoordinate(lastX - x, lastY - y, lastZ - z);
+        SimpleCollisionBox movementThisTick = GetBoundingBox.getCollisionBoxForPlayer(this, x, y, z);
+        double deltaX = lastX - x;
+        double deltaY = lastY - y;
+        double deltaZ = lastZ - z;
+
+        // Very large deltas are server teleports or corrections, not client movement through blocks.
+        // Sweeping them can span millions of chunks and run inside the Netty event loop.
+        if (NetherPortalMovement.shouldSweep(deltaX, deltaY, deltaZ)) {
+            movementThisTick.expandToCoordinate(deltaX, deltaY, deltaZ);
+        }
         isInNetherPortal = compensatedWorld.containsNetherPortal(movementThisTick);
     }
 

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/NetherPortalMovement.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/NetherPortalMovement.java
@@ -1,0 +1,15 @@
+package ac.grim.grimac.utils.nmsutil;
+
+public final class NetherPortalMovement {
+    private static final double MAX_SWEEP_DISTANCE = 64.0D;
+
+    private NetherPortalMovement() {
+    }
+
+    public static boolean shouldSweep(double deltaX, double deltaY, double deltaZ) {
+        return Double.isFinite(deltaX) && Double.isFinite(deltaY) && Double.isFinite(deltaZ)
+                && Math.abs(deltaX) <= MAX_SWEEP_DISTANCE
+                && Math.abs(deltaY) <= MAX_SWEEP_DISTANCE
+                && Math.abs(deltaZ) <= MAX_SWEEP_DISTANCE;
+    }
+}

--- a/common/src/test/java/ac/grim/grimac/utils/nmsutil/NetherPortalMovementTest.java
+++ b/common/src/test/java/ac/grim/grimac/utils/nmsutil/NetherPortalMovementTest.java
@@ -1,0 +1,28 @@
+package ac.grim.grimac.utils.nmsutil;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NetherPortalMovementTest {
+    @Test
+    void shouldSweepNormalMovementForPortals() {
+        assertTrue(NetherPortalMovement.shouldSweep(0.4D, 0.0D, -0.8D));
+        assertTrue(NetherPortalMovement.shouldSweep(64.0D, -64.0D, 64.0D));
+    }
+
+    @Test
+    void shouldNotSweepTeleportSizedMovementForPortals() {
+        assertFalse(NetherPortalMovement.shouldSweep(64.0001D, 0.0D, 0.0D));
+        assertFalse(NetherPortalMovement.shouldSweep(0.0D, -64.0001D, 0.0D));
+        assertFalse(NetherPortalMovement.shouldSweep(0.0D, 0.0D, 64.0001D));
+    }
+
+    @Test
+    void shouldNotSweepInvalidMovementForPortals() {
+        assertFalse(NetherPortalMovement.shouldSweep(Double.NaN, 0.0D, 0.0D));
+        assertFalse(NetherPortalMovement.shouldSweep(0.0D, Double.POSITIVE_INFINITY, 0.0D));
+        assertFalse(NetherPortalMovement.shouldSweep(0.0D, 0.0D, Double.NEGATIVE_INFINITY));
+    }
+}


### PR DESCRIPTION
Fixed a severe nether portal collision check issue where large server-side teleports could trigger an enormous movement sweep, causing packet-thread stalls and making the server unusable.

`updateNetherPortalState()` expanded the player’s current bounding box using the delta between the previous and current position. This works fine for normal movement, but large teleports or position corrections can make that delta span a huge area. As a result, the portal collision query could scan a very large region during movement packet handling.

On the live Folia server where this was observed, the issue caused all players to time out, spammed the server console with repeated keepalive timeout disconnect logs, and left the server unable to accept new connections or restart cleanly.

The fix keeps the normal per-tick movement sweep for portal detection, but avoids doing oversized portal collision sweeps for teleport-sized or invalid movement deltas.

Added unit coverage for normal, oversized, and non-finite deltas. Also validated with `./gradlew.bat common:check` and tested in-game on the same live Folia server. The same large `/home` teleport no longer reproduces the pathological portal collision scan.

Related to #2767 and #2791