### PR TITLE
Narrow exception scope and log empty catch blocks

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/common/src/main/java/ac/grim/grimac/checks/Check.java
@@ -318,7 +318,7 @@ public class Check extends GrimProcessor implements AbstractCheck {
                     try {
                         value = supplier.get();
                         if (value == null) value = "";
-                    } catch (Throwable ignored) {
+                    } catch (RuntimeException ignored) {
                         value = "";
                     }
                     computed = true;

--- a/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/PunishmentManager.java
@@ -207,7 +207,7 @@ public class PunishmentManager implements ConfigReloadable {
         try {
             String value = supplier.get();
             return value == null ? "" : value;
-        } catch (Throwable ignored) {
+        } catch (RuntimeException ignored) {
             return "";
         }
     }

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
@@ -170,12 +170,12 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
             this.loaded = buildAndStart(dataFolder);
         } catch (FatalStorageStartupException e) {
             logger.log(Level.SEVERE, "[grim-datastore] fatal storage startup failure - shutting down server", e);
-            try { close(); } catch (Exception ignore) {}
+            try { close(); } catch (Exception closeEx) { logger.log(Level.FINE, "[grim-datastore] close during shutdown failed", closeEx); }
             this.enabled = false;
             shutdownServerAfterFatalStorageStartup();
         } catch (Exception | LinkageError e) {
             logger.log(Level.SEVERE, "[grim-datastore] failed to initialise storage - falling back to disabled", e);
-            try { close(); } catch (Exception ignore) {}
+            try { close(); } catch (Exception closeEx) { logger.log(Level.FINE, "[grim-datastore] close during fallback failed", closeEx); }
             this.enabled = false;
             installLocalVerboseRegistry();
         }

--- a/common/src/main/java/ac/grim/grimac/manager/init/start/CommandRegister.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/start/CommandRegister.java
@@ -11,7 +11,7 @@ public record CommandRegister(CommandService service) implements StartableInitab
             if (service != null) {
                 service.registerCommands();
             }
-        } catch (Throwable t) {
+        } catch (RuntimeException t) {
             // This is the ultimate safety net. If command registration fails, Grim keeps running.
             LogUtil.error("Failed to register commands! Grim will run without command support.", t);
         }


### PR DESCRIPTION
## Changes

Found by custom Java linter static analysis of the common module.

### Empty catch blocks
`DataStoreLifecycle.java:173,178` — `try { close(); } catch (Exception ignore) {}` on error cleanup paths. Added FINE-level logging so exceptions during close are visible in debug logs.

### Throwable → RuntimeException
`Check.java:321`, `PunishmentManager.java:210`, `CommandRegister.java:14` — catching `Throwable` is overly broad and would catch `Error` types (OOME, etc.) that should propagate. Changed to `RuntimeException`.