### PR TITLE
Fix block predictions getting stranded, leaving permanent ghost blocks

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -202,6 +202,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                     player.compensatedWorld.activePistons.clear();
                     player.compensatedWorld.openShulkerBoxes.clear();
                     player.compensatedWorld.chunks.clear();
+                    player.compensatedWorld.clearPredictions();
                     player.compensatedGeysers.clear();
                     player.compensatedWorld.isRaining = false;
                     player.checkManager.getBlockPlaceCheck(BadPacketsH.class).onWorldChange();

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -110,8 +110,6 @@ public class CompensatedWorld implements PacketWorld {
             if (iter.getKey() <= prediction) {
                 applyBlockChanges(iter.getValue());
                 it.remove();
-            } else {
-                break;
             }
         }
     }

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -215,6 +215,14 @@ public class CompensatedWorld implements PacketWorld {
         }
     }
 
+    public void clearPredictions() {
+        originalServerBlocks.clear();
+        currentlyChangedBlocks = new LinkedList<>();
+        serverIsCurrentlyProcessingThesePredictions.clear();
+        unackedActions.clear();
+        isCurrentlyPredicting = false;
+    }
+
     public static long chunkPositionToLong(int x, int z) {
         return ((x & 0xFFFFFFFFL) << 32L) | (z & 0xFFFFFFFFL);
     }


### PR DESCRIPTION
`handlePredictionConfirmation` iterates `serverIsCurrentlyProcessingThesePredictions` and breaks on the first entry with a sequence newer than the confirmed one. The map is an `Int2ObjectOpenHashMap` though, so iteration order has nothing to do with sequence order, and with several predictions in flight a confirmed entry can sit behind a newer one and never get applied.

Once that happens the block is stuck in its client-predicted state: the leftover entry in `originalServerBlocks` also makes `updateBlock` return early for every later server block update at that position, so even resending the chunk doesn't recover it.

Repro: stand on a block and dig it in a place where the break gets cancelled and the block resent (WorldGuard region for example). After enough breaks grim starts simulating the player falling through a block the client is standing on, and the setbacks/simulation flags follow.

The second commit drops prediction state on world change, since the client throws its predictions away together with the old level. A confirmation arriving after the switch could otherwise write an old-world block back into the new world, or move the tracked player position back to the pre-teleport one stored with the prediction.