### PR TITLE
Fix NPE by using PlayerManager.getUser over manual channel

### DIFF
--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/player/BukkitPlatformPlayer.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/player/BukkitPlatformPlayer.java
@@ -46,8 +46,7 @@ public class BukkitPlatformPlayer extends BukkitGrimEntity implements PlatformPl
         this.bukkitPlayer = bukkitPlayer;
         this.inventory = new BukkitPlatformInventory(bukkitPlayer);
         if (CommonGrimArguments.USE_CHAT_FAST_BYPASS.value()) {
-            Object channel = PacketEvents.getAPI().getProtocolManager().getChannel(bukkitPlayer.getUniqueId());
-            this.user = PacketEvents.getAPI().getProtocolManager().getUser(channel);
+            this.user = PacketEvents.getAPI().getPlayerManager().getUser(bukkitPlayer);
         } else {
             this.user = null;
         }

--- a/common/src/main/java/ac/grim/grimac/utils/anticheat/PlayerDataManager.java
+++ b/common/src/main/java/ac/grim/grimac/utils/anticheat/PlayerDataManager.java
@@ -4,6 +4,8 @@ import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.event.events.GrimJoinEvent;
 import ac.grim.grimac.api.event.events.GrimQuitEvent;
 import ac.grim.grimac.player.GrimPlayer;
+import ac.grim.grimac.platform.api.player.PlatformPlayer;
+import ac.grim.grimac.platform.api.player.PlatformPlayerCache;
 import ac.grim.grimac.utils.reflection.GeyserUtil;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
@@ -126,9 +128,10 @@ public class PlayerDataManager {
         if (uuid == null)
             return; // folia doesn't like null getPlayer()
 
-        GrimAPI.INSTANCE.getAlertManager().handlePlayerQuit(
-                GrimAPI.INSTANCE.getPlatformPlayerFactory().getFromUUID(uuid)
-        );
+        PlatformPlayer quittingPlayer = PlatformPlayerCache.getInstance().getPlayer(uuid);
+        if (quittingPlayer != null) {
+            GrimAPI.INSTANCE.getAlertManager().handlePlayerQuit(quittingPlayer);
+        }
 
         GrimAPI.INSTANCE.getSpectateManager().onQuit(uuid);
 

--- a/common/src/main/java/ac/grim/grimac/utils/common/arguments/CommonGrimArguments.java
+++ b/common/src/main/java/ac/grim/grimac/utils/common/arguments/CommonGrimArguments.java
@@ -26,7 +26,7 @@ public class CommonGrimArguments {
      * <b>TRADE-OFF:</b> This completely bypasses the platform's event system (e.g., Bukkit's chat events).
      * Other plugins will NOT be able to see, format, or cancel these messages.
      * <p>
-     * This setting is opt-in (default: false) and requires a server restart to change.
+     * This setting is opt-out (default: true) and requires a server restart to change.
      */
     public final static SystemArgument<Boolean> USE_CHAT_FAST_BYPASS = FACTORY.create(string("ChatFastBypass", true));
 


### PR DESCRIPTION
## How do I reproduce this?
Use SoulFire to make bots quickly connect to and disconnect from the server.

## Root cause
https://github.com/GrimAnticheat/Grim/commit/90036e2bf2eaaf365e091ee884b120fbd8553682 added direct channel → User lookup in `BukkitPlatformPlayer` constructor:
```java
Object channel = PacketEvents.getAPI().getProtocolManager().getChannel(uuid);
this.user = PacketEvents.getAPI().getProtocolManager().getUser(channel);
```
`ProtocolManager.getChannel(UUID)` returns null once the channel has been removed from PacketEvents internal map - which happens on disconnect, protocol switch, or for NPCs without a real channel. The null is passed unconditionally to `getUser()`, which bottoms out in `channel.pipeline()`.

## Verification
Tested using the same method mentioned in **How do I reproduce this?**, error is now gone.

## References
* Fixes https://github.com/GrimAnticheat/Grim/issues/2418
* Regression introduced by https://github.com/GrimAnticheat/Grim/commit/90036e2bf2eaaf365e091ee884b120fbd8553682