### PR TITLE
use getCheck(check) instead of getPacketCheck(check) and such

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketEntityAction.java
@@ -66,7 +66,7 @@ public class PacketEntityAction extends PacketListenerAbstract {
                         break;
                     }
 
-                    player.checkManager.getPostPredictionCheck(ElytraA.class).onStartGliding(event);
+                    player.checkManager.getCheck(ElytraA.class).onStartGliding(event);
 
                     // Starting fall flying is server sided on 1.14 and below
                     if (player.getClientVersion().isOlderThan(ClientVersion.V_1_15)) return;

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -101,7 +101,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
             if (health.getHealth() <= 0) {
                 player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get(), () -> {
                     player.compensatedEntities.self.isDead = true;
-                    player.checkManager.getPreViaPacketCheck(BadPacketsM.class).onDeath();
+                    player.checkManager.getCheck(BadPacketsM.class).onDeath();
                 });
             } else {
                 player.latencyUtils.addRealTimeTask(player.lastTransactionSent.get() + 1, () -> player.compensatedEntities.self.isDead = false);
@@ -167,7 +167,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 player.packetStateData.lastClaimedPosition = new Vector3d();
                 player.filterMojangStupidityOnMojangStupidity.zero();
 
-                player.checkManager.getPreViaPacketCheck(BadPacketsM.class).onRespawn();
+                player.checkManager.getCheck(BadPacketsM.class).onRespawn();
 
                 final boolean keepTrackedData = this.hasFlag(respawn, KEEP_TRACKED_DATA);
 
@@ -177,7 +177,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                     player.compensatedEntities.self.hasGravity = true;
                     player.playerEntityHasGravity = true;
                     player.packetStateData.knownInput = KnownInput.DEFAULT;
-                    player.checkManager.getPostPredictionCheck(ElytraC.class).exempt = true;
+                    player.checkManager.getCheck(ElytraC.class).exempt = true;
 
                     // 1.19.4 uses current sprinting, older versions use last sprinting
                     if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19_4)) {
@@ -188,12 +188,12 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                     }
                 }
 
-                player.checkManager.getPacketCheck(BadPacketsE.class).handleRespawn(); // Reminder ticks reset
-                player.checkManager.getPreViaPacketCheck(BadPacketsG.class).handleRespawn();
+                player.checkManager.getCheck(BadPacketsE.class).handleRespawn(); // Reminder ticks reset
+                player.checkManager.getCheck(BadPacketsG.class).handleRespawn();
 
                 // compensate for immediate respawn gamerule
                 if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)) {
-                    player.checkManager.getPreViaPacketCheck(BadPacketsF.class).exemptNext = true;
+                    player.checkManager.getCheck(BadPacketsF.class).exemptNext = true;
                 }
 
                 // EVERYTHING gets reset on a cross dimensional teleport, clear chunks and entities!
@@ -204,7 +204,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                     player.compensatedWorld.chunks.clear();
                     player.compensatedGeysers.clear();
                     player.compensatedWorld.isRaining = false;
-                    player.checkManager.getBlockPlaceCheck(BadPacketsH.class).onWorldChange();
+                    player.checkManager.getCheck(BadPacketsH.class).onWorldChange();
                 }
                 player.dimensionType = respawn.getDimensionType();
                 player.worldName = respawn.getWorldName().orElse(null);
@@ -218,7 +218,7 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
                 if (player.getClientVersion().isOlderThan(ClientVersion.V_1_14)) { // 1.14+ players send a packet for this, listen for it instead
                     player.isSprinting = false;
                     player.vehicleData.camelSprintingState = SprintingState.STOPPED;
-                    player.checkManager.getPreViaPacketCheck(BadPacketsF.class).lastSprinting = false; // Pre 1.14 clients set this to false when creating new entity
+                    player.checkManager.getCheck(BadPacketsF.class).lastSprinting = false; // Pre 1.14 clients set this to false when creating new entity
                     // TODO: What the fuck viaversion, why do you throw out keep all metadata?
                     // The server doesn't even use it... what do we do?
                     player.compensatedEntities.hasSprintingAttributeEnabled = false;

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerTick.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerTick.java
@@ -27,14 +27,14 @@ public class PacketPlayerTick extends PacketListenerAbstract {
             if (player == null || player.getClientVersion().isOlderThan(ClientVersion.V_1_21_2))
                 return;
 
-            PacketWorldBorder border = player.checkManager.getPacketCheck(PacketWorldBorder.class);
+            PacketWorldBorder border = player.checkManager.getCheck(PacketWorldBorder.class);
             border.tickBorder();
         } else if (WrapperPlayClientPlayerFlying.isFlying(event.getPacketType())) {
             GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
             if (player == null || player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21_2))
                 return;
 
-            PacketWorldBorder border = player.checkManager.getPacketCheck(PacketWorldBorder.class);
+            PacketWorldBorder border = player.checkManager.getCheck(PacketWorldBorder.class);
             border.tickBorder();
         }
     }

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -68,15 +68,6 @@ public class CheckManager {
     private static final AtomicBoolean initedAtomic = new AtomicBoolean(false);
     private static boolean inited;
     public final ClassToInstanceMap<AbstractCheck> allChecks;
-    private final ClassToInstanceMap<PacketCheck> preViaPacketChecks;
-    private final ClassToInstanceMap<PacketCheck> packetChecks;
-    private final ClassToInstanceMap<PositionCheck> positionChecks;
-    private final ClassToInstanceMap<RotationCheck> rotationChecks;
-    private final ClassToInstanceMap<VehicleCheck> vehicleChecks;
-    private final ClassToInstanceMap<PacketCheck> prePredictionChecks;
-    private final ClassToInstanceMap<BlockBreakCheck> blockBreakChecks;
-    private final ClassToInstanceMap<BlockPlaceCheck> blockPlaceChecks;
-    private final ClassToInstanceMap<PostPredictionCheck> postPredictionChecks;
 
     private final List<PacketCheck> preViaPacketChecksValues;
     private final List<PacketCheck> packetChecksValues;
@@ -89,7 +80,7 @@ public class CheckManager {
     private final List<PostPredictionCheck> postPredictionChecksValues;
 
     public CheckManager(GrimPlayer player) {
-        preViaPacketChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
+        ClassToInstanceMap<PacketCheck> preViaPacketChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
                 .put(CompensatedCameraEntity.class, player.cameraEntity)
                 .put(ChatA.class, new ChatA(player))
                 .put(ChatB.class, new ChatB(player))
@@ -116,7 +107,7 @@ public class CheckManager {
                 .build();
 
         // TODO: migrate the rest of these to pre-via
-        packetChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
+        ClassToInstanceMap<PacketCheck> packetChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
                 .put(PacketOrderProcessor.class, player.packetOrderProcessor)
                 .put(Reach.class, new Reach(player))
                 .put(PacketEntityReplication.class, player.packetEntityReplication)
@@ -158,20 +149,20 @@ public class CheckManager {
                 .put(SetbackBlocker.class, new SetbackBlocker(player)) // Must be last class otherwise we can't check while blocking packets
                 .build();
 
-        positionChecks = new ImmutableClassToInstanceMap.Builder<PositionCheck>()
+        ClassToInstanceMap<PositionCheck> positionChecks = new ImmutableClassToInstanceMap.Builder<PositionCheck>()
                 .put(PredictionRunner.class, new PredictionRunner(player))
                 .put(CompensatedCooldown.class, new CompensatedCooldown(player))
                 .build();
-        rotationChecks = new ImmutableClassToInstanceMap.Builder<RotationCheck>()
+        ClassToInstanceMap<RotationCheck> rotationChecks = new ImmutableClassToInstanceMap.Builder<RotationCheck>()
                 .put(AimProcessor.class, new AimProcessor(player))
                 .put(AimModulo360.class, new AimModulo360(player))
                 .put(AimDuplicateLook.class, new AimDuplicateLook(player))
                 .build();
-        vehicleChecks = new ImmutableClassToInstanceMap.Builder<VehicleCheck>()
+        ClassToInstanceMap<VehicleCheck> vehicleChecks = new ImmutableClassToInstanceMap.Builder<VehicleCheck>()
                 .put(VehiclePredictionRunner.class, new VehiclePredictionRunner(player))
                 .build();
 
-        postPredictionChecks = new ImmutableClassToInstanceMap.Builder<PostPredictionCheck>()
+        ClassToInstanceMap<PostPredictionCheck> postPredictionChecks = new ImmutableClassToInstanceMap.Builder<PostPredictionCheck>()
                 .put(NegativeTimer.class, new NegativeTimer(player))
                 .put(ExplosionHandler.class, new ExplosionHandler(player))
                 .put(KnockbackHandler.class, new KnockbackHandler(player))
@@ -218,7 +209,7 @@ public class CheckManager {
                 .put(LastInstanceManager.class, player.lastInstanceManager)
                 .build();
 
-        blockPlaceChecks = new ImmutableClassToInstanceMap.Builder<BlockPlaceCheck>()
+        ClassToInstanceMap<BlockPlaceCheck> blockPlaceChecks = new ImmutableClassToInstanceMap.Builder<BlockPlaceCheck>()
                 .put(InvalidPlaceA.class, new InvalidPlaceA(player))
                 .put(InvalidPlaceB.class, new InvalidPlaceB(player))
                 .put(AirLiquidPlace.class, new AirLiquidPlace(player))
@@ -236,7 +227,7 @@ public class CheckManager {
                 .put(GhostBlockMitigation.class, new GhostBlockMitigation(player))
                 .build();
 
-        prePredictionChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
+        ClassToInstanceMap<PacketCheck> prePredictionChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
                 .put(Timer.class, new Timer(player))
                 .put(TickTimer.class, new TickTimer(player))
                 .put(TimerLimit.class, new TimerLimit(player))
@@ -245,7 +236,7 @@ public class CheckManager {
                 .put(VehicleTimer.class, new VehicleTimer(player))
                 .build();
 
-        blockBreakChecks = new ImmutableClassToInstanceMap.Builder<BlockBreakCheck>()
+        ClassToInstanceMap<BlockBreakCheck> blockBreakChecks = new ImmutableClassToInstanceMap.Builder<BlockBreakCheck>()
                 .put(AirLiquidBreak.class, new AirLiquidBreak(player))
                 .put(WrongBreak.class, new WrongBreak(player))
                 .put(RotationBreak.class, new RotationBreak(player))
@@ -310,34 +301,6 @@ public class CheckManager {
 
     public <T extends AbstractCheck> T getCheck(Class<T> check) {
         return allChecks.getInstance(check);
-    }
-
-    public <T extends PositionCheck> T getPositionCheck(Class<T> check) {
-        return positionChecks.getInstance(check);
-    }
-
-    public <T extends RotationCheck> T getRotationCheck(Class<T> check) {
-        return rotationChecks.getInstance(check);
-    }
-
-    public <T extends BlockPlaceCheck> T getBlockPlaceCheck(Class<T> check) {
-        return blockPlaceChecks.getInstance(check);
-    }
-
-    public <T extends PacketCheck> T getPacketCheck(Class<T> check) {
-        return packetChecks.getInstance(check);
-    }
-
-    public <T extends PacketCheck> T getPreViaPacketCheck(Class<T> check) {
-        return preViaPacketChecks.getInstance(check);
-    }
-
-    public <T extends PacketCheck> T getPrePredictionCheck(Class<T> check) {
-        return prePredictionChecks.getInstance(check);
-    }
-
-    public <T extends PostPredictionCheck> T getPostPredictionCheck(Class<T> check) {
-        return postPredictionChecks.getInstance(check);
     }
 
     public void onPrePredictionReceivePacket(final PacketReceiveEvent packet) {
@@ -455,31 +418,31 @@ public class CheckManager {
     }
 
     public ExplosionHandler getExplosionHandler() {
-        return getPostPredictionCheck(ExplosionHandler.class);
+        return getCheck(ExplosionHandler.class);
     }
 
     public NoFall getNoFall() {
-        return getPacketCheck(NoFall.class);
+        return getCheck(NoFall.class);
     }
 
     public KnockbackHandler getKnockbackHandler() {
-        return getPostPredictionCheck(KnockbackHandler.class);
+        return getCheck(KnockbackHandler.class);
     }
 
     public CompensatedCooldown getCompensatedCooldown() {
-        return getPositionCheck(CompensatedCooldown.class);
+        return getCheck(CompensatedCooldown.class);
     }
 
     public NoSlow getNoSlow() {
-        return getPostPredictionCheck(NoSlow.class);
+        return getCheck(NoSlow.class);
     }
 
     public SetbackTeleportUtil getSetbackUtil() {
-        return getPostPredictionCheck(SetbackTeleportUtil.class);
+        return getCheck(SetbackTeleportUtil.class);
     }
 
     public DebugHandler getDebugHandler() {
-        return getPostPredictionCheck(DebugHandler.class);
+        return getCheck(DebugHandler.class);
     }
 
     private void init() {

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/LiveWriteHooks.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/LiveWriteHooks.java
@@ -95,7 +95,7 @@ public interface LiveWriteHooks {
         String serverVersion = GrimAPI.INSTANCE.getPlatformServer().getPlatformImplementationString();
         String brand = null;
         if (gp != null) {
-            ClientBrand check = gp.checkManager.getPacketCheck(ClientBrand.class);
+            ClientBrand check = gp.checkManager.getCheck(ClientBrand.class);
             if (check != null && check.isHasBrand()) brand = check.getBrand();
         }
         return new SessionTracker.ClientMeta(grimVersion, brand, clientVersionPvn, serverVersion);

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -912,7 +912,7 @@ public class GrimPlayer implements GrimUser {
 
     @Override
     public String getBrand() {
-        return checkManager.getPacketCheck(ClientBrand.class).getBrand();
+        return checkManager.getCheck(ClientBrand.class).getBrand();
     }
 
     @Override
@@ -932,12 +932,12 @@ public class GrimPlayer implements GrimUser {
 
     @Override
     public double getHorizontalSensitivity() {
-        return checkManager.getRotationCheck(AimProcessor.class).sensitivityX;
+        return checkManager.getCheck(AimProcessor.class).sensitivityX;
     }
 
     @Override
     public double getVerticalSensitivity() {
-        return checkManager.getRotationCheck(AimProcessor.class).sensitivityY;
+        return checkManager.getCheck(AimProcessor.class).sensitivityY;
     }
 
     @Override

--- a/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/MovementCheckRunner.java
@@ -136,7 +136,7 @@ public class MovementCheckRunner extends Check implements PositionCheck {
         // Manually call prediction complete to handle teleport
         PredictionComplete predictionComplete = new PredictionComplete(0, update, true);
         player.getSetbackTeleportUtil().onPredictionComplete(predictionComplete);
-        player.checkManager.getPostPredictionCheck(Phase.class).onPredictionComplete(predictionComplete);
+        player.checkManager.getCheck(Phase.class).onPredictionComplete(predictionComplete);
 
         player.uncertaintyHandler.lastHorizontalOffset = 0;
         player.uncertaintyHandler.lastVerticalOffset = 0;

--- a/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/movementtick/MovementTicker.java
@@ -59,7 +59,7 @@ public class MovementTicker {
             playerBox.encompass(GetBoundingBox.getBoundingBoxFromPosAndSize(player, player.x, player.y, player.z, 0.6f, 1.8f).expand(player.getMovementThreshold()));
             playerBox.expand(0.2);
 
-            final TeamHandler teamHandler = player.checkManager.getPacketCheck(TeamHandler.class);
+            final TeamHandler teamHandler = player.checkManager.getCheck(TeamHandler.class);
             final EntityTeam playerTeam = teamHandler != null ? teamHandler.getPlayerTeam() : null;
             for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
                 // TODO actually handle entity collisions instead of this awfulness

--- a/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/predictions/PredictionEngine.java
@@ -79,7 +79,7 @@ public class PredictionEngine {
         // Computers are actually really fast at sorting, I don't see sorting as a problem
         possibleVelocities.sort((a, b) -> sortVectorData(a, b, player));
 
-        player.checkManager.getPostPredictionCheck(SneakingEstimator.class).storePossibleVelocities(possibleVelocities);
+        player.checkManager.getCheck(SneakingEstimator.class).storePossibleVelocities(possibleVelocities);
 
         double bestInput = Double.MAX_VALUE;
 
@@ -609,7 +609,7 @@ public class PredictionEngine {
         box.combineToMinimum(box.minX, levitation, box.minZ);
 
 
-        SneakingEstimator sneaking = player.checkManager.getPostPredictionCheck(SneakingEstimator.class);
+        SneakingEstimator sneaking = player.checkManager.getCheck(SneakingEstimator.class);
         box.minX += sneaking.getSneakingPotentialHiddenVelocity().minX;
         box.minZ += sneaking.getSneakingPotentialHiddenVelocity().minZ;
         box.maxX += sneaking.getSneakingPotentialHiddenVelocity().maxX;

--- a/common/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
+++ b/common/src/main/java/ac/grim/grimac/utils/data/packetentity/PacketEntitySelf.java
@@ -150,7 +150,7 @@ public class PacketEntitySelf extends PacketEntity {
     @Override
     public void addPotionEffect(PotionType effect, int amplifier) {
         if (effect == PotionTypes.BLINDNESS && !hasPotionEffect(PotionTypes.BLINDNESS)) {
-            player.checkManager.getPostPredictionCheck(SprintD.class).startedSprintingBeforeBlind = player.isSprinting;
+            player.checkManager.getCheck(SprintD.class).startedSprintingBeforeBlind = player.isSprinting;
         }
 
         player.pointThreeEstimator.updatePlayerPotions(effect, amplifier);

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/Collisions.java
@@ -213,7 +213,7 @@ public final class Collisions {
         // Worldborders were added in 1.8
         // Don't add to border unless the player is colliding with it and is near it
         if (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_8)) {
-            PacketWorldBorder border = player.checkManager.getPacketCheck(PacketWorldBorder.class);
+            PacketWorldBorder border = player.checkManager.getCheck(PacketWorldBorder.class);
 
             double minX = Math.floor(border.getMinX());
             double minZ = Math.floor(border.getMinZ());

--- a/common/src/main/java/ac/grim/grimac/utils/team/EntityTeam.java
+++ b/common/src/main/java/ac/grim/grimac/utils/team/EntityTeam.java
@@ -25,7 +25,7 @@ public final class EntityTeam {
     public void update(WrapperPlayServerTeams teams) {
         teams.getTeamInfo().ifPresent(info -> this.collisionRule = info.getCollisionRule());
 
-        final TeamHandler teamHandler = player.checkManager.getPacketCheck(TeamHandler.class);
+        final TeamHandler teamHandler = player.checkManager.getCheck(TeamHandler.class);
         final WrapperPlayServerTeams.TeamMode mode = teams.getTeamMode();
         if (mode == WrapperPlayServerTeams.TeamMode.ADD_ENTITIES || mode == WrapperPlayServerTeams.TeamMode.CREATE) {
             label:


### PR DESCRIPTION
It seems to be consistently faster in my testing, which consisted of timing `getExplosionHandler()` and `getKnockbackHandler()` with `System.nanoTime()` with one using `getCheck(...)` and the other using  `getPostPredictionCheck(...)`. The one using `getPostPredictionCheck(...)` averaged 110 ns, whereas the one using `getCheck(...)` averaged 90 ns (over 10,000 calls).