### PR TITLE
Fix Simulation false flags when colliding with sulfur spikes

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/collisions/datatypes/OffsetCollisionBox.java
+++ b/common/src/main/java/ac/grim/grimac/utils/collisions/datatypes/OffsetCollisionBox.java
@@ -47,7 +47,7 @@ public class OffsetCollisionBox extends SimpleCollisionBox {
 
     public OffsetCollisionBox(StateType block, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
         super(minX, minY, minZ, maxX, maxY, maxZ);
-        if (block.equals(StateTypes.POINTED_DRIPSTONE)) {
+        if (block.equals(StateTypes.POINTED_DRIPSTONE) || block.equals(StateTypes.SULFUR_SPIKE)) {
             maxHorizontalModelOffset = 0.125F;
         }
 //        else if (block.equals(StateTypes.SMALL_DRIPLEAF)) {


### PR DESCRIPTION
## What
Apply the 0.125 max horizontal model-offset clamp to `SULFUR_SPIKE` in `OffsetCollisionBox`, the same clamp already used for `POINTED_DRIPSTONE`. Sulfur spikes share dripstone's collision shape via `CollisionData.POINTED_DRIPSTONE`, but fell through to the default 0.25 clamp.

## Why
The client clamps a sulfur spike's random XZ model offset to +/-0.125 (same as pointed dripstone). For any spike whose raw per-position hash offset exceeds 0.125, Grim placed its collision box up to ~0.09 blocks away from where the client has it. Walking into such a spike then false flags Simulation (offsets ~0.01-0.02, repeating while the player is pressed against the spike).

## Verification
Reproduced against a Simulation debug dump (26.2, vanilla client) and checked the math directly:
- Spike at (-2877, -3123): with the 0.125 clamp its -X face sits at exactly x = -2876.8125, matching the client's stuck position; the dump's "Actually" movement of 0.07812360173011257 is exactly the distance to that face. With the 0.25 clamp the box shifts to x = -2876.904, which the player's bounding box already intersected, so the simulation ignored the collision and predicted free movement - producing the flagged offset.
- Spike at (-2877, -3125): with the 0.125 clamp its +Z face is exactly the player's stuck minZ = -3124.4375; with 0.25 it lands at -3124.529 and the collision is missed.

`:bukkit:shadowJar` builds and the packaged `OffsetCollisionBox` class was verified (via javap) to contain the fix.
