### PR TITLE
Replace assert null checks with Objects.requireNonNull

### DIFF
--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class PredictionEngine {
@@ -179,8 +180,8 @@ public class PredictionEngine {
             }
         }
 
-        assert beforeCollisionMovement != null;
-        assert realBeforeCollisionMovement != null;
+        Objects.requireNonNull(beforeCollisionMovement, "beforeCollisionMovement");
+        Objects.requireNonNull(realBeforeCollisionMovement, "realBeforeCollisionMovement");
 
         player.clientVelocity = realBeforeCollisionMovement.clone();
         player.predictedVelocity = bestCollisionVel; // Set predicted vel to get the vector types later in the move method


### PR DESCRIPTION
## Changes

`assert` statements are disabled at runtime by default in Java (only active with `-ea` flag), making these null guards ineffective in production. Replaced with `Objects.requireNonNull()` which always executes.

`PredictionEngine.java:182,183` — two `assert` statements guarding `beforeCollisionMovement` and `realBeforeCollisionMovement`

Found by custom Java linter static analysis.