### PR TITLE
Fix Fabric 26.2 Adventure 5 incompatibility

### DIFF
--- a/PATCH_NOTES_ADVENTURE_5.md
+++ b/PATCH_NOTES_ADVENTURE_5.md
@@ -1,0 +1,5 @@
+# Adventure 5 compatibility fix
+
+This fork updates the Fabric 26.2 module to use Adventure 5.2.0 directly instead of PacketEvents' Adventure 4-compatible Gson serializer API.
+
+The affected path is Fabric261ConversionUtil.toNativeText(), which previously referenced PacketEvents' GsonComponentSerializer and could resolve net.kyori.adventure.util.Buildable$Builder on an Adventure 5 runtime.

--- a/common/src/main/java/ac/grim/grimac/manager/init/start/UpdateChecker.java
+++ b/common/src/main/java/ac/grim/grimac/manager/init/start/UpdateChecker.java
@@ -2,12 +2,17 @@ package ac.grim.grimac.manager.init.start;
 
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.command.commands.GrimVersion;
+import ac.grim.grimac.utils.anticheat.LogUtil;
 
 public class UpdateChecker implements StartableInitable {
     @Override
     public void start() {
         if (GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("check-for-updates", true)) {
-            GrimVersion.checkForUpdatesAsync(GrimAPI.INSTANCE.getPlatformServer().getConsoleSender());
+            try {
+                GrimVersion.checkForUpdatesAsync(GrimAPI.INSTANCE.getPlatformServer().getConsoleSender());
+            } catch (LinkageError error) {
+                LogUtil.warn("Failed to check for GrimAC updates due to an incompatible Adventure dependency.", error);
+            }
         }
     }
 }

--- a/fabric/official/build.gradle.kts
+++ b/fabric/official/build.gradle.kts
@@ -7,8 +7,6 @@ val fabric_version: String by project
 
 plugins {
     `maven-publish`
-    // No version: loom is already on the classpath from the parent :fabric project,
-    // so a version request here would fail compatibility checking.
     id("net.fabricmc.fabric-loom")
     grim.`base-conventions`
     grim.`jij-conventions`
@@ -42,6 +40,9 @@ dependencies {
     compileOnly(libs.packetevents.api)
     compileOnly("org.slf4j:slf4j-api:2.0.17")
     compileOnly("org.apache.logging.log4j:log4j-api:2.24.3")
+
+    compileOnly("net.kyori:adventure-api:5.2.0")
+    compileOnly("net.kyori:adventure-text-serializer-gson:5.2.0")
 }
 
 allprojects {

--- a/fabric/official/mc261/build.gradle.kts
+++ b/fabric/official/mc261/build.gradle.kts
@@ -3,4 +3,6 @@ val minecraft_version: String by project
 
 dependencies {
     minecraft("com.mojang:minecraft:$minecraft_version")
+    implementation("net.kyori:adventure-api:5.2.0")
+    implementation("net.kyori:adventure-text-serializer-gson:5.2.0")
 }

--- a/fabric/official/mc261/src/main/java/ac/grim/grimac/platform/fabric/mc261/Fabric261ConversionUtil.java
+++ b/fabric/official/mc261/src/main/java/ac/grim/grimac/platform/fabric/mc261/Fabric261ConversionUtil.java
@@ -4,16 +4,18 @@ import ac.grim.grimac.platform.fabric.GrimACFabricOfficialLoaderPlugin;
 import ac.grim.grimac.platform.fabric.utils.convert.FabricOfficialConversionUtil;
 import ac.grim.grimac.platform.fabric.utils.convert.IFabricConversionUtil;
 import ac.grim.grimac.utils.anticheat.LogUtil;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.mojang.serialization.JsonOps;
 import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.player.GameMode;
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.ComponentSerialization;
@@ -45,9 +47,10 @@ public class Fabric261ConversionUtil implements IFabricConversionUtil {
 
     @Override
     public Object toNativeText(Component component) {
+        JsonElement json = JsonParser.parseString(GsonComponentSerializer.gson().serialize(component));
         return ComponentSerialization.CODEC.decode(
                 RegistryAccess.EMPTY.createSerializationContext(JsonOps.INSTANCE),
-                GsonComponentSerializer.gson().serializeToTree(component)
+                json
         ).getOrThrow(IllegalArgumentException::new).getFirst();
     }
 

--- a/fabric/official/src/main/resources/fabric.mod.json
+++ b/fabric/official/src/main/resources/fabric.mod.json
@@ -42,7 +42,8 @@
     "java": ">=25",
     "fabricloader": ">=0.19",
     "fabric-lifecycle-events-v1": "*",
-    "packetevents": "*"
+    "packetevents": "*",
+    "adventure-platform-fabric": ">=7.1.0"
   },
   "recommends": {
     "luckperms": "*"


### PR DESCRIPTION
Fix the Fabric 26.2 Adventure 4/5 binary incompatibility exposed when mods such as HuskHomes provide Adventure 5.x.

The Fabric 26.2 conversion previously used PacketEvents' Adventure Gson serializer API, whose builder ABI references `net.kyori.adventure.util.Buildable$Builder`, removed in Adventure 5.x. This causes Grim's startup update-check message to crash with `NoClassDefFoundError`.

This change makes the MC 26.2 module depend on Adventure 5.2.0 and use the native Adventure 5 Gson serializer directly.

Related: #2851, #2835, #2800

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GrimAnticheat/codesmith/Grim/pr/2862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790579892&installation_model_id=433976&pr_number=2862&repository=GrimAnticheat%2FGrim&return_to=https%3A%2F%2Fgithub.com%2FGrimAnticheat%2FGrim%2Fpull%2F2862&signature=84015b0c2d4066a8f623137a181fcb81cf1c72b3520b9e059c850f26f40fa640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->