### PR TITLE
Fix legacy compatibility and proxy alert exceptions

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     compileOnly(libs.luckperms)
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testImplementation(libs.packetevents.api)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -19,6 +19,7 @@ import ac.grim.grimac.api.config.ConfigManager;
 import ac.grim.grimac.api.storage.verbose.Verbose;
 import ac.grim.grimac.checks.Check;
 import ac.grim.grimac.checks.CheckData;
+import ac.grim.grimac.checks.impl.verbose.VerboseCodecs;
 import ac.grim.grimac.checks.type.PacketReceiveListener;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
@@ -234,7 +235,7 @@ public class Reach extends Check implements PacketReceiveListener {
             CheckResult result = checkReach(reachEntity, interactionData.x, interactionData.y, interactionData.z, interactionData.hasAttackRange, interactionData.maxReach, interactionData.hitboxMargin, interactionData.attackRangeMovement, false);
             switch (result.type()) {
                 case REACH -> flag(
-                        V.write(verbose()).f64(result.minDistance()).uint(reachEntity.getType().getId(player.getClientVersion())),
+                        V.write(verbose()).f64(result.minDistance()).uint(VerboseCodecs.entity(reachEntity.getType(), player.getClientVersion())),
                         () -> {
                             String added = ", type=" + reachEntity.getType().getName().getKey();
                             if (reachEntity instanceof PacketEntitySizeable sizeable) {

--- a/common/src/main/java/ac/grim/grimac/checks/impl/verbose/VerboseCodecs.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/verbose/VerboseCodecs.java
@@ -33,6 +33,8 @@ public final class VerboseCodecs {
     public static final int PACKET_NONE = Integer.MIN_VALUE;
     /** {@code {packet}} sentinel for transaction/pong. */
     public static final int PACKET_TRANSACTION = Integer.MIN_VALUE + 1;
+    /** {@code {entity}} sentinel for types unavailable in the player's client version. */
+    public static final int ENTITY_UNKNOWN = Integer.MAX_VALUE;
 
     static {
         VerboseTags.registerEnum("face", BlockFace.values());
@@ -99,7 +101,15 @@ public final class VerboseCodecs {
 
     /** Encoder for {@code {entity}}. */
     public static int entity(@NotNull EntityType type, @NotNull ClientVersion version) {
-        return type.getId(version);
+        try {
+            return entityIdOrUnknown(type.getId(version));
+        } catch (RuntimeException e) {
+            return ENTITY_UNKNOWN;
+        }
+    }
+
+    static int entityIdOrUnknown(int id) {
+        return id < 0 ? ENTITY_UNKNOWN : id;
     }
 
     private static @NotNull String blockName(int clientVersionPvn, int id) {
@@ -122,6 +132,7 @@ public final class VerboseCodecs {
     }
 
     private static @NotNull String entityTypeName(int clientVersionPvn, int entityId) {
+        if (entityId == ENTITY_UNKNOWN) return "unknown";
         EntityType entityType = EntityTypes.getById(ClientVersion.getById(clientVersionPvn), entityId);
         return entityType == null ? "unknown" : entityType.getName().getKey();
     }

--- a/common/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
@@ -1,6 +1,7 @@
 package ac.grim.grimac.events.packets;
 
 import ac.grim.grimac.GrimAPI;
+import ac.grim.grimac.api.config.ConfigManager;
 import ac.grim.grimac.utils.anticheat.LogUtil;
 import ac.grim.grimac.utils.anticheat.MessageUtil;
 import com.github.retrooper.packetevents.PacketEvents;
@@ -59,11 +60,17 @@ public class ProxyAlertMessenger extends PacketListenerAbstract {
     }
 
     public static boolean canSendAlerts() {
-        return usingProxy && GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("alerts.proxy.send", false) && !GrimAPI.INSTANCE.getPlatformPlayerFactory().getOnlinePlayers().isEmpty();
+        if (!usingProxy) return false;
+
+        ConfigManager config = GrimAPI.INSTANCE.getConfigManager().getConfig();
+        return config != null && config.getBooleanElse("alerts.proxy.send", false) && !GrimAPI.INSTANCE.getPlatformPlayerFactory().getOnlinePlayers().isEmpty();
     }
 
     public static boolean canReceiveAlerts() {
-        return usingProxy && GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("alerts.proxy.receive", false) && GrimAPI.INSTANCE.getAlertManager().hasAlertListeners();
+        if (!usingProxy) return false;
+
+        ConfigManager config = GrimAPI.INSTANCE.getConfigManager().getConfig();
+        return config != null && config.getBooleanElse("alerts.proxy.receive", false) && GrimAPI.INSTANCE.getAlertManager().hasAlertListeners();
     }
 
     // TODO (Cross-Platform) check if new getBooleanFromFile impl is correct

--- a/common/src/main/java/ac/grim/grimac/utils/nmsutil/FluidTypeFlowing.java
+++ b/common/src/main/java/ac/grim/grimac/utils/nmsutil/FluidTypeFlowing.java
@@ -11,6 +11,7 @@ import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState
 import com.github.retrooper.packetevents.protocol.world.states.defaulttags.BlockTags;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
+import com.github.retrooper.packetevents.protocol.world.states.type.StateValue;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -109,7 +110,7 @@ public class FluidTypeFlowing {
         }
 
         Vector3dm vec3d = new Vector3dm(modX, 0.0D, modZ);
-        if (state.getLevel() >= 8) {
+        if (state.hasProperty(StateValue.LEVEL) && state.getLevel() >= 8) {
             for (BlockFace direction : new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST}) {
                 if (isSolidFace(player, originalX, originalY, originalZ, direction) || isSolidFace(player, originalX, originalY + 1, originalZ, direction)) {
                     vec3d = VectorUtils.normalize(player, vec3d).add(0.0D, -6.0D, 0.0D);
@@ -126,6 +127,10 @@ public class FluidTypeFlowing {
         if (water ? !Materials.isWater(player.getClientVersion(), state) : state.getType() != StateTypes.LAVA) {
             return -1;
         }
+
+        // Bubble columns count as water for legacy clients, but unlike water and lava
+        // they do not expose the LEVEL block-state property. They behave as sources.
+        if (!state.hasProperty(StateValue.LEVEL)) return 0;
 
         int level = state.getLevel();
         return level >= 8 ? 0 : level;

--- a/common/src/test/java/ac/grim/grimac/checks/impl/verbose/VerboseCodecsTest.java
+++ b/common/src/test/java/ac/grim/grimac/checks/impl/verbose/VerboseCodecsTest.java
@@ -1,0 +1,19 @@
+package ac.grim.grimac.checks.impl.verbose;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VerboseCodecsTest {
+
+    @Test
+    void unsupportedEntityUsesUnknownSentinel() {
+        assertEquals(VerboseCodecs.ENTITY_UNKNOWN,
+                VerboseCodecs.entityIdOrUnknown(-1));
+    }
+
+    @Test
+    void supportedEntityKeepsProtocolId() {
+        assertEquals(42, VerboseCodecs.entityIdOrUnknown(42));
+    }
+}


### PR DESCRIPTION
## Summary

- Guard legacy fluid-flow handling from reading the `LEVEL` property on water-like block states that do not define it.
- Treat bubble columns as source water for legacy liquid-depth calculations.
- Disable proxy alert send/receive checks while Grim's configuration is transiently unavailable during startup or reload.
- Encode entity types unavailable to legacy clients as an explicit unknown sentinel in verbose Reach data.

## Root cause

Legacy fluid prediction assumed every state classified as water exposed `StateValue.LEVEL`. Bubble columns are water-like but do not have that property, so movement processing could throw while reading their level.

Proxy alert packet handling also assumed the active configuration was always non-null. Packets arriving during a startup or reload transition could race with configuration replacement and repeatedly throw.

Reach verbose output wrote PacketEvents' per-client entity ID directly to an unsigned field. Entity types unavailable in an older client version produce `-1`, causing verbose serialization to throw instead of recording the Reach result.

## Impact

These guards prevent all three exception paths without changing normal behavior once valid state is available. Legacy clients can move around bubble columns without triggering the fluid-level failure, proxy alert packets safely no-op during short configuration transitions, and unsupported entity types render as `unknown` without interrupting Reach processing.

## Validation

- `gradlew :common:test :bukkit:build`
- Added regression coverage for supported and unsupported verbose entity IDs.
- Built and deployed the patched Bukkit jar on Leaf 1.21.11.
- Restarted the server and ran `grim reload`; the console remained clean while players reconnected.
