### PR TITLE
Skip inapplicable checks during dispatch

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/common/src/main/java/ac/grim/grimac/checks/Check.java
@@ -97,6 +97,10 @@ public class Check extends GrimProcessor implements AbstractCheck {
                 && !exemptPermission;
     }
 
+    public boolean isApplicable() {
+        return true;
+    }
+
     public final void updatePermissions() {
         if (configName == null) return;
         final String id = configName.toLowerCase();

--- a/common/src/main/java/ac/grim/grimac/checks/Check.java
+++ b/common/src/main/java/ac/grim/grimac/checks/Check.java
@@ -97,6 +97,10 @@ public class Check extends GrimProcessor implements AbstractCheck {
                 && !exemptPermission;
     }
 
+    /**
+     * Evaluated once when CheckManager builds the dispatch arrays.
+     * Implementations must only depend on immutable connection properties.
+     */
     public boolean isApplicable() {
         return true;
     }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
@@ -25,6 +25,11 @@ public class BadPacketsH extends BlockPlaceCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return isSupportedVersion;
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.USE_ITEM
                 && shouldCancel(new WrapperPlayClientUseItem(event).getSequence())) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
@@ -25,11 +25,6 @@ public class BadPacketsH extends BlockPlaceCheck {
     }
 
     @Override
-    public boolean isApplicable() {
-        return isSupportedVersion;
-    }
-
-    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.USE_ITEM
                 && shouldCancel(new WrapperPlayClientUseItem(event).getSequence())) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsH.java
@@ -18,10 +18,15 @@ public class BadPacketsH extends BlockPlaceCheck {
     private static final Verbose V = Verbose.of("expected={sint}, id={sint}");
 
     private int lastSequence;
-    private final boolean isSupportedVersion = player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19) && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19);
 
     public BadPacketsH(final GrimPlayer player) {
         super(player);
+    }
+
+    @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19)
+                && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19);
     }
 
     @Override
@@ -59,7 +64,7 @@ public class BadPacketsH extends BlockPlaceCheck {
     public boolean shouldCancel(int sequence) {
         int expected = lastSequence + 1;
         lastSequence = sequence;
-        return isSupportedVersion && sequence != expected
+        return sequence != expected
                 && flagSequence(expected, sequence)
                 && shouldModifyPackets();
     }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsJ.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsJ.java
@@ -24,6 +24,12 @@ public class BadPacketsJ extends Check implements PacketCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)
+                && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (!player.cameraEntity.isSelf()) {
             rotations.clear();

--- a/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsJ.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/badpackets/BadPacketsJ.java
@@ -36,8 +36,7 @@ public class BadPacketsJ extends Check implements PacketCheck {
             return;
         }
 
-        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_21)
-                && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
+        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM) {
             WrapperPlayClientUseItem packet = new WrapperPlayClientUseItem(event);
             rotations.add(new HeadRotation(packet.getYaw(), packet.getPitch()));
         }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/chat/ChatA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/chat/ChatA.java
@@ -24,7 +24,7 @@ public class ChatA extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_13)) {
+        if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE) {
             WrapperPlayClientTabComplete wrapper = new WrapperPlayClientTabComplete(event);
             String text = wrapper.getText();
             if (text.equals("/") || text.trim().isEmpty()) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/chat/ChatA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/chat/ChatA.java
@@ -18,6 +18,11 @@ public class ChatA extends Check implements PacketCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_13);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.TAB_COMPLETE && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_13)) {
             WrapperPlayClientTabComplete wrapper = new WrapperPlayClientTabComplete(event);

--- a/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
@@ -27,6 +27,11 @@ public class CrashD extends Check implements PacketCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return isSupportedVersion();
+    }
+
+    @Override
     public void onPacketSend(final PacketSendEvent event) {
         if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW && isSupportedVersion()) {
             WrapperPlayServerOpenWindow window = new WrapperPlayServerOpenWindow(event);

--- a/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashD.java
@@ -28,12 +28,12 @@ public class CrashD extends Check implements PacketCheck {
 
     @Override
     public boolean isApplicable() {
-        return isSupportedVersion();
+        return PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_14);
     }
 
     @Override
     public void onPacketSend(final PacketSendEvent event) {
-        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW && isSupportedVersion()) {
+        if (event.getPacketType() == PacketType.Play.Server.OPEN_WINDOW) {
             WrapperPlayServerOpenWindow window = new WrapperPlayServerOpenWindow(event);
             this.type = MenuType.getMenuType(window.getType());
             if (type == MenuType.LECTERN) lecternId = window.getContainerId();
@@ -42,7 +42,7 @@ public class CrashD extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW && isSupportedVersion()) {
+        if (event.getPacketType() == PacketType.Play.Client.CLICK_WINDOW) {
             WrapperPlayClientClickWindow click = new WrapperPlayClientClickWindow(event);
             int clickType = VerboseCodecs.enumId(click.getWindowClickType());
             int button = click.getButton();
@@ -56,9 +56,4 @@ public class CrashD extends Check implements PacketCheck {
             }
         }
     }
-
-    private boolean isSupportedVersion() {
-        return PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_14);
-    }
-
 }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
@@ -21,12 +21,13 @@ public class CrashG extends BlockPlaceCheck {
 
     @Override
     public boolean isApplicable() {
-        return isSupportedVersion();
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19)
+                && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19);
     }
 
     @Override
     public void onPacketReceive(final PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM && isSupportedVersion()) {
+        if (event.getPacketType() == PacketType.Play.Client.USE_ITEM) {
             WrapperPlayClientUseItem use = new WrapperPlayClientUseItem(event);
             if (use.getSequence() < 0) {
                 flag();
@@ -38,7 +39,7 @@ public class CrashG extends BlockPlaceCheck {
 
     @Override
     public void onBlockBreak(BlockBreak blockBreak) {
-        if (blockBreak.sequence < 0 && isSupportedVersion()) {
+        if (blockBreak.sequence < 0) {
             flag();
             blockBreak.cancel();
         }
@@ -46,14 +47,9 @@ public class CrashG extends BlockPlaceCheck {
 
     @Override
     public void onBlockPlace(BlockPlace place) {
-        if (place.sequence < 0 && isSupportedVersion()) {
+        if (place.sequence < 0) {
             flag();
             place.resync();
         }
     }
-
-    private boolean isSupportedVersion() {
-        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_19) && PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_19);
-    }
-
 }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/crash/CrashG.java
@@ -20,6 +20,11 @@ public class CrashG extends BlockPlaceCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return isSupportedVersion();
+    }
+
+    @Override
     public void onPacketReceive(final PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.USE_ITEM && isSupportedVersion()) {
             WrapperPlayClientUseItem use = new WrapperPlayClientUseItem(event);

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
@@ -18,14 +18,10 @@ public class ElytraA extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     public void onStartGliding(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (player.isGliding && flag()) {
             setback = true;
             if (shouldModifyPackets()) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraA.java
@@ -16,6 +16,11 @@ public class ElytraA extends Check implements PostPredictionCheck {
         super(player);
     }
 
+    @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
     public void onStartGliding(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
@@ -22,6 +22,11 @@ public class ElytraB extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.supportsEndTick();
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraB.java
@@ -29,8 +29,7 @@ public class ElytraB extends Check implements PostPredictionCheck {
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
-                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.supportsEndTick()) {
+                && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA) {
             if (player.packetStateData.knownInput.jump()) {
                 if (flag(V.write(verbose()).bool(true))) {
                     setback = true;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
@@ -21,6 +21,11 @@ public class ElytraC extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraC.java
@@ -22,15 +22,11 @@ public class ElytraC extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (!player.cameraEntity.isSelf()) {
             glideThisTick = glideLastTick = false;
         }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
@@ -19,6 +19,11 @@ public class ElytraD extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraD.java
@@ -20,15 +20,11 @@ public class ElytraD extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
                 && !player.canGlide()

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
@@ -20,15 +20,11 @@ public class ElytraE extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
                 && player.isFlying

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraE.java
@@ -19,6 +19,11 @@ public class ElytraE extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
@@ -19,6 +19,11 @@ public class ElytraF extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraF.java
@@ -20,15 +20,11 @@ public class ElytraF extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
                 && player.clientClaimsLastOnGround

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
@@ -28,7 +28,6 @@ public class ElytraG extends Check implements PostPredictionCheck {
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
-                && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16)
                 && player.compensatedEntities.self.hasPotionEffect(PotionTypes.LEVITATION)
                 && flag()) {
             setback = true;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraG.java
@@ -20,6 +20,11 @@ public class ElytraG extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_16);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
@@ -20,15 +20,11 @@ public class ElytraH extends Check implements PostPredictionCheck {
 
     @Override
     public boolean isApplicable() {
-        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
     }
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
-            return;
-        }
-
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
                 && player.inVehicle()

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraH.java
@@ -19,6 +19,11 @@ public class ElytraH extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_8);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8)) {
             return;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
@@ -28,7 +28,6 @@ public class ElytraI extends Check implements PostPredictionCheck {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA
                 && player.wasTouchingWater
-                && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15)
                 && flag()) {
             setback = true;
             if (shouldModifyPackets()) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/elytra/ElytraI.java
@@ -19,6 +19,11 @@ public class ElytraI extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_15);
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (event.getPacketType() == PacketType.Play.Client.ENTITY_ACTION
                 && new WrapperPlayClientEntityAction(event).getAction() == WrapperPlayClientEntityAction.Action.START_FLYING_WITH_ELYTRA

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderC.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderC.java
@@ -40,6 +40,11 @@ public class PacketOrderC extends Check implements PacketCheck {
         super(player);
     }
 
+    @Override
+    public boolean isApplicable() {
+        return !exempt;
+    }
+
     private Verbose.Writer writeKind(int kind) {
         return V.write(verbose(), kind);
     }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderC.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderC.java
@@ -29,8 +29,6 @@ public class PacketOrderC extends Check implements PacketCheck {
     static final int KIND_SKIPPED_INTERACT_TICK = 2;
     static final int KIND_MISMATCH = 3;
 
-    private final boolean exempt = player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_7_10) // 1.7 players do not send INTERACT_AT
-            || player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_26_1); // 26.1 players do not send INTERACT
     private boolean sentInteractAt = false;
     private int requiredEntity;
     private InteractionHand requiredHand;
@@ -42,7 +40,8 @@ public class PacketOrderC extends Check implements PacketCheck {
 
     @Override
     public boolean isApplicable() {
-        return !exempt;
+        return player.getClientVersion().isNewerThan(ClientVersion.V_1_7_10) // 1.7 players do not send INTERACT_AT
+                || player.getClientVersion().isOlderThan(ClientVersion.V_26_1); // 26.1 players do not send INTERACT
     }
 
     private Verbose.Writer writeKind(int kind) {
@@ -51,10 +50,6 @@ public class PacketOrderC extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (exempt) {
-            return;
-        }
-
         if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
             final WrapperPlayClientInteractEntity packet = new WrapperPlayClientInteractEntity(event);
 

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderD.java
@@ -32,7 +32,7 @@ public class PacketOrderD extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY && player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9)) {
+        if (event.getPacketType() == PacketType.Play.Client.INTERACT_ENTITY) {
             final WrapperPlayClientInteractEntity packet = new WrapperPlayClientInteractEntity(event);
             InteractAction action = packet.getAction();
             if (action != InteractAction.ATTACK) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderD.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderD.java
@@ -21,6 +21,11 @@ public class PacketOrderD extends Check implements PacketCheck {
         super(player);
     }
 
+    @Override
+    public boolean isApplicable() {
+        return player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_9);
+    }
+
     private boolean sentMainhand;
     private int requiredEntity;
     private boolean requiredSneaking;

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderO.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderO.java
@@ -33,7 +33,7 @@ public class PacketOrderO extends Check implements PacketCheck {
             flying = false;
         }
 
-        if (isFlying(event.getPacketType()) && player.supportsEndTick() && !player.packetStateData.lastPacketWasTeleport) {
+        if (isFlying(event.getPacketType()) && !player.packetStateData.lastPacketWasTeleport) {
             flying = true;
             return;
         }

--- a/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderO.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/packetorder/PacketOrderO.java
@@ -20,6 +20,11 @@ public class PacketOrderO extends Check implements PacketCheck {
         super(player);
     }
 
+    @Override
+    public boolean isApplicable() {
+        return player.supportsEndTick();
+    }
+
     private boolean flying;
 
     @Override

--- a/common/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintF.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintF.java
@@ -14,6 +14,11 @@ public class SprintF extends Check implements PostPredictionCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.getClientVersion() == ClientVersion.V_1_21_4;
+    }
+
+    @Override
     public void onPredictionComplete(final PredictionComplete predictionComplete) {
         if (player.wasGliding && player.isGliding && player.getClientVersion() == ClientVersion.V_1_21_4) {
             if (player.isSprinting) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintF.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/sprint/SprintF.java
@@ -20,7 +20,7 @@ public class SprintF extends Check implements PostPredictionCheck {
 
     @Override
     public void onPredictionComplete(final PredictionComplete predictionComplete) {
-        if (player.wasGliding && player.isGliding && player.getClientVersion() == ClientVersion.V_1_21_4) {
+        if (player.wasGliding && player.isGliding) {
             if (player.isSprinting) {
                 flagWithSetback();
             } else {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
@@ -22,6 +22,11 @@ public class TickTimer extends Check implements PacketCheck {
     }
 
     @Override
+    public boolean isApplicable() {
+        return player.supportsEndTick();
+    }
+
+    @Override
     public void onPacketReceive(PacketReceiveEvent event) {
         if (!player.supportsEndTick()) return;
         if (isFlying(event.getPacketType()) && !player.packetStateData.lastPacketWasTeleport) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/timer/TickTimer.java
@@ -28,7 +28,6 @@ public class TickTimer extends Check implements PacketCheck {
 
     @Override
     public void onPacketReceive(PacketReceiveEvent event) {
-        if (!player.supportsEndTick()) return;
         if (isFlying(event.getPacketType()) && !player.packetStateData.lastPacketWasTeleport) {
             if (!receivedTickEnd && flagWithSetback(V.write(verbose()).bool(false).uint(flyingPackets))) {
                 handleViolation();

--- a/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/common/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -60,7 +60,9 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 public class CheckManager {
     private static final AtomicBoolean initedAtomic = new AtomicBoolean(false);
@@ -281,15 +283,15 @@ public class CheckManager {
                 .putAll(noneModules)
                 .build();
 
-        preViaPacketChecksValues = preViaPacketChecks.values().toArray(new PacketCheck[0]);
-        packetChecksValues = packetChecks.values().toArray(new PacketCheck[0]);
-        positionChecksValues = positionChecks.values().toArray(new PositionCheck[0]);
-        rotationChecksValues = rotationChecks.values().toArray(new RotationCheck[0]);
-        vehicleChecksValues = vehicleChecks.values().toArray(new VehicleCheck[0]);
-        prePredictionChecksValues = prePredictionChecks.values().toArray(new PacketCheck[0]);
-        blockBreakChecksValues = blockBreakChecks.values().toArray(new BlockBreakCheck[0]);
-        blockPlaceChecksValues = blockPlaceChecks.values().toArray(new BlockPlaceCheck[0]);
-        postPredictionChecksValues = postPredictionChecks.values().toArray(new PostPredictionCheck[0]);
+        preViaPacketChecksValues = applicable(preViaPacketChecks.values()).toArray(PacketCheck[]::new);
+        packetChecksValues = applicable(packetChecks.values()).toArray(PacketCheck[]::new);
+        positionChecksValues = applicable(positionChecks.values()).toArray(PositionCheck[]::new);
+        rotationChecksValues = applicable(rotationChecks.values()).toArray(RotationCheck[]::new);
+        vehicleChecksValues = applicable(vehicleChecks.values()).toArray(VehicleCheck[]::new);
+        prePredictionChecksValues = applicable(prePredictionChecks.values()).toArray(PacketCheck[]::new);
+        blockBreakChecksValues = applicable(blockBreakChecks.values()).toArray(BlockBreakCheck[]::new);
+        blockPlaceChecksValues = applicable(blockPlaceChecks.values()).toArray(BlockPlaceCheck[]::new);
+        postPredictionChecksValues = applicable(postPredictionChecks.values()).toArray(PostPredictionCheck[]::new);
 
         init();
     }
@@ -466,6 +468,10 @@ public class CheckManager {
 
     public CompensatedCooldown getCompensatedCooldown() {
         return getPositionCheck(CompensatedCooldown.class);
+    }
+
+    private static <T> Stream<T> applicable(Collection<T> checks) {
+        return checks.stream().filter(check -> !(check instanceof Check grimCheck) || grimCheck.isApplicable());
     }
 
     public NoSlow getNoSlow() {


### PR DESCRIPTION
Filters `CheckManager` dispatch arrays once during initialization using a per-check `isApplicable()` hook.
Version-specific checks implement the hook with immutable client and server protocol conditions. 

`BadPacketsH` is left ungated because its `CANCELLED_DIGGING` path currently runs outside `isSupportedVersion()`.