### PR TITLE
fix five incorrect conditions in the movement simulation

### DIFF
--- a/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/EntityFluidInteraction.java
@@ -46,7 +46,10 @@ public class EntityFluidInteraction {
         double aabbMinY = player.boundingBox.minY;
 
         int playerX = GrimMath.floor(player.lastX);
-        double playerEyeY = player.lastY + player.getEyeHeight() - 0.1111111119389534D;
+        // Entity#getEyeY(), with no offset. The 0.1111111119389534 fudge belongs to the pre-1.21.12
+        // updateFluidOnEyes path (see PlayerBaseTick) and was dropped when Mojang rewrote this into
+        // EntityFluidInteraction; carrying it over here would sink the eye below where the client has it.
+        double playerEyeY = player.lastY + player.getEyeHeight();
         int playerZ = GrimMath.floor(player.lastZ);
 
         FluidTag fluid = null;

--- a/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/PlayerBaseTick.java
@@ -134,7 +134,7 @@ public final class PlayerBaseTick {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_15_2))
             player.wasEyeInWater = false;
 
-        d1 = (float) Math.floor(d0) + player.compensatedWorld.getWaterFluidLevelAt(player.lastX, d0, player.lastZ);
+        d1 = (float) Math.floor(d0) + player.compensatedWorld.getLavaFluidLevelAt(player.lastX, d0, player.lastZ);
         if (d1 > d0) {
             player.fluidOnEyes = FluidTag.LAVA;
         }

--- a/common/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
+++ b/common/src/main/java/ac/grim/grimac/predictionengine/UncertaintyHandler.java
@@ -341,10 +341,11 @@ public class UncertaintyHandler {
 
     private boolean striderCollision(SimpleCollisionBox expandedBB) {
         // Stiders can walk on top of other striders
-        if (player.compensatedEntities.self.getRiding() instanceof PacketEntityStrider) {
+        final PacketEntity riding = player.compensatedEntities.self.getRiding();
+        if (riding instanceof PacketEntityStrider) {
             for (PacketEntity entity : player.compensatedEntities.entityMap.values()) {
-                if (entity.getType() == EntityTypes.STRIDER && entity != player.compensatedEntities.self.getRiding()
-                        && !entity.hasPassenger(entity) && entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
+                if (entity.getType() == EntityTypes.STRIDER && entity != riding
+                        && !riding.hasPassenger(entity) && entity.getPossibleCollisionBoxes().isIntersected(expandedBB)) {
                     return true;
                 }
             }

--- a/common/src/main/java/ac/grim/grimac/utils/collisions/AxisUtil.java
+++ b/common/src/main/java/ac/grim/grimac/utils/collisions/AxisUtil.java
@@ -16,11 +16,11 @@ public class AxisUtil {
         boolean insideZ = toMerge.minZ <= base.minZ && toMerge.maxZ >= base.maxZ;
 
         if (insideX && insideY && !insideZ) {
-            return new SimpleCollisionBox(base.minX, base.maxY, Math.min(base.minZ, toMerge.minZ), base.minX, base.maxY, Math.max(base.maxZ, toMerge.maxZ));
+            return new SimpleCollisionBox(base.minX, base.minY, Math.min(base.minZ, toMerge.minZ), base.maxX, base.maxY, Math.max(base.maxZ, toMerge.maxZ));
         } else if (insideX && !insideY && insideZ) {
             return new SimpleCollisionBox(base.minX, Math.min(base.minY, toMerge.minY), base.minZ, base.maxX, Math.max(base.maxY, toMerge.maxY), base.maxZ);
         } else if (!insideX && insideY && insideZ) {
-            return new SimpleCollisionBox(Math.min(base.minX, toMerge.maxX), base.minY, base.maxZ, Math.max(base.minX, toMerge.minX), base.minY, base.maxZ);
+            return new SimpleCollisionBox(Math.min(base.minX, toMerge.minX), base.minY, base.minZ, Math.max(base.maxX, toMerge.maxX), base.maxY, base.maxZ);
         }
 
         return base;

--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedWorld.java
@@ -679,6 +679,10 @@ public class CompensatedWorld implements PacketWorld {
         return Collisions.hasMaterial(player, box, (block, x, y, z) -> Materials.isWater(player.getClientVersion(), block) || block.getType() == StateTypes.LAVA);
     }
 
+    public float getLavaFluidLevelAt(double x, double y, double z) {
+        return getLavaFluidLevelAt(GrimMath.floor(x), GrimMath.floor(y), GrimMath.floor(z));
+    }
+
     public float getLavaFluidLevelAt(int x, int y, int z) {
         WrappedBlockState magicBlockState = getBlock(x, y, z);
         WrappedBlockState magicBlockStateAbove = getBlock(x, y + 1, z);

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/MainSupportingBlockPosFinder.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/MainSupportingBlockPosFinder.java
@@ -54,30 +54,14 @@ public class MainSupportingBlockPosFinder {
     }
 
     private boolean firstHasPriorityOverSecond(int firstX, int firstY, int firstZ, @NotNull Vector3i second) {
-        // Order of loop is X, Y, and Z
-        // We prioritize lowest Y axis, then lowest X axis, then lowest Z axis
-        // Ties among the X and Z positions are broken by the order of looping being X
+        // Vanilla (CollisionGetter#findSupportingBlock) keeps the candidate over the current best
+        // when best.compareTo(candidate) < 0, and Vec3i#compareTo orders lexicographically by
+        // Y, then Z, then X. So on a distance tie the greatest block in that order wins.
         //
-        // X O O
-        // 0 X 0
-        // 0 0 X
-        // If the three blocks were this, the lowest right would win because of iteration order
-        //
-        // X 0 0
-        // 0 0 X
-        // But the upper left would win here because of prioritizing negative X and negative Z
-        if (firstY < second.getY()) return true;
-
-        double sumX = second.getX() - firstX;
-        double sumY = second.getZ() - firstZ;
-
-        double horizontalSumTotal = sumX + sumY;
-        if (horizontalSumTotal == 0) {
-            // If X is farther in the X direction, then it was found later and therefore won't override
-            return sumX < 0;
-        }
-
-        // Otherwise, lower X and lower Z have priority
-        return horizontalSumTotal < 0;
+        // This must be a strict lexicographic order, not a sum of the axis deltas: (0,y,5) vs
+        // (5,y,0) sums to zero on both axes while the Z comparison clearly separates them.
+        if (second.getY() != firstY) return second.getY() < firstY;
+        if (second.getZ() != firstZ) return second.getZ() < firstZ;
+        return second.getX() < firstX;
     }
 }


### PR DESCRIPTION
Five independent fixes in the movement simulation, each in its own commit. They are all cases where a condition could never be true, or where the code did not match what the client actually does. None of them change any threshold or add a heuristic.

### What changed

**`fix eye in lava check reading the water level`**
The lava branch of `updateFluidOnEyes` called `getWaterFluidLevelAt`, the same call as the water branch above it. Since that branch already returns when it matches, the lava branch could never be true. Adds a `double` overload of `getLavaFluidLevelAt` so the call reads the same way as the water one.

**`fix strider collision check comparing an entity with itself`**
`hasPassenger` was called on the entity being tested, which can never be true, so the check never filtered anything out. It should skip striders riding the player's own strider, the way the boat check just below it does.

**`fix AxisUtil.combine returning boxes with swapped corners`**
Two of the three branches used `maxY` where `minY` was meant and `minX` where `maxX` was meant, producing boxes with no width and no height. Nothing calls this method at the moment, so this is a correctness fix only.

**`match vanilla when picking between blocks at the same distance`**
When two blocks are the same distance away, vanilla compares them by Y, then Z, then X, and keeps the greater one. The old code compared Y the other way round, fell through instead of deciding when the Y values differed, and added the X and Z differences together, which does not give the same answer as comparing them one after the other. For example `(0, y, 5)` and `(5, y, 0)` sum to the same thing on both axes, while comparing Z separates them.

**`remove leftover eye offset in the 1.21.12+ fluid check`**
`EntityFluidInteraction` kept the `0.1111111119389534` offset from the older `updateFluidOnEyes` code. Vanilla uses the plain eye height here, so the eye was tracked slightly lower than the client has it, which can keep the swimming pose on for a moment too long. The offset is still correct in `PlayerBaseTick`, which is the path older clients take.

### Version and platform reach

Nothing here is platform specific — all of it is in `common`, no new API is used.

Version-wise, each fix only takes effect where the corresponding client code path runs, and none of them change behaviour on versions they do not apply to:

| Fix | Affected clients |
| --- | --- |
| Lava eye level | 1.8 and up (path used up to 1.21.11) |
| Strider collision | 1.8 and up |
| `AxisUtil.combine` | none currently, no callers |
| Supporting block tie-break | 1.20 and up, older clients do not use the supporting block position |
| Fluid eye offset | 1.21.12 and up, older clients go through `PlayerBaseTick` |

The two eye-level fixes are deliberately split so the older and newer paths stay independent: the offset is kept in `PlayerBaseTick` and only dropped in `EntityFluidInteraction`.

### Notes for review

The tie-break change is the one worth a close look, since it is the only one that can change an outcome on a currently reachable path. The order it now implements is the one `Vec3i#compareTo` gives (Y, then Z, then X, greater wins), matching `findSupportingBlock`.

The `AxisUtil` and lava eye-level fixes have no observable effect today — the first has no callers, the second has no reader of `isEyeInFluid(LAVA)` on that path. They are included because leaving a condition that can never be true is a trap for whoever wires them up later.
