### PR TITLE
guard proxy alert parsing against malformed client payloads

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/ProxyAlertMessenger.java
@@ -95,18 +95,25 @@ public class ProxyAlertMessenger extends PacketListenerAbstract {
         if (!wrapper.getChannelName().equals("BungeeCord") && !wrapper.getChannelName().equals("bungeecord:main"))
             return;
 
-        ByteArrayDataInput in = ByteStreams.newDataInput(wrapper.getData());
-
-        if (!in.readUTF().equals("GRIMAC")) return;
-
+        // The payload is entirely client-controlled: any client can send a plugin
+        // message on the BungeeCord channel, so every read below may throw on a
+        // malformed (or maliciously truncated) payload. Never let a parse failure
+        // escape into the packet pipeline as a per-packet logged exception.
         final String alert;
-        byte[] messageBytes = new byte[in.readShort()];
-        in.readFully(messageBytes);
-
         try {
+            ByteArrayDataInput in = ByteStreams.newDataInput(wrapper.getData());
+
+            if (!in.readUTF().equals("GRIMAC")) return;
+
+            short length = in.readShort();
+            if (length < 0) return;
+
+            byte[] messageBytes = new byte[length];
+            in.readFully(messageBytes);
+
             alert = new DataInputStream(new ByteArrayInputStream(messageBytes)).readUTF();
-        } catch (IOException exception) {
-            LogUtil.error("Something went wrong whilst reading an alert forwarded from another server!", exception);
+        } catch (IOException | RuntimeException exception) {
+            LogUtil.error("Something went wrong whilst reading an alert from another server!", exception);
             return;
         }
         Component message = MessageUtil.miniMessage(alert);


### PR DESCRIPTION
Related to #2868.

`ProxyAlertMessenger` currently reads part of the plugin message before entering the existing try/catch. Since clients can send messages on the `BungeeCord` channel themselves, a malformed or truncated payload can throw out of the packet listener.

This moves the parsing into the guarded section and rejects invalid message lengths, so malformed payloads are ignored instead of bubbling an exception.

This does not fix the spoofing described in #2868. A client connected directly to the backend can still send a correctly formatted forged proxy alert. Preventing that would require a way to verify that the message actually came from the proxy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GrimAnticheat/codesmith/Grim/pr/2869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790931825&installation_model_id=433976&pr_number=2869&repository=GrimAnticheat%2FGrim&return_to=https%3A%2F%2Fgithub.com%2FGrimAnticheat%2FGrim%2Fpull%2F2869&signature=d2e5bdf3deba4dfae09c3a4de27f0f6ad091444b2e8f2db18d559c0cea62e22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->