### PR TITLE
fix noslow bypass

### DIFF
--- a/common/src/main/java/ac/grim/grimac/checks/impl/movement/NoSlow.java
+++ b/common/src/main/java/ac/grim/grimac/checks/impl/movement/NoSlow.java
@@ -6,7 +6,7 @@ import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.PostPredictionListener;
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.anticheat.update.PredictionComplete;
-import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import org.jetbrains.annotations.NotNull;
 
 @CheckData(name = "NoSlow", stableKey = "grim.movement.noslow", description = "Was not slowed while using an item", setback = 5)
@@ -14,7 +14,8 @@ public class NoSlow extends Check implements PostPredictionListener {
     // The player sends that they switched items the next tick if they switch from an item that can be used
     // to another item that can be used.  What the fuck Mojang.  Affects 1.8 (and most likely 1.7) clients.
     public boolean didSlotChangeLastTick = false;
-    public boolean flaggedLastTick = false;
+    public int flaggedMainHandSlotLastTick = -1;
+    private boolean needFlag;
     private double offsetToFlag;
     private double bestOffset = 1;
 
@@ -24,27 +25,36 @@ public class NoSlow extends Check implements PostPredictionListener {
 
     @Override
     public void onPredictionComplete(final PredictionComplete predictionComplete) {
-        if (!predictionComplete.isChecked()) return;
+        if (needFlag && flaggedMainHandSlotLastTick == player.packetStateData.lastSlotSelected
+                && player.packetStateData.isSlowedByUsingItem() && !didSlotChangeLastTick) {
+            flagWithSetback();
+        }
 
+        needFlag = false;
+
+        int flaggedMainHandSlotThisTick = -1;
         // If the player was using an item for certain, and their predicted velocity had a flipped item
-        if (player.packetStateData.isSlowedByUsingItem()) {
-            // 1.8 users are not slowed the first tick they use an item, strangely
-            if (player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8) && didSlotChangeLastTick) {
-                didSlotChangeLastTick = false;
-                flaggedLastTick = false;
-            }
-
+        if (predictionComplete.isChecked() && player.packetStateData.isSlowedByUsingItem()) {
             if (bestOffset > offsetToFlag) {
-                if (flaggedLastTick) {
+                int slot = player.packetStateData.lastSlotSelected;
+                if (player.packetStateData.itemInUseHand == InteractionHand.OFF_HAND) {
                     flagWithSetback();
+                } else if (player.packetStateData.getSlowedByUsingItemSlot() == player.packetStateData.lastSlotSelected) {
+                    flaggedMainHandSlotThisTick = slot;
+                    if (flaggedMainHandSlotLastTick == flaggedMainHandSlotThisTick) {
+                        flagWithSetback();
+                    } else {
+                        needFlag = true;
+                    }
                 }
-                flaggedLastTick = true;
             } else {
                 reward();
-                flaggedLastTick = false;
             }
         }
+
+        flaggedMainHandSlotLastTick = flaggedMainHandSlotThisTick;
         bestOffset = 1;
+        didSlotChangeLastTick = false;
     }
 
     public void handlePredictionAnalysis(double offset) {

--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
@@ -116,8 +116,9 @@ public class PacketPlayerDigging extends PacketListenerAbstract {
                 boolean usingInMainHand = player.packetStateData.isSlowedByUsingItem() && player.packetStateData.itemInUseHand == InteractionHand.MAIN_HAND;
                 if (usingInMainHand && player.canSkipTicks() && !player.isTickingReliablyFor(3)) {
                     player.packetStateData.setSlowedByUsingItem(false);
-                    player.checkManager.getNoSlow().didSlotChangeLastTick = true;
                 }
+
+                player.checkManager.getNoSlow().didSlotChangeLastTick = true;
             }
             player.packetStateData.lastSlotSelected = slot;
         }


### PR DESCRIPTION
fixes #2055

Supposedly, not requiring the player to be using the item for 2 ticks to flag will cause issues for legit players using shields, but I can't seem to trigger that issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GrimAnticheat/codesmith/Grim/pr/2864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790721930&installation_model_id=433976&pr_number=2864&repository=GrimAnticheat%2FGrim&return_to=https%3A%2F%2Fgithub.com%2FGrimAnticheat%2FGrim%2Fpull%2F2864&signature=504c1551ee61e5d1f98b2343667d19a281ecc866ca6a140fb78de9ef3b51c689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->