### PR TITLE
Fix missing @Override annotations and ByteBuf leak

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/velocity/VectorPrecisionConverter.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/velocity/VectorPrecisionConverter.java
@@ -6,6 +6,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.util.LpVector3d;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.experimental.UtilityClass;
 
@@ -25,9 +26,14 @@ public class VectorPrecisionConverter {
     }
 
     public static Vector3d legacyToLp(Vector3d legacy) {
-        PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(Unpooled.buffer());
-        LpVector3d.write(wrapper, legacy);
-        return LpVector3d.read(wrapper);
+        ByteBuf buf = Unpooled.buffer();
+        try {
+            PacketWrapper<?> wrapper = PacketWrapper.createUniversalPacketWrapper(buf);
+            LpVector3d.write(wrapper, legacy);
+            return LpVector3d.read(wrapper);
+        } finally {
+            buf.release();
+        }
     }
 
     private static final double PRECISION_LOSS_FIX = 1e-11d;

--- a/common/src/main/java/ac/grim/grimac/utils/collisions/datatypes/BoundingBox.java
+++ b/common/src/main/java/ac/grim/grimac/utils/collisions/datatypes/BoundingBox.java
@@ -171,6 +171,7 @@ public class BoundingBox {
         return new SimpleCollisionBox(minX, minY, minZ, maxX, maxY, maxZ);
     }
 
+    @Override
     public String toString() {
         return "[" + minX + ", " + minY + ", " + minZ + ", " + maxX + ", " + maxY + ", " + maxZ + "]";
     }

--- a/common/src/main/java/ac/grim/grimac/utils/math/Location.java
+++ b/common/src/main/java/ac/grim/grimac/utils/math/Location.java
@@ -157,6 +157,7 @@ public class Location implements Cloneable {
         return this.set(base.x - x, base.y - y, base.z - z);
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (obj == null || this.getClass() != obj.getClass()) {
             return false;
@@ -171,6 +172,7 @@ public class Location implements Cloneable {
         }
     }
 
+    @Override
     public int hashCode() {
         int hash = 3;
         PlatformWorld world = this.world == null ? null : this.world.get();
@@ -183,6 +185,7 @@ public class Location implements Cloneable {
         return hash;
     }
 
+    @Override
     public String toString() {
         return "Location{world=" + (this.world == null ? null : this.world.get()) + ",x=" + this.x + ",y=" + this.y + ",z=" + this.z + ",pitch=" + this.pitch + ",yaw=" + this.yaw + "}";
     }

--- a/common/src/main/java/ac/grim/grimac/utils/math/Vector3dm.java
+++ b/common/src/main/java/ac/grim/grimac/utils/math/Vector3dm.java
@@ -330,10 +330,12 @@ public class Vector3dm implements Cloneable, Serializable {
     }
 
     @Contract(value = "null -> false", pure = true)
+    @Override
     public boolean equals(Object obj) {
         return obj instanceof Vector3dm other && Math.abs(this.x - other.x) < 1.0E-6 && Math.abs(this.y - other.y) < 1.0E-6 && Math.abs(this.z - other.z) < 1.0E-6 && this.getClass().equals(obj.getClass());
     }
 
+    @Override
     public int hashCode() {
         int hash = 7;
         hash = 79 * hash + Long.hashCode(Double.doubleToLongBits(this.x));
@@ -350,6 +352,7 @@ public class Vector3dm implements Cloneable, Serializable {
         }
     }
 
+    @Override
     public String toString() {
         return this.x + "," + this.y + "," + this.z;
     }


### PR DESCRIPTION
## Changes

Bugs found by a custom Java linter static analysis of the common module.

### @Override annotations added
Missing `@Override` on `equals`, `hashCode`, and `toString` in:
- `BoundingBox.java` — `toString()`
- `Location.java` — `equals()`, `hashCode()`, `toString()`
- `Vector3dm.java` — `equals()`, `hashCode()`, `toString()`

### ByteBuf leak fixed
`VectorPrecisionConverter.legacyToLp()` allocated a `ByteBuf` via `Unpooled.buffer()` without releasing it. Wrapped in try-finally to ensure `release()` is called.