### PR TITLE
Implement system property to disable join warning

### DIFF
--- a/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/grim.shadow-conventions.gradle.kts
@@ -11,6 +11,9 @@ tasks.named<ShadowJar>("shadowJar") {
         // ServiceLoader, so minimize() strips it and adventure's static init then throws
         // (ServiceConfigurationError) on enable. Keep the gson serializer's classes.
         exclude(dependency("net.kyori:adventure-text-serializer-gson:.*"))
+        // slf4j-jdk14's provider is reached only through ServiceLoader, so minimize()
+        // drops it and the shaded slf4j goes back to printing that it found no providers.
+        exclude(dependency("org.slf4j:slf4j-jdk14:.*"))
     }
     archiveFileName = "${rootProject.name}-${project.name}-${rootProject.version}.jar"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -22,7 +25,7 @@ tasks.named<ShadowJar>("shadowJar") {
             relocate("net.kyori", "ac.grim.grimac.shaded.kyori") // use PE's built-in adventure instead when not shading PE
         }
         relocate("club.minnced", "ac.grim.grimac.shaded.discord-webhooks")
-        relocate("org.slf4j", "ac.grim.grimac.shaded.slf4j") // Required by discord-webhooks
+        relocate("org.slf4j", "ac.grim.grimac.shaded.slf4j") // Required by HikariCP; slf4j-jdk14 ships beside it as the provider
         relocate("github.scarsz.configuralize", "ac.grim.grimac.shaded.configuralize")
         relocate("com.github.puregero", "ac.grim.grimac.shaded.com.github.puregero")
         relocate("com.google.code.gson", "ac.grim.grimac.shaded.gson")

--- a/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/GrimACBukkitLoaderPlugin.java
+++ b/bukkit/src/main/java/ac/grim/grimac/platform/bukkit/GrimACBukkitLoaderPlugin.java
@@ -163,7 +163,7 @@ public final class GrimACBukkitLoaderPlugin extends JavaPlugin implements Platfo
             event.setCancelled(event.isCancelled() || bukkitEvent.isCancelled());
         }, 0, false, GrimACBukkitLoaderPlugin.class);
 
-        eventBus.get(ac.grim.grimac.api.event.events.CommandExecuteEvent.class).onCommandExecute(plugin, (user, check, verbose, command, cancelled) -> {
+        eventBus.get(ac.grim.grimac.api.event.events.CommandExecuteEvent.class).onCommandExecuteSupplier(plugin, (user, check, verbose, command, cancelled) -> {
             ac.grim.grimac.api.events.CommandExecuteEvent bukkitEvent =
                     new ac.grim.grimac.api.events.CommandExecuteEvent(user, check, verbose, command);
             Bukkit.getPluginManager().callEvent(bukkitEvent);

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     api(libs.adventure.text.minimessage)
     api(libs.jetbrains.annotations)
     api(libs.hikaricp)
+    runtimeOnly(libs.slf4j.jdk14)
     api(libs.grim.api)
     api(libs.grim.internal)
     compileOnly(libs.grim.internal.shims)

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPluginMessage.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPluginMessage.java
@@ -29,8 +29,8 @@ public class PacketPluginMessage extends PacketListenerAbstract {
     private void checkChannel(User user, String channelName) {
         if (!"vv:proxy_details".equals(channelName)) return;
         final boolean usingProxy = ProxyAlertMessenger.isUsingProxy();
-        // warn if they are using a proxy
-        if (usingProxy) {
+        // warn if they are using a proxy, unless the server has asked not to be told again
+        if (usingProxy && CommonGrimArguments.WARN_ON_VIA_PROXY.value()) {
             LogUtil.warn(
                     user.getName() + " seems to have connected through a proxy running ViaVersion. "
                             + "Having ViaVersion installed on the proxy is incompatible with GrimAC and causes many issues. "

--- a/common/src/main/java/ac/grim/grimac/utils/common/arguments/CommonGrimArguments.java
+++ b/common/src/main/java/ac/grim/grimac/utils/common/arguments/CommonGrimArguments.java
@@ -37,4 +37,14 @@ public class CommonGrimArguments {
      */
     public final static SystemArgument<Boolean> KICK_ON_VIA_PROXY = FACTORY.create(string("KickOnViaProxy", true));
 
+    /**
+     * If true, a warning is logged whenever a player connects through a proxy running ViaVersion.
+     * <p>
+     * The warning repeats for every player who joins, so a server that has read it and decided to
+     * keep ViaVersion on its proxy has nothing further to learn from it.
+     * <p>
+     * This setting is opt-out (default: true) and requires a server restart to change.
+     */
+    public final static SystemArgument<Boolean> WARN_ON_VIA_PROXY = FACTORY.create(string("WarnOnViaProxy", true));
+
 }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -21,6 +21,7 @@ luckperms = "5.5"
 # --- General Java Utilities ---
 fastutil = "8.5.15"
 hikaricp = "7.0.2"
+slf4j = "2.0.17"
 jetbrains-annotations = "24.1.0"
 mongoDriverSync = "5.3.1"
 netty = "4.1.85.Final"
@@ -68,6 +69,7 @@ viabackwards = { group = "com.viaversion", name = "viabackwards", version.ref = 
 # --- General Java Utilities ---
 fastutil = { group = "it.unimi.dsi", name = "fastutil", version.ref = "fastutil"}
 hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikaricp" }
+slf4j-jdk14 = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 mongoDriverSync = { group = "org.mongodb", name = "mongodb-driver-sync", version.ref = "mongoDriverSync" }
 netty = { group = "io.netty", name = "netty-all", version.ref = "netty" }


### PR DESCRIPTION
There are few circumstances where running ViaVersion with GrimAC are acceptable: more specifically, a server that uses ViaVersion but only supports a very small range of versions (e.g. 26.1 to 26.2 only, base as 26.2). Our lobby uses Minestom instead of Paper (for maximum performance) which more or less requires this setup.

This flag allows the user to solemnly acknowledge that they are aware of the incompatibilities and are choosing to "accept their fate."

Edit: This also includes some adjustments I've made to resolve some obscure warnings I saw on startup.